### PR TITLE
Expand README with Quest Philosophy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
 # Quest: Stop blaming the model. Fix the process.
-## A Multi-Agent Orchestration Blueprint
+
+## Quest Philosophy
+
+Unlocking agentic engineering leverage is not driven by massive models, endless swarms, or magical autonomy. It comes from discipline, process, and constraints.
+
+Quest is not about prompt tricks, cute `skill.md` files, or model specific hacks. It is about building engineering agentic systems that reliably produce correct outcomes.
+
+Humans set direction, constraints, and intent.  
+Systems execute, verify, and enforce correctness.
+
+We do not trust single outputs, human or machine.  
+We trust repeatable processes backed by evidence.
+
+Models generate artifacts.  
+Pipelines validate artifacts and decide what is acceptable.
+
+Autonomy is earned through constraints, not granted by capability.  
+More autonomy without rigor increases risk, not leverage.
+
+Clean context and focus are mandatory.  
+Context contamination is a system failure, not a user habit.
+
+Artifacts must be explicit, reviewable, traceable, and reproducible.  
+Nothing important should live only in a model’s head or a chat window.
+
+Verification must be continuous and automated wherever possible.  
+Humans review intent, evidence, and anomalies, not every line of output.
+
+The system should make correct behavior easy.  
+The system should make incorrect behavior hard.
+
+Scaling output without scaling engineering discipline is a dead end.  
+Speed without rigor only accelerates failure.
+
+Humans remain in the loop at the system level.  
+Requiring humans to advance every step does not scale and increases error.
+
+We are not replacing human judgment.  
+We are amplifying it by removing avoidable toil and preventing avoidable mistakes.
+
+
+# Quest: A Multi-Agent Orchestration Blueprint
 
 **Part of the [Candid Talent Edge](https://candidtalentedge.com) initiative by KjellKod**
 


### PR DESCRIPTION
This PR adds a new “Quest Philosophy” section to the top of the README to clearly define what Quest is (and is not).

It emphasizes that reliable agentic systems come from engineering discipline, clean context, artifact handoffs, verification, and process enforced constraints, not from bigger models, swarms, or prompt hacks.

Goal is to make the repo’s purpose immediately obvious: stop blaming the model, fix the process.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds "Quest Philosophy" section to `README.md`, emphasizing engineering discipline over model complexity.
> 
>   - **README Update**:
>     - Adds "Quest Philosophy" section to the top of `README.md`.
>     - Emphasizes engineering discipline, process, and constraints over model complexity and prompt hacks.
>     - Clarifies that Quest focuses on reliable agentic systems, not on increasing model size or autonomy without rigor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fquest&utm_source=github&utm_medium=referral)<sup> for 2889c29af97b537ba2bfcbe0bf641829e3ba01dc. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->