### PR TITLE
Journal cleanup: backfill missing entries, discard superseded quests

### DIFF
--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -62,6 +62,13 @@ Before creating the quest folder, present the routing classification to the user
 2. If the quest went through the questioner path, note this: "Questioning phase completed — gaps addressed before planning."
 3. Wait for user acknowledgment before proceeding (for high risk only). For medium and low, display and continue.
 
+### Quest Folder Structure
+
+`.quest/` contains:
+- Active quest directories (created per-run)
+- `archive/` — completed quests moved here after journaling (see Step 7 in workflow.md)
+- `audit.log` — persistent log across all quest runs
+
 ### Quest Folder Creation
 
 1. Suggest a slug (lowercase, hyphenated, 2-5 words) and confirm with the user

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -416,14 +416,20 @@ After plan approval, present the plan interactively before proceeding to build.
      - Quote the original idea content under "This is where it all began..."
      - Update the idea file's `## Status` to `implemented`
 
-3. **Show summary:**
+3. **Archive the quest working directory:**
+   - Create `.quest/archive/` if it doesn't exist
+   - Move `.quest/<id>/` to `.quest/archive/<id>/`
+   - The journal entry in `docs/quest-journal/` is the permanent record; the archive preserves raw artifacts for reference
+   - `.quest/` root should only contain active quests, `archive/`, and `audit.log`
+
+4. **Show summary:**
    - Quest ID
    - Files changed (from `git diff --name-only` and `state.json` artifact paths)
    - Total iterations (plan + fix, from `state.json`)
-   - Location of artifacts
+   - Location of artifacts (now in `.quest/archive/<id>/`)
    - Location of journal entry
 
-4. **Next steps suggestion:**
+5. **Next steps suggestion:**
    ```
    Review changes: git diff
    Commit: git add -p && git commit

--- a/docs/quest-journal/interactive-plan-presentation_2026-02-04.md
+++ b/docs/quest-journal/interactive-plan-presentation_2026-02-04.md
@@ -1,0 +1,29 @@
+# Quest Journal: interactive-plan-presentation
+
+**Quest ID:** interactive-plan-presentation_2026-02-04__1516
+**Completed:** 2026-02-04
+**Status:** Complete
+
+## Summary
+
+Enhanced the quest orchestration to present plans interactively rather than dumping the full plan at once. Users now see a brief summary first, then can opt into a phase-by-phase walkthrough with the ability to request changes at each step.
+
+**What was built:**
+- Brief summary presentation (1-3 sentences + file location) as the default
+- Phase-by-phase detailed walkthrough on request
+- Change handling: user feedback triggers re-plan and re-review cycles
+- Seamless flow integration into existing SKILL.md Steps 3 and 7
+
+## Key Changes
+
+Updated quest orchestration flow (SKILL.md) to add an interactive presentation gate between plan approval and build. If the user requests changes during presentation, the system loops back through planning and review.
+
+## Impact
+
+Made the quest system more collaborative — users aren't surprised by what gets built because they reviewed the plan interactively first. This became Step 3.5 in the delegation workflow.
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 3
+- Review verdict: Approved

--- a/docs/quest-journal/quest-council-mode_2026-02-05.md
+++ b/docs/quest-journal/quest-council-mode_2026-02-05.md
@@ -1,0 +1,24 @@
+# Quest Journal: quest-council-mode
+
+**Quest ID:** quest-council-mode_2026-02-05__1636
+**Date:** 2026-02-05
+**Status:** Abandoned (plan approved, never built)
+
+## Summary
+
+Planned a dual-planning-track feature for `/quest` where users could choose between "Quest" (fast, single plan) and "Quest Council" (rigorous, two competing plans merged by arbiter). Plan was approved after 2 iterations but was never built.
+
+## What was planned
+
+- Planning track prompt at quest start: Quest vs Quest Council
+- Council flow: generate `plan_a.md` and `plan_b.md`, review both, arbiter merges best parts into final `plan.md`
+- `planning_track` field in state.json for resume support
+- `planning.mode` and `planning.ask` fields in allowlist.json
+
+## Why abandoned
+
+The idea was captured in `ideas/quest-council_v1.md` and `ideas/quest-council_v1_alternative.md` for future consideration. The thin-orchestrator work (Phase 2) was prioritized instead. Council mode may return as a future phase.
+
+## This is where it all began... an idea
+
+> Complex work (migrations, refactors) benefits from exploring multiple approaches early. Quest Council generates two competing plan candidates, compares them, and merges into one best final plan before execution.

--- a/docs/quest-journal/validate-and-launch_2026-02-04.md
+++ b/docs/quest-journal/validate-and-launch_2026-02-04.md
@@ -1,0 +1,30 @@
+# Quest Journal: validate-and-launch
+
+**Quest ID:** validate-and-launch_2026-02-04__1045
+**Completed:** 2026-02-04
+**Status:** Complete
+
+## Summary
+
+First-ever quest run on the extracted repository. Validated that the Quest blueprint was correctly extracted from the source repo, created the `ideas/` directory for tracking future work, and updated the README with public domain messaging.
+
+**What was built:**
+- Validated all required files present (allowlist, roles, hooks, gitignore)
+- Created `ideas/` directory with seed ideas (installer script, CI validation, commit-time validation)
+- Updated README with public domain messaging and usage guidance
+
+## Key Changes
+
+- `ideas/` directory established as the place for future work items
+- README updated with welcoming, casual tone for public use
+- Confirmed `.quest/` properly gitignored and system functional
+
+## Impact
+
+This quest proved the system works end-to-end in its new standalone home. The ideas seeded here (installer, CI validation) became full quests later.
+
+## Iterations
+
+- Plan iterations: 1
+- Fix iterations: 1
+- Review verdict: Approved


### PR DESCRIPTION
## Summary

- Backfill 3 missing quest journal entries: `validate-and-launch`, `interactive-plan-presentation`, `quest-council-mode`
- Remove superseded/out-of-scope quest artifacts: `github-ci-commit-validation` (replaced by `ci-quest-validation`), `validate-pdf-skill` (PDF is a domain tool, not core)
- Add archive step to quest lifecycle: completed quests move to `.quest/archive/` after journaling
- Document `.quest/` folder structure in SKILL.md (active quests, `archive/`, `audit.log`)

## Changes

**Journal cleanup:**
- Added journal entries for quests that were missing from `docs/quest-journal/`
- Discarded journal/working dirs for superseded quests

**Quest archive workflow:**
- New Step 7.3 in `workflow.md`: after journaling, move `.quest/<id>/` to `.quest/archive/<id>/`
- New "Quest Folder Structure" section in `SKILL.md` documenting `.quest/` layout
- `.quest/` root now only contains active quests, `archive/`, and `audit.log`

## Test plan

- [x] Verify all completed `.quest/` runs have matching `docs/quest-journal/` entries
- [x] `scripts/validate-manifest.sh` passes
- [x] New quest run creates working dir in `.quest/` root (not in archive)
- [x] Completing a quest moves it to `.quest/archive/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Backfill missing quest journal entries, remove outdated quests, and add an archive step to the quest lifecycle, updating documentation accordingly.
> 
>   - **Behavior**:
>     - Backfill missing quest journal entries: `validate-and-launch`, `interactive-plan-presentation`, `quest-council-mode`.
>     - Remove superseded quests: `github-ci-commit-validation`, `validate-pdf-skill`.
>     - Add archive step in `workflow.md`: completed quests move to `.quest/archive/` after journaling.
>   - **Documentation**:
>     - Document `.quest/` folder structure in `SKILL.md`.
>     - Update `workflow.md` to include new archive step.
>   - **Misc**:
>     - Ensure `.quest/` root only contains active quests, `archive/`, and `audit.log`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=KjellKod%2Fquest&utm_source=github&utm_medium=referral)<sup> for 3329e13fc45a5e843bacb406afa44ad420187375. You can [customize](https://app.ellipsis.dev/KjellKod/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->