### PR TITLE
Claude/check OpenAI sandbox access

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Quest SessionStart hook for Claude Code on the web
+# Installs dependencies needed for Quest's dual-model review workflow
+# Only runs in remote/web sandbox environments
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "=== Quest session-start: setting up web sandbox ==="
+
+# --- OpenAI API Key ---
+# If OPENAI_API_KEY is already set (e.g. from sandbox config), persist it for the session.
+# Otherwise, check for a .env file at the project root.
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  echo "export OPENAI_API_KEY='${OPENAI_API_KEY}'" >> "$CLAUDE_ENV_FILE"
+  echo "[session-start] OPENAI_API_KEY found in environment, persisted to session"
+elif [ -f "${CLAUDE_PROJECT_DIR:-.}/.env" ]; then
+  # Source .env and export OPENAI_API_KEY if present
+  OPENAI_KEY=$(grep -E '^OPENAI_API_KEY=' "${CLAUDE_PROJECT_DIR:-.}/.env" 2>/dev/null | head -1 | cut -d'=' -f2- | tr -d "'\"" || true)
+  if [ -n "$OPENAI_KEY" ]; then
+    echo "export OPENAI_API_KEY='${OPENAI_KEY}'" >> "$CLAUDE_ENV_FILE"
+    echo "[session-start] OPENAI_API_KEY loaded from .env"
+  else
+    echo "[session-start] WARNING: No OPENAI_API_KEY in .env — Codex MCP reviews will be skipped"
+  fi
+else
+  echo "[session-start] WARNING: No OPENAI_API_KEY found — Codex MCP reviews will be skipped"
+  echo "[session-start] Set OPENAI_API_KEY in environment or create .env at project root"
+fi
+
+# --- Python: openai package ---
+if ! python3 -c "import openai" 2>/dev/null; then
+  echo "[session-start] Installing openai Python package..."
+  pip install --quiet openai 2>&1 | tail -1
+  echo "[session-start] openai package installed"
+else
+  echo "[session-start] openai package already available"
+fi
+
+# --- Node.js: Codex MCP server ---
+# Quest uses @anthropic/codex-mcp-server for dual-model (Claude + GPT) reviews
+if ! command -v npx &>/dev/null; then
+  echo "[session-start] WARNING: npx not available — cannot set up Codex MCP server"
+  echo "[session-start] Install Node.js to enable dual-model reviews"
+else
+  echo "[session-start] npx available — Codex MCP server can be launched on demand"
+fi
+
+# --- Shellcheck (linter for shell scripts) ---
+if ! command -v shellcheck &>/dev/null; then
+  echo "[session-start] Installing shellcheck..."
+  apt-get update -qq 2>/dev/null && apt-get install -y -qq shellcheck 2>/dev/null | tail -1 || echo "[session-start] WARNING: shellcheck install failed (non-fatal)"
+  echo "[session-start] shellcheck installed"
+else
+  echo "[session-start] shellcheck already available"
+fi
+
+echo "=== Quest session-start: setup complete ==="

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "codex": {
       "command": "codex",
-      "args": ["-m", "gpt-5.2", "mcp-server"]
+      "args": ["-m", "gpt-5.3-codex", "mcp-server"]
     }
   }
 }

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "codex": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/codex-mcp-server"]
+      "command": "codex",
+      "args": ["-m", "gpt-5.2", "mcp-server"]
     }
   }
 }

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "codex": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/codex-mcp-server"]
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "sandbox": {
+    "network": {
+      "allowedDomains": ["api.openai.com"]
+    }
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds session start script for OpenAI API key handling and tool checks, updates configuration for sandbox and MCP server.
> 
>   - **Session Start Script**:
>     - Adds `session-start.sh` to handle OpenAI API key persistence and tool availability checks.
>     - Persists `OPENAI_API_KEY` from environment or `.env` file.
>     - Checks for `codex` CLI and `shellcheck` availability.
>   - **Configuration**:
>     - Updates `settings.json` to include `session-start.sh` in `SessionStart` hooks and allow `api.openai.com` in sandbox network.
>     - Adds `mcp.json` to configure `codex` MCP server with `gpt-5.3-codex` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fquest&utm_source=github&utm_medium=referral)<sup> for d5f25c74ab765117063490398e0b413cd5dc7844. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->