### PR TITLE
Add quest portfolio dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Quest is very useful, but it is not currently intended to be a long term maintai
 
 ![Adventurers in our quest](docs/media/quest_v0.14.png)
 
+## Dashboard
+
+Track portfolio status in the static executive dashboard:
+
+- [Quest Dashboard](docs/dashboard/index.html)
+- [Dashboard deployment + regeneration guide](docs/dashboard/README.md)
+
 ## What is Quest?
 
 Quest is a multi-agent workflow where specialized AI agents (planner, reviewers, builder) work in **isolated contexts** with **human approval gates**. Two different models (Claude + GPT) review independently, an arbiter filters nitpicks, and you approve before anything gets built.

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1,0 +1,71 @@
+# Quest Dashboard
+
+Static executive dashboard for Quest portfolio tracking, served from `docs/dashboard/`.
+
+## What It Shows
+
+- KPI summary: total, finished, in-progress, blocked, abandoned
+- Status distribution chart (doughnut)
+- Monthly final-status-over-time chart (line)
+- Quest cards with title, elevator pitch, status, completion date, and iteration counts
+
+## Data Pipeline
+
+Generate dashboard data from journal + active/archive state files:
+
+```bash
+python3 scripts/generate_quest_dashboard_data.py
+```
+
+This writes:
+
+- `docs/dashboard/dashboard-data.json`
+
+## Local Preview
+
+Serve `docs/` as static files (recommended for fetch behavior):
+
+```bash
+cd docs
+python3 -m http.server 8000
+```
+
+Then open:
+
+- `http://localhost:8000/dashboard/`
+
+## GitHub Pages Deployment
+
+1. Open repository settings on GitHub.
+2. Navigate to `Settings -> Pages`.
+3. Set **Build and deployment** source to:
+   - `Deploy from a branch`
+   - Branch: `main`
+   - Folder: `/docs`
+4. Save and wait for Pages publish.
+
+Expected URL format:
+
+- `https://<org-or-user>.github.io/<repo>/dashboard/`
+
+Example for this repository:
+
+- `https://kjellkod.github.io/quest/dashboard/`
+
+## Update Workflow
+
+When quest journal/state data changes:
+
+1. Regenerate JSON:
+
+```bash
+python3 scripts/generate_quest_dashboard_data.py
+```
+
+2. Validate JSON:
+
+```bash
+python3 -m json.tool docs/dashboard/dashboard-data.json >/dev/null
+```
+
+3. Commit the updated data and dashboard assets.

--- a/docs/dashboard/app.js
+++ b/docs/dashboard/app.js
@@ -1,0 +1,337 @@
+const STATUS_ORDER = ["in_progress", "blocked", "abandoned", "finished", "unknown"];
+const STATUS_LABELS = {
+  in_progress: "In Progress",
+  blocked: "Blocked",
+  abandoned: "Abandoned",
+  finished: "Finished",
+  unknown: "Unknown",
+};
+
+const STATUS_COLORS = {
+  in_progress: "#60a5fa",
+  blocked: "#f59e0b",
+  abandoned: "#f87171",
+  finished: "#34d399",
+  unknown: "#a78bfa",
+};
+
+let statusChartInstance = null;
+let trendChartInstance = null;
+
+function setBannerState(type, message) {
+  const banner = document.getElementById("stateBanner");
+  banner.className = `state-banner ${type}`;
+  banner.textContent = message;
+}
+
+function formatDate(value) {
+  if (!value) {
+    return "Not available";
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return "Not available";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(parsed);
+}
+
+function statusLabel(status) {
+  return STATUS_LABELS[status] || STATUS_LABELS.unknown;
+}
+
+function statusClass(status) {
+  return `badge-${STATUS_ORDER.includes(status) ? status : "unknown"}`;
+}
+
+function numberOrDash(value) {
+  return Number.isFinite(value) ? String(value) : "-";
+}
+
+function safeTrendPoints(data) {
+  const points = data?.trends?.points;
+  if (!Array.isArray(points)) {
+    return [];
+  }
+  return points.filter((point) => point && typeof point.period === "string");
+}
+
+function applySummary(summary) {
+  const byStatus = summary.by_status || {};
+  document.getElementById("kpi-total").textContent = String(summary.total || 0);
+  document.getElementById("kpi-finished").textContent = String(byStatus.finished || 0);
+  document.getElementById("kpi-in-progress").textContent = String(byStatus.in_progress || 0);
+  document.getElementById("kpi-blocked").textContent = String(byStatus.blocked || 0);
+  document.getElementById("kpi-abandoned").textContent = String(byStatus.abandoned || 0);
+}
+
+function buildQuestCard(quest) {
+  const status = STATUS_ORDER.includes(quest.status) ? quest.status : "unknown";
+  const card = document.createElement("article");
+  card.className = "quest-card";
+
+  const title = quest.title || quest.slug || quest.quest_id || "Untitled Quest";
+  const pitch = quest.elevator_pitch || "No summary recorded yet.";
+  const completionText = quest.completed_date
+    ? formatDate(quest.completed_date)
+    : quest.status === "finished"
+      ? "Completed date missing"
+      : "Not finished yet";
+
+  card.innerHTML = `
+    <div class="quest-card-header">
+      <h3 class="quest-title"></h3>
+      <span class="status-badge ${statusClass(status)}"></span>
+    </div>
+    <p class="quest-pitch"></p>
+    <p class="quest-meta">
+      <span><b>Quest ID:</b> ${quest.quest_id || "Not available"}</span>
+      <span><b>Completion Date:</b> ${completionText}</span>
+      <span><b>Iterations:</b> plan ${numberOrDash(quest.plan_iteration)} / fix ${numberOrDash(quest.fix_iteration)}</span>
+    </p>
+  `;
+
+  card.querySelector(".quest-title").textContent = title;
+  card.querySelector(".status-badge").textContent = statusLabel(status);
+  card.querySelector(".quest-pitch").textContent = pitch;
+
+  return card;
+}
+
+function renderQuestCards(quests) {
+  const questGrid = document.getElementById("questGrid");
+  questGrid.innerHTML = "";
+
+  const sorted = [...quests].sort((a, b) => {
+    const aDate = a.completed_date || a.updated_at || "";
+    const bDate = b.completed_date || b.updated_at || "";
+    if (aDate !== bDate) {
+      return bDate.localeCompare(aDate);
+    }
+    return (a.title || "").localeCompare(b.title || "");
+  });
+
+  for (const quest of sorted) {
+    questGrid.appendChild(buildQuestCard(quest));
+  }
+
+  document.getElementById("questCountLabel").textContent = `${sorted.length} quests represented`;
+}
+
+function teardownCharts() {
+  if (statusChartInstance) {
+    statusChartInstance.destroy();
+    statusChartInstance = null;
+  }
+  if (trendChartInstance) {
+    trendChartInstance.destroy();
+    trendChartInstance = null;
+  }
+}
+
+function renderCharts(data) {
+  teardownCharts();
+
+  const statusCanvas = document.getElementById("statusChart");
+  const trendCanvas = document.getElementById("trendChart");
+
+  if (typeof window.Chart !== "function") {
+    const fallback = document.createElement("p");
+    fallback.className = "fallback-note";
+    fallback.textContent = "Charts unavailable: Chart.js failed to load from CDN.";
+    statusCanvas.closest(".panel").appendChild(fallback.cloneNode(true));
+    trendCanvas.closest(".panel").appendChild(fallback);
+    return;
+  }
+
+  const summaryCounts = STATUS_ORDER.map((status) => data.summary.by_status?.[status] || 0);
+
+  statusChartInstance = new window.Chart(statusCanvas, {
+    type: "doughnut",
+    data: {
+      labels: STATUS_ORDER.map((status) => STATUS_LABELS[status]),
+      datasets: [
+        {
+          data: summaryCounts,
+          backgroundColor: STATUS_ORDER.map((status) => STATUS_COLORS[status]),
+          borderWidth: 1,
+          borderColor: "rgba(15, 23, 42, 0.85)",
+          hoverOffset: 8,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          position: "bottom",
+          labels: {
+            color: "#cbd5e1",
+            boxWidth: 14,
+            padding: 16,
+          },
+        },
+      },
+    },
+  });
+
+  const trendPoints = safeTrendPoints(data);
+
+  trendChartInstance = new window.Chart(trendCanvas, {
+    type: "line",
+    data: {
+      labels: trendPoints.map((point) => point.period),
+      datasets: STATUS_ORDER.map((status) => ({
+        label: STATUS_LABELS[status],
+        data: trendPoints.map((point) => point[status] || 0),
+        borderColor: STATUS_COLORS[status],
+        backgroundColor: STATUS_COLORS[status],
+        fill: false,
+        tension: 0.25,
+        borderWidth: 2,
+        pointRadius: 3,
+      })),
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: {
+        mode: "nearest",
+        intersect: false,
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: "#cbd5e1",
+          },
+          grid: {
+            color: "rgba(148, 163, 184, 0.16)",
+          },
+        },
+        y: {
+          beginAtZero: true,
+          precision: 0,
+          ticks: {
+            color: "#cbd5e1",
+            stepSize: 1,
+          },
+          grid: {
+            color: "rgba(148, 163, 184, 0.16)",
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          labels: {
+            color: "#cbd5e1",
+            padding: 12,
+            boxWidth: 12,
+          },
+        },
+      },
+    },
+  });
+}
+
+function validateData(data) {
+  if (!data || typeof data !== "object") {
+    throw new Error("invalid_json");
+  }
+  if (!data.summary || typeof data.summary !== "object") {
+    throw new Error("invalid_json");
+  }
+  if (!Array.isArray(data.quests)) {
+    throw new Error("invalid_json");
+  }
+  if (!data.summary.by_status || typeof data.summary.by_status !== "object") {
+    throw new Error("invalid_json");
+  }
+}
+
+function renderDashboard(data) {
+  applySummary(data.summary);
+  document.getElementById("generatedAt").textContent = formatTimestamp(data.generated_at);
+
+  const main = document.getElementById("dashboardMain");
+  main.classList.remove("hidden");
+
+  if (!data.quests.length) {
+    setBannerState("is-empty", "No quests available yet. Generate data after quest activity to populate this dashboard.");
+    document.getElementById("chartsSection").classList.add("hidden");
+    document.getElementById("questGrid").innerHTML = "";
+    document.getElementById("questCountLabel").textContent = "0 quests represented";
+    teardownCharts();
+    return;
+  }
+
+  document.getElementById("chartsSection").classList.remove("hidden");
+  renderCharts(data);
+  renderQuestCards(data.quests);
+  setBannerState("is-ready", "");
+}
+
+async function loadDashboardData() {
+  setBannerState("is-loading", "Loading dashboard data...");
+
+  let response;
+  try {
+    response = await fetch("./dashboard-data.json", { cache: "no-store" });
+  } catch (error) {
+    throw new Error("fetch_failure");
+  }
+
+  if (!response.ok) {
+    throw new Error("fetch_failure");
+  }
+
+  const body = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(body);
+  } catch (error) {
+    throw new Error("invalid_json");
+  }
+
+  validateData(payload);
+  return payload;
+}
+
+async function init() {
+  try {
+    const data = await loadDashboardData();
+    renderDashboard(data);
+  } catch (error) {
+    const main = document.getElementById("dashboardMain");
+    main.classList.add("hidden");
+
+    if (error.message === "invalid_json") {
+      setBannerState("is-error", "Data format invalid. Regenerate dashboard-data.json and retry.");
+      return;
+    }
+
+    setBannerState("is-error", "Dashboard data unavailable. Ensure dashboard-data.json exists and is served correctly.");
+  }
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/docs/dashboard/dashboard-data.json
+++ b/docs/dashboard/dashboard-data.json
@@ -1,0 +1,196 @@
+{
+  "generated_at": "2026-02-11T18:51:56Z",
+  "summary": {
+    "total": 12,
+    "by_status": {
+      "in_progress": 1,
+      "blocked": 0,
+      "abandoned": 1,
+      "finished": 10,
+      "unknown": 0
+    }
+  },
+  "trends": {
+    "granularity": "month",
+    "points": [
+      {
+        "period": "2026-02",
+        "in_progress": 1,
+        "blocked": 0,
+        "abandoned": 1,
+        "finished": 10,
+        "unknown": 0
+      }
+    ]
+  },
+  "quests": [
+    {
+      "quest_id": "caching-strategy-exploration_2026-02-06__1305",
+      "slug": "caching-strategy-exploration",
+      "title": "Caching Strategy Exploration",
+      "elevator_pitch": "Comprehensive research exploration mapping 11 distinct caching strategies applicable to the Quest AI agent system. The quest produced two educational research documents and a quest index README \u2014 no code changes, as the research itself was the deliverable.",
+      "status": "finished",
+      "completed_date": "2026-02-06",
+      "created_at": null,
+      "updated_at": null,
+      "plan_iteration": null,
+      "fix_iteration": null,
+      "journal_path": "docs/quest-journal/caching-strategy-exploration_2026-02-06.md",
+      "state_path": null
+    },
+    {
+      "quest_id": "ci-quest-validation_2026-02-04__1532",
+      "slug": "ci-quest-validation",
+      "title": "CI Quest Validation",
+      "elevator_pitch": "Implemented GitHub Actions CI and local pre-commit hooks that validate quest-related artifacts to prevent broken configurations from being committed.",
+      "status": "finished",
+      "completed_date": "2026-02-04",
+      "created_at": "2026-02-04T15:32:00Z",
+      "updated_at": "2026-02-04T16:00:00Z",
+      "plan_iteration": 3,
+      "fix_iteration": 1,
+      "journal_path": "docs/quest-journal/ci-quest-validation_2026-02-04.md",
+      "state_path": ".quest/archive/ci-quest-validation_2026-02-04__1532/state.json"
+    },
+    {
+      "quest_id": "handoff-contract-fix_2026-02-09__2228",
+      "slug": "handoff-contract-fix",
+      "title": "handoff-contract-fix",
+      "elevator_pitch": "Fixed handoff contract inconsistencies across Quest role files and workflow. Standardized all 6 role files on `---HANDOFF---` text format with STATUS/ARTIFACTS/NEXT/SUMMARY fields, removed \"Context Is In Your Prompt\" contradictions, and made workflow prompts explicitly request handoff format.",
+      "status": "finished",
+      "completed_date": "2026-02-09",
+      "created_at": "2026-02-09T22:28:00Z",
+      "updated_at": "2026-02-10T06:30:00Z",
+      "plan_iteration": 3,
+      "fix_iteration": 1,
+      "journal_path": "docs/quest-journal/handoff-contract-fix_2026-02-09.md",
+      "state_path": ".quest/archive/handoff-contract-fix_2026-02-09__2228/state.json"
+    },
+    {
+      "quest_id": "installer-script_2026-02-04__1841",
+      "slug": "installer-script",
+      "title": "Installer Script",
+      "elevator_pitch": "Created a single unified installer script (`scripts/quest_installer.sh`) that installs and updates Quest in any repository.",
+      "status": "finished",
+      "completed_date": "2026-02-04",
+      "created_at": "2026-02-04T18:41:00Z",
+      "updated_at": "2026-02-04T19:30:00Z",
+      "plan_iteration": 2,
+      "fix_iteration": 1,
+      "journal_path": "docs/quest-journal/installer-script_2026-02-04.md",
+      "state_path": ".quest/archive/installer-script_2026-02-04__1841/state.json"
+    },
+    {
+      "quest_id": "interactive-plan-presentation_2026-02-04__1516",
+      "slug": "interactive-plan-presentation",
+      "title": "interactive-plan-presentation",
+      "elevator_pitch": "Enhanced the quest orchestration to present plans interactively rather than dumping the full plan at once. Users now see a brief summary first, then can opt into a phase-by-phase walkthrough with the ability to request changes at each step.",
+      "status": "finished",
+      "completed_date": "2026-02-04",
+      "created_at": "2026-02-04T22:16:34Z",
+      "updated_at": "2026-02-04T23:15:00Z",
+      "plan_iteration": 2,
+      "fix_iteration": 3,
+      "journal_path": "docs/quest-journal/interactive-plan-presentation_2026-02-04.md",
+      "state_path": ".quest/archive/interactive-plan-presentation_2026-02-04__1516/state.json"
+    },
+    {
+      "quest_id": "quest-council-mode_2026-02-05__1636",
+      "slug": "quest-council-mode",
+      "title": "quest-council-mode",
+      "elevator_pitch": "Planned a dual-planning-track feature for `/quest` where users could choose between \"Quest\" (fast, single plan) and \"Quest Council\" (rigorous, two competing plans merged by arbiter). Plan was approved after 2 iterations but was never built.",
+      "status": "abandoned",
+      "completed_date": "2026-02-05",
+      "created_at": null,
+      "updated_at": null,
+      "plan_iteration": null,
+      "fix_iteration": null,
+      "journal_path": "docs/quest-journal/quest-council-mode_2026-02-05.md",
+      "state_path": null
+    },
+    {
+      "quest_id": "quest-dashboard_2026-02-11__0936",
+      "slug": "quest-dashboard",
+      "title": "quest-dashboard",
+      "elevator_pitch": "",
+      "status": "in_progress",
+      "completed_date": null,
+      "created_at": "2026-02-11T16:36:57Z",
+      "updated_at": "2026-02-11T16:48:00Z",
+      "plan_iteration": 2,
+      "fix_iteration": 0,
+      "journal_path": null,
+      "state_path": ".quest/quest-dashboard_2026-02-11__0936/state.json"
+    },
+    {
+      "quest_id": "quest-delegation-gate_2026-02-05__2125",
+      "slug": "quest-delegation-gate",
+      "title": "Delegation-Based Intake Gate",
+      "elevator_pitch": "Decomposed the monolithic `.skills/quest/SKILL.md` (635 lines) into a slim routing entry point (73 lines) plus three delegation files under `.skills/quest/delegation/`. The delegation pattern structurally enforces intake quality \u2014 vague input routes to a dedicated questioning phase before planning begins, while detailed input goes directly to the workflow.",
+      "status": "finished",
+      "completed_date": "2026-02-06",
+      "created_at": null,
+      "updated_at": null,
+      "plan_iteration": null,
+      "fix_iteration": null,
+      "journal_path": "docs/quest-journal/quest-delegation-gate_2026-02-06.md",
+      "state_path": null
+    },
+    {
+      "quest_id": "skill-strategy_2026-02-09__1200",
+      "slug": "skill-strategy",
+      "title": "skill-strategy",
+      "elevator_pitch": "Analyzed how Quest should organize, manage, and distribute skills. Researched community best practices (Agent Skills standard, plugin marketplaces, distribution patterns). Produced strategic recommendations.",
+      "status": "finished",
+      "completed_date": "2026-02-09",
+      "created_at": "2026-02-09T12:00:00Z",
+      "updated_at": "2026-02-09T12:15:00Z",
+      "plan_iteration": 1,
+      "fix_iteration": 0,
+      "journal_path": "docs/quest-journal/skill-strategy_2026-02-09.md",
+      "state_path": ".quest/archive/skill-strategy_2026-02-09__1200/state.json"
+    },
+    {
+      "quest_id": "thin-orchestrator_2026-02-09__1845",
+      "slug": "thin-orchestrator",
+      "title": "thin-orchestrator",
+      "elevator_pitch": "Implemented Phase 2 of the Quest architecture evolution: the \"thin orchestrator\" principle. The Quest orchestrator now passes file paths to subagents instead of embedding content, reducing context growth from O(n*content_size) to O(n*one_line).",
+      "status": "finished",
+      "completed_date": "2026-02-09",
+      "created_at": "2026-02-09T18:45:00Z",
+      "updated_at": "2026-02-09T20:20:00Z",
+      "plan_iteration": 1,
+      "fix_iteration": 1,
+      "journal_path": "docs/quest-journal/thin-orchestrator_2026-02-09.md",
+      "state_path": ".quest/archive/thin-orchestrator_2026-02-09__1845/state.json"
+    },
+    {
+      "quest_id": "validate-and-launch_2026-02-04__1045",
+      "slug": "validate-and-launch",
+      "title": "validate-and-launch",
+      "elevator_pitch": "First-ever quest run on the extracted repository. Validated that the Quest blueprint was correctly extracted from the source repo, created the `ideas/` directory for tracking future work, and updated the README with public domain messaging.",
+      "status": "finished",
+      "completed_date": "2026-02-04",
+      "created_at": "2026-02-04T10:45:00Z",
+      "updated_at": "2026-02-04T12:15:00Z",
+      "plan_iteration": 1,
+      "fix_iteration": 1,
+      "journal_path": "docs/quest-journal/validate-and-launch_2026-02-04.md",
+      "state_path": ".quest/archive/validate-and-launch_2026-02-04__1045/state.json"
+    },
+    {
+      "quest_id": "weekly-update-check_2026-02-04__2349",
+      "slug": "weekly-update-check",
+      "title": "Weekly Update Check",
+      "elevator_pitch": "Implemented automatic weekly update checking for Quest. After a quest completes, the system checks if updates are available (respecting a configurable interval) and prompts the user to update if a newer version exists upstream.",
+      "status": "finished",
+      "completed_date": "2026-02-05",
+      "created_at": "2026-02-04T23:49:00Z",
+      "updated_at": "2026-02-05T00:20:00Z",
+      "plan_iteration": 2,
+      "fix_iteration": 0,
+      "journal_path": "docs/quest-journal/weekly-update-check_2026-02-05.md",
+      "state_path": ".quest/archive/weekly-update-check_2026-02-04__2349/state.json"
+    }
+  ]
+}

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quest Portfolio Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="page-glow page-glow-left" aria-hidden="true"></div>
+    <div class="page-glow page-glow-right" aria-hidden="true"></div>
+
+    <div class="layout">
+      <header class="hero">
+        <p class="eyebrow">Quest Intelligence</p>
+        <h1>Quest Portfolio Dashboard</h1>
+        <p class="hero-subtitle">
+          Board-level visibility into quest outcomes, execution momentum, and strategic throughput.
+        </p>
+        <div class="meta-row">
+          <span class="meta-label">Data generated:</span>
+          <span id="generatedAt" class="meta-value">Loading...</span>
+        </div>
+      </header>
+
+      <div id="stateBanner" class="state-banner is-loading">Loading dashboard data...</div>
+
+      <main id="dashboardMain" class="dashboard hidden" aria-live="polite">
+        <section class="kpi-grid" aria-label="Portfolio KPI summary">
+          <article class="kpi-card">
+            <p class="kpi-label">Total Quests</p>
+            <p id="kpi-total" class="kpi-value">0</p>
+          </article>
+          <article class="kpi-card">
+            <p class="kpi-label">Finished</p>
+            <p id="kpi-finished" class="kpi-value status-finished">0</p>
+          </article>
+          <article class="kpi-card">
+            <p class="kpi-label">In Progress</p>
+            <p id="kpi-in-progress" class="kpi-value status-in-progress">0</p>
+          </article>
+          <article class="kpi-card">
+            <p class="kpi-label">Blocked</p>
+            <p id="kpi-blocked" class="kpi-value status-blocked">0</p>
+          </article>
+          <article class="kpi-card">
+            <p class="kpi-label">Abandoned</p>
+            <p id="kpi-abandoned" class="kpi-value status-abandoned">0</p>
+          </article>
+        </section>
+
+        <section id="chartsSection" class="panel-grid" aria-label="Portfolio charting">
+          <article class="panel">
+            <h2>Status Distribution</h2>
+            <p class="panel-subtitle">Current normalized state across all quests</p>
+            <div class="chart-wrap">
+              <canvas id="statusChart" role="img" aria-label="Quest status distribution chart"></canvas>
+            </div>
+          </article>
+
+          <article class="panel">
+            <h2>Final Status Over Time</h2>
+            <p class="panel-subtitle">Monthly trend using each quest's final/current status</p>
+            <div class="chart-wrap">
+              <canvas id="trendChart" role="img" aria-label="Quest monthly trend chart"></canvas>
+            </div>
+          </article>
+        </section>
+
+        <section class="quests-section" aria-label="Quest details">
+          <div class="quests-header">
+            <h2>Quest Portfolio</h2>
+            <p id="questCountLabel" class="panel-subtitle"></p>
+          </div>
+          <div id="questGrid" class="quest-grid"></div>
+        </section>
+      </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/docs/dashboard/styles.css
+++ b/docs/dashboard/styles.css
@@ -1,0 +1,404 @@
+:root {
+  --bg-0: #05070f;
+  --bg-1: #0a0f1d;
+  --surface-0: rgba(17, 24, 39, 0.78);
+  --surface-1: rgba(15, 23, 42, 0.84);
+  --surface-2: rgba(30, 41, 59, 0.75);
+  --line: rgba(148, 163, 184, 0.22);
+  --text-0: #f8fafc;
+  --text-1: #cbd5e1;
+  --text-2: #94a3b8;
+
+  --status-finished: #34d399;
+  --status-in-progress: #60a5fa;
+  --status-blocked: #f59e0b;
+  --status-abandoned: #f87171;
+  --status-unknown: #a78bfa;
+
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --shadow-lg: 0 25px 60px rgba(2, 6, 23, 0.45);
+  --shadow-md: 0 14px 38px rgba(2, 6, 23, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text-0);
+  background:
+    radial-gradient(1200px circle at 8% -5%, rgba(56, 189, 248, 0.18), transparent 42%),
+    radial-gradient(1000px circle at 92% 12%, rgba(45, 212, 191, 0.12), transparent 38%),
+    linear-gradient(155deg, var(--bg-0) 0%, var(--bg-1) 68%, #0f172a 100%);
+}
+
+.page-glow {
+  position: fixed;
+  width: 480px;
+  height: 480px;
+  border-radius: 50%;
+  filter: blur(95px);
+  opacity: 0.38;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.page-glow-left {
+  top: -220px;
+  left: -160px;
+  background: #0ea5e9;
+}
+
+.page-glow-right {
+  top: 120px;
+  right: -180px;
+  background: #14b8a6;
+}
+
+.layout {
+  position: relative;
+  z-index: 1;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 40px 22px 64px;
+}
+
+.hero {
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.74));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 36px 34px;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #67e8f9;
+  font-weight: 700;
+}
+
+.hero h1 {
+  margin: 14px 0 12px;
+  font-size: clamp(1.95rem, 3.6vw, 3rem);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+}
+
+.hero-subtitle {
+  margin: 0;
+  max-width: 65ch;
+  color: var(--text-1);
+  line-height: 1.65;
+}
+
+.meta-row {
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-2);
+}
+
+.meta-label {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.meta-value {
+  font-family: "IBM Plex Mono", Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92rem;
+  color: var(--text-0);
+}
+
+.state-banner {
+  margin: 18px 0 22px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-weight: 600;
+}
+
+.state-banner.is-loading {
+  background: rgba(56, 189, 248, 0.14);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #bfdbfe;
+}
+
+.state-banner.is-error {
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.38);
+  color: #fecaca;
+}
+
+.state-banner.is-empty {
+  background: rgba(248, 250, 252, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-1);
+}
+
+.state-banner.is-ready {
+  display: none;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.dashboard {
+  display: grid;
+  gap: 22px;
+}
+
+.kpi-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.kpi-card {
+  background: var(--surface-0);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 18px 18px 16px;
+  box-shadow: var(--shadow-md);
+}
+
+.kpi-label {
+  margin: 0;
+  color: var(--text-2);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.kpi-value {
+  margin: 8px 0 0;
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.status-finished {
+  color: var(--status-finished);
+}
+
+.status-in-progress {
+  color: var(--status-in-progress);
+}
+
+.status-blocked {
+  color: var(--status-blocked);
+}
+
+.status-abandoned {
+  color: var(--status-abandoned);
+}
+
+.panel-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.panel {
+  background: var(--surface-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  min-height: 340px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.panel-subtitle {
+  margin: 6px 0 0;
+  font-size: 0.92rem;
+  color: var(--text-2);
+  line-height: 1.5;
+}
+
+.chart-wrap {
+  margin-top: 14px;
+  height: 255px;
+}
+
+.quests-section {
+  background: var(--surface-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 22px;
+}
+
+.quests-header {
+  margin-bottom: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.quests-header h2 {
+  margin: 0;
+  font-size: 1.18rem;
+}
+
+.quest-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.quest-card {
+  position: relative;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+  min-height: 210px;
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.quest-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(148, 163, 184, 0.5);
+  box-shadow: var(--shadow-md);
+}
+
+.quest-card-header {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.quest-title {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.status-badge {
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.72rem;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.badge-finished {
+  color: #86efac;
+  background: rgba(52, 211, 153, 0.16);
+  border-color: rgba(52, 211, 153, 0.38);
+}
+
+.badge-in_progress {
+  color: #93c5fd;
+  background: rgba(96, 165, 250, 0.16);
+  border-color: rgba(96, 165, 250, 0.38);
+}
+
+.badge-blocked {
+  color: #fcd34d;
+  background: rgba(245, 158, 11, 0.16);
+  border-color: rgba(245, 158, 11, 0.38);
+}
+
+.badge-abandoned {
+  color: #fca5a5;
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.38);
+}
+
+.badge-unknown {
+  color: #c4b5fd;
+  background: rgba(167, 139, 250, 0.16);
+  border-color: rgba(167, 139, 250, 0.38);
+}
+
+.quest-pitch {
+  margin: 0;
+  color: var(--text-1);
+  line-height: 1.58;
+  font-size: 0.92rem;
+}
+
+.quest-meta {
+  margin: 0;
+  display: grid;
+  gap: 5px;
+  font-size: 0.83rem;
+  color: var(--text-2);
+}
+
+.quest-meta b {
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.fallback-note {
+  margin-top: 12px;
+  color: var(--text-2);
+  font-size: 0.86rem;
+}
+
+@media (max-width: 1120px) {
+  .kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .quest-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 780px) {
+  .layout {
+    padding: 28px 14px 40px;
+  }
+
+  .hero {
+    padding: 26px 20px;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quest-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 460px) {
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quests-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/scripts/generate_quest_dashboard_data.py
+++ b/scripts/generate_quest_dashboard_data.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Generate dashboard data for Quest history."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+STATUS_ORDER = ("in_progress", "blocked", "abandoned", "finished", "unknown")
+_DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+_HEADER_RE = re.compile(r"^\*\*(.+?)\*\*\s*:?[ \t]*(.+?)\s*$")
+_TITLE_PREFIX = "Quest Journal:"
+
+
+def _to_posix(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _extract_date(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    match = _DATE_RE.search(value)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _slug_from_quest_id(quest_id: Optional[str]) -> Optional[str]:
+    if not quest_id:
+        return None
+    match = re.match(r"^(?P<slug>.+)_\d{4}-\d{2}-\d{2}__\d{4}$", quest_id)
+    if match:
+        return match.group("slug")
+    return quest_id
+
+
+def _slug_from_stem(stem: str) -> str:
+    match = re.match(r"^(?P<slug>.+)_\d{4}-\d{2}-\d{2}$", stem)
+    if match:
+        return match.group("slug")
+    return stem
+
+
+def _coalesce(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _clean_meta_value(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == "`" and value[-1] == "`":
+        return value[1:-1].strip()
+    return value
+
+
+def _date_from_timestamp(timestamp: Optional[str]) -> Optional[str]:
+    if not timestamp:
+        return None
+    timestamp = timestamp.strip()
+    if not timestamp:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return _extract_date(timestamp)
+    return parsed.date().isoformat()
+
+
+def _status_from_value(value: Optional[str]) -> str:
+    if not value:
+        return "unknown"
+
+    normalized = value.strip().lower()
+    normalized = normalized.replace("`", "")
+    normalized = normalized.replace("-", "_")
+    normalized = normalized.replace(" ", "_")
+
+    if normalized.startswith("completed") or normalized.startswith("complete"):
+        return "finished"
+    if normalized.startswith("finished"):
+        return "finished"
+    if normalized.startswith("in_progress"):
+        return "in_progress"
+    if normalized.startswith("blocked"):
+        return "blocked"
+    if normalized.startswith("abandoned"):
+        return "abandoned"
+    return "unknown"
+
+
+def normalize_status(journal_record: Optional[Dict[str, Any]], state_record: Optional[Dict[str, Any]]) -> str:
+    """Map state/journal status values into dashboard canonical statuses."""
+
+    state_status = None
+    state_phase = None
+    journal_status = None
+    completed_date = None
+
+    if state_record:
+        state_status = state_record.get("status_raw")
+        state_phase = state_record.get("phase")
+    if journal_record:
+        journal_status = journal_record.get("status_raw")
+        completed_date = journal_record.get("completed_date")
+
+    for candidate in (state_status, state_phase, journal_status):
+        mapped = _status_from_value(candidate)
+        if mapped != "unknown":
+            return mapped
+
+    if completed_date:
+        return "finished"
+    return "unknown"
+
+
+def parse_journal_entry(path: Path, repo_root: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    title: Optional[str] = None
+    meta: Dict[str, str] = {}
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("# ") and title is None:
+            heading = stripped[2:].strip()
+            if heading.lower().startswith(_TITLE_PREFIX.lower()):
+                heading = heading[len(_TITLE_PREFIX) :].strip()
+            title = heading
+            continue
+
+        header_match = _HEADER_RE.match(stripped)
+        if not header_match:
+            continue
+
+        key = header_match.group(1).strip().lower().replace("_", " ").rstrip(":")
+        value = _clean_meta_value(header_match.group(2))
+        meta[key] = value
+
+    summary = ""
+    summary_index = None
+    for idx, line in enumerate(lines):
+        if re.match(r"^##\s+summary\b", line.strip(), flags=re.IGNORECASE):
+            summary_index = idx + 1
+            break
+
+    if summary_index is not None:
+        paragraph_lines: List[str] = []
+        for line in lines[summary_index:]:
+            stripped = line.strip()
+            if not stripped and paragraph_lines:
+                break
+            if not stripped and not paragraph_lines:
+                continue
+            if stripped.startswith("## "):
+                break
+            paragraph_lines.append(stripped)
+        summary = " ".join(paragraph_lines).strip()
+
+    quest_id = _coalesce(meta.get("quest id"), meta.get("quest_id"))
+    slug = _slug_from_quest_id(quest_id) or _slug_from_stem(path.stem)
+    completed_date = _extract_date(_coalesce(meta.get("completed"), meta.get("date")))
+
+    return {
+        "quest_id": quest_id,
+        "slug": slug,
+        "title": title or slug,
+        "elevator_pitch": summary,
+        "completed_date": completed_date,
+        "status_raw": meta.get("status"),
+        "journal_path": _to_posix(path, repo_root),
+    }
+
+
+def _load_state_file(path: Path, repo_root: Path) -> Dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    quest_id = payload.get("quest_id")
+
+    return {
+        "quest_id": quest_id,
+        "slug": payload.get("slug") or _slug_from_quest_id(quest_id),
+        "status_raw": _coalesce(payload.get("status"), payload.get("phase")),
+        "phase": payload.get("phase"),
+        "plan_iteration": payload.get("plan_iteration"),
+        "fix_iteration": payload.get("fix_iteration"),
+        "created_at": payload.get("created_at"),
+        "updated_at": payload.get("updated_at"),
+        "state_path": _to_posix(path, repo_root),
+    }
+
+
+def _state_index(records: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    by_key: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        quest_id = record.get("quest_id")
+        slug = record.get("slug")
+        if quest_id:
+            by_key[f"id:{quest_id}"] = record
+        if slug:
+            by_key[f"slug:{slug}"] = record
+    return by_key
+
+
+def load_active_states(quest_dir: Path, repo_root: Path) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for path in sorted(quest_dir.glob("*/state.json")):
+        if "archive" in path.parts:
+            continue
+        records.append(_load_state_file(path, repo_root))
+    return records
+
+
+def load_archive_states(archive_dir: Path, repo_root: Path) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for path in sorted(archive_dir.glob("*/state.json")):
+        records.append(_load_state_file(path, repo_root))
+    return records
+
+
+def _merge_records(
+    journal_records: List[Dict[str, Any]],
+    active_states: List[Dict[str, Any]],
+    archive_states: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    # Dedup precedence: archive state overrides active state for duplicate keys.
+    active_by_key = _state_index(active_states)
+    archive_by_key = _state_index(archive_states)
+    merged_by_key: Dict[str, Dict[str, Any]] = dict(active_by_key)
+    merged_by_key.update(archive_by_key)
+
+    merged_states = list({id(value): value for value in merged_by_key.values()}.values())
+    state_by_id = {
+        record["quest_id"]: record
+        for record in merged_states
+        if record.get("quest_id")
+    }
+    state_by_slug = {
+        record["slug"]: record
+        for record in merged_states
+        if record.get("slug")
+    }
+
+    quests: List[Dict[str, Any]] = []
+    seen_state_ids = set()
+
+    for journal in journal_records:
+        quest_id = journal.get("quest_id")
+        slug = journal.get("slug")
+
+        state = None
+        if quest_id and quest_id in state_by_id:
+            state = state_by_id[quest_id]
+        elif slug and slug in state_by_slug:
+            state = state_by_slug[slug]
+
+        if state is not None:
+            seen_state_ids.add(id(state))
+
+        status = normalize_status(journal, state)
+        fallback_state_date = _date_from_timestamp(
+            _coalesce(
+                state.get("updated_at") if state else None,
+                state.get("created_at") if state else None,
+            )
+        )
+
+        completed_date = journal.get("completed_date")
+        if not completed_date and status == "finished":
+            completed_date = fallback_state_date
+
+        resolved_quest_id = _coalesce(state.get("quest_id") if state else None, quest_id)
+        resolved_slug = _coalesce(
+            state.get("slug") if state else None,
+            slug,
+            _slug_from_quest_id(resolved_quest_id),
+        )
+
+        quests.append(
+            {
+                "quest_id": resolved_quest_id,
+                "slug": resolved_slug,
+                "title": journal.get("title") or resolved_slug or resolved_quest_id,
+                "elevator_pitch": journal.get("elevator_pitch") or "",
+                "status": status,
+                "completed_date": completed_date,
+                "created_at": state.get("created_at") if state else None,
+                "updated_at": state.get("updated_at") if state else None,
+                "plan_iteration": state.get("plan_iteration") if state else None,
+                "fix_iteration": state.get("fix_iteration") if state else None,
+                "journal_path": journal.get("journal_path"),
+                "state_path": state.get("state_path") if state else None,
+            }
+        )
+
+    for state in merged_states:
+        if id(state) in seen_state_ids:
+            continue
+
+        status = normalize_status(None, state)
+        completed_date = None
+        fallback_date = _date_from_timestamp(_coalesce(state.get("updated_at"), state.get("created_at")))
+        if status == "finished":
+            completed_date = fallback_date
+
+        quests.append(
+            {
+                "quest_id": state.get("quest_id"),
+                "slug": state.get("slug") or _slug_from_quest_id(state.get("quest_id")),
+                "title": state.get("slug") or state.get("quest_id") or "Untitled quest",
+                "elevator_pitch": "",
+                "status": status,
+                "completed_date": completed_date,
+                "created_at": state.get("created_at"),
+                "updated_at": state.get("updated_at"),
+                "plan_iteration": state.get("plan_iteration"),
+                "fix_iteration": state.get("fix_iteration"),
+                "journal_path": None,
+                "state_path": state.get("state_path"),
+            }
+        )
+
+    quests.sort(
+        key=lambda quest: (
+            quest.get("quest_id") or "",
+            quest.get("slug") or "",
+            quest.get("journal_path") or "",
+            quest.get("state_path") or "",
+        )
+    )
+    return quests
+
+
+def build_trend_points(quests: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    points: Dict[str, Dict[str, int]] = {}
+
+    for quest in quests:
+        event_date = _coalesce(
+            quest.get("completed_date"),
+            _date_from_timestamp(quest.get("updated_at")),
+            _date_from_timestamp(quest.get("created_at")),
+        )
+        if not event_date:
+            continue
+
+        period = event_date[:7]
+        if not re.match(r"^\d{4}-\d{2}$", period):
+            continue
+
+        if period not in points:
+            points[period] = {status: 0 for status in STATUS_ORDER}
+
+        status = quest.get("status")
+        if status not in STATUS_ORDER:
+            status = "unknown"
+        points[period][status] += 1
+
+    trend_points = []
+    for period in sorted(points):
+        point: Dict[str, Any] = {"period": period}
+        for status in STATUS_ORDER:
+            point[status] = points[period][status]
+        trend_points.append(point)
+    return trend_points
+
+
+def build_dashboard_data(
+    journal_dir: Path,
+    quest_dir: Path,
+    archive_dir: Path,
+    repo_root: Path,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    journal_records = []
+    for path in sorted(journal_dir.glob("*.md")):
+        if path.name.lower() == "readme.md":
+            continue
+        journal_records.append(parse_journal_entry(path, repo_root))
+
+    active_states = load_active_states(quest_dir, repo_root)
+    archive_states = load_archive_states(archive_dir, repo_root)
+
+    quests = _merge_records(journal_records, active_states, archive_states)
+
+    by_status = {status: 0 for status in STATUS_ORDER}
+    for quest in quests:
+        status = quest.get("status")
+        if status not in STATUS_ORDER:
+            status = "unknown"
+        by_status[status] += 1
+
+    if not generated_at:
+        generated_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    return {
+        "generated_at": generated_at,
+        "summary": {
+            "total": len(quests),
+            "by_status": by_status,
+        },
+        "trends": {
+            "granularity": "month",
+            "points": build_trend_points(quests),
+        },
+        "quests": quests,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate Quest dashboard JSON data")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root path (defaults to parent of this script)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output JSON path (defaults to docs/dashboard/dashboard-data.json)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else Path(__file__).resolve().parent.parent
+    output_path = (
+        Path(args.output).resolve()
+        if args.output
+        else repo_root / "docs" / "dashboard" / "dashboard-data.json"
+    )
+
+    dashboard_data = build_dashboard_data(
+        journal_dir=repo_root / "docs" / "quest-journal",
+        quest_dir=repo_root / ".quest",
+        archive_dir=repo_root / ".quest" / "archive",
+        repo_root=repo_root,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(dashboard_data, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Wrote {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_generate_quest_dashboard_data.py
+++ b/tests/unit/test_generate_quest_dashboard_data.py
@@ -1,0 +1,275 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate_quest_dashboard_data.py"
+SPEC = importlib.util.spec_from_file_location("generate_quest_dashboard_data", MODULE_PATH)
+GENERATOR = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(GENERATOR)
+
+
+class GenerateQuestDashboardDataTests(unittest.TestCase):
+    def test_parse_journal_extracts_summary_and_dates(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            journal_path = root / "docs" / "quest-journal" / "example-quest_2026-02-01.md"
+            journal_path.parent.mkdir(parents=True, exist_ok=True)
+            journal_path.write_text(
+                "\n".join(
+                    [
+                        "# Quest Journal: Example Quest",
+                        "",
+                        "**Quest ID:** `example-quest_2026-02-01__1010`",
+                        "**Completed:** 2026-02-02",
+                        "",
+                        "## Summary",
+                        "",
+                        "This is the elevator pitch.",
+                        "",
+                        "## Details",
+                        "More details.",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            record = GENERATOR.parse_journal_entry(journal_path, root)
+
+            self.assertEqual(record["quest_id"], "example-quest_2026-02-01__1010")
+            self.assertEqual(record["completed_date"], "2026-02-02")
+            self.assertEqual(record["elevator_pitch"], "This is the elevator pitch.")
+            self.assertEqual(record["title"], "Example Quest")
+            self.assertEqual(record["journal_path"], "docs/quest-journal/example-quest_2026-02-01.md")
+
+    def test_merge_prefers_state_fields_and_preserves_journal_pitch(self):
+        journal = [
+            {
+                "quest_id": "dup_2026-02-02__1111",
+                "slug": "dup",
+                "title": "Duplicate",
+                "elevator_pitch": "Journal narrative",
+                "completed_date": "2026-02-02",
+                "status_raw": "Complete",
+                "journal_path": "docs/quest-journal/dup_2026-02-02.md",
+            }
+        ]
+
+        active = [
+            {
+                "quest_id": "dup_2026-02-02__1111",
+                "slug": "dup",
+                "status_raw": "blocked",
+                "phase": "building",
+                "plan_iteration": 1,
+                "fix_iteration": 0,
+                "created_at": "2026-02-02T10:00:00Z",
+                "updated_at": "2026-02-02T12:00:00Z",
+                "state_path": ".quest/dup_2026-02-02__1111/state.json",
+            }
+        ]
+
+        archive = [
+            {
+                "quest_id": "dup_2026-02-02__1111",
+                "slug": "dup",
+                "status_raw": "complete",
+                "phase": "complete",
+                "plan_iteration": 3,
+                "fix_iteration": 1,
+                "created_at": "2026-02-02T10:00:00Z",
+                "updated_at": "2026-02-02T13:00:00Z",
+                "state_path": ".quest/archive/dup_2026-02-02__1111/state.json",
+            }
+        ]
+
+        quests = GENERATOR._merge_records(journal, active, archive)
+
+        self.assertEqual(len(quests), 1)
+        self.assertEqual(quests[0]["state_path"], ".quest/archive/dup_2026-02-02__1111/state.json")
+        self.assertEqual(quests[0]["status"], "finished")
+        self.assertEqual(quests[0]["plan_iteration"], 3)
+        self.assertEqual(quests[0]["elevator_pitch"], "Journal narrative")
+
+    def test_merge_includes_active_non_archived_quest_in_quests_and_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            journal_dir = root / "docs" / "quest-journal"
+            quest_dir = root / ".quest"
+            archive_dir = quest_dir / "archive"
+            journal_dir.mkdir(parents=True, exist_ok=True)
+            archive_dir.mkdir(parents=True, exist_ok=True)
+
+            (journal_dir / "README.md").write_text("ignored", encoding="utf-8")
+            (journal_dir / "active-only_2026-02-11.md").write_text(
+                "\n".join(
+                    [
+                        "# Quest Journal: Active Only",
+                        "",
+                        "**Quest ID:** active-only_2026-02-11__0900",
+                        "",
+                        "## Summary",
+                        "",
+                        "Active narrative.",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            active_state_dir = quest_dir / "active-only_2026-02-11__0900"
+            active_state_dir.mkdir(parents=True, exist_ok=True)
+            (active_state_dir / "state.json").write_text(
+                json.dumps(
+                    {
+                        "quest_id": "active-only_2026-02-11__0900",
+                        "slug": "active-only",
+                        "status": "in_progress",
+                        "phase": "building",
+                        "plan_iteration": 2,
+                        "fix_iteration": 0,
+                        "created_at": "2026-02-11T09:00:00Z",
+                        "updated_at": "2026-02-11T10:00:00Z",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            data = GENERATOR.build_dashboard_data(
+                journal_dir=journal_dir,
+                quest_dir=quest_dir,
+                archive_dir=archive_dir,
+                repo_root=root,
+                generated_at="2026-02-11T12:00:00Z",
+            )
+
+            self.assertEqual(data["summary"]["total"], 1)
+            self.assertEqual(data["summary"]["by_status"]["in_progress"], 1)
+            self.assertEqual(data["quests"][0]["quest_id"], "active-only_2026-02-11__0900")
+
+    def test_normalize_status_maps_variants_to_canonical_values(self):
+        self.assertEqual(GENERATOR.normalize_status({"status_raw": "Completed"}, None), "finished")
+        self.assertEqual(GENERATOR.normalize_status({"status_raw": "complete"}, None), "finished")
+        self.assertEqual(
+            GENERATOR.normalize_status(None, {"status_raw": "in_progress", "phase": "building"}),
+            "in_progress",
+        )
+        self.assertEqual(GENERATOR.normalize_status({"status_raw": "blocked"}, None), "blocked")
+        self.assertEqual(
+            GENERATOR.normalize_status({"status_raw": "Abandoned (plan approved, never built)"}, None),
+            "abandoned",
+        )
+
+    def test_normalize_status_unknown_values_map_to_unknown(self):
+        self.assertEqual(GENERATOR.normalize_status({"status_raw": "paused"}, None), "unknown")
+        self.assertEqual(
+            GENERATOR.normalize_status(None, {"status_raw": "building", "phase": "routing"}),
+            "unknown",
+        )
+
+    def test_build_trend_points_final_status_over_time_semantic_dataset(self):
+        quests = [
+            {
+                "status": "finished",
+                "completed_date": "2026-01-15",
+                "updated_at": "2026-01-15T12:00:00Z",
+                "created_at": None,
+            },
+            {
+                "status": "blocked",
+                "completed_date": None,
+                "updated_at": "2026-01-22T12:00:00Z",
+                "created_at": None,
+            },
+            {
+                "status": "abandoned",
+                "completed_date": "2026-02-01",
+                "updated_at": None,
+                "created_at": None,
+            },
+            {
+                "status": "in_progress",
+                "completed_date": None,
+                "updated_at": "2026-02-08T12:00:00Z",
+                "created_at": None,
+            },
+        ]
+
+        points = GENERATOR.build_trend_points(quests)
+
+        self.assertEqual(points[0]["period"], "2026-01")
+        self.assertEqual(points[0]["finished"], 1)
+        self.assertEqual(points[0]["blocked"], 1)
+        self.assertEqual(points[1]["period"], "2026-02")
+        self.assertEqual(points[1]["abandoned"], 1)
+        self.assertEqual(points[1]["in_progress"], 1)
+
+    def test_dashboard_data_schema_requires_quest_keys_and_nullable_completed_date(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            journal_dir = root / "docs" / "quest-journal"
+            quest_dir = root / ".quest"
+            archive_dir = quest_dir / "archive"
+            journal_dir.mkdir(parents=True, exist_ok=True)
+            archive_dir.mkdir(parents=True, exist_ok=True)
+
+            (journal_dir / "schema-case_2026-02-11.md").write_text(
+                "\n".join(
+                    [
+                        "# Quest Journal: Schema Case",
+                        "",
+                        "**Quest ID:** schema-case_2026-02-11__1000",
+                        "",
+                        "## Summary",
+                        "",
+                        "Schema summary.",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            state_dir = quest_dir / "schema-case_2026-02-11__1000"
+            state_dir.mkdir(parents=True, exist_ok=True)
+            (state_dir / "state.json").write_text(
+                json.dumps(
+                    {
+                        "quest_id": "schema-case_2026-02-11__1000",
+                        "slug": "schema-case",
+                        "status": "in_progress",
+                        "phase": "building",
+                        "plan_iteration": 1,
+                        "fix_iteration": 0,
+                        "created_at": "2026-02-11T10:00:00Z",
+                        "updated_at": "2026-02-11T10:30:00Z",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            data = GENERATOR.build_dashboard_data(
+                journal_dir=journal_dir,
+                quest_dir=quest_dir,
+                archive_dir=archive_dir,
+                repo_root=root,
+                generated_at="2026-02-11T12:00:00Z",
+            )
+
+            self.assertEqual(len(data["quests"]), 1)
+            quest = data["quests"][0]
+            for key in (
+                "quest_id",
+                "slug",
+                "title",
+                "elevator_pitch",
+                "status",
+                "completed_date",
+                "journal_path",
+                "state_path",
+            ):
+                self.assertIn(key, quest)
+            self.assertIsNone(quest["completed_date"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a static executive dashboard with KPI cards, status distribution doughnut chart, and monthly trend line chart using Chart.js
- Python data generator merges quest journal entries with active/archive state files into `dashboard-data.json`
- Zero server-side dependencies — static HTML/CSS/JS served via GitHub Pages

## Changes

- **Behavior**:
  - Adds `scripts/generate_quest_dashboard_data.py` — merges `.quest/`, `.quest/archive/`, and `docs/quest-journal/` data into `docs/dashboard/dashboard-data.json`
  - Dashboard renders KPI cards (total, active, completed quests), status doughnut chart, and monthly trend line chart
- **Dashboard**:
  - Adds `docs/dashboard/index.html`, `styles.css`, `app.js` — static frontend using Chart.js
  - Adds `docs/dashboard/dashboard-data.json` — pre-generated data artifact
  - Adds `docs/dashboard/README.md` — data generation and deployment instructions
- **Tests**:
  - Adds `tests/unit/test_generate_quest_dashboard_data.py` — unit tests for data generation logic
- **Documentation**:
  - Updates `README.md` with dashboard link and deployment guide for GitHub Pages

## How to Try It

```bash
# 1. Generate dashboard data from quest journal + state files
python3 scripts/generate_quest_dashboard_data.py

# 2. Serve locally
cd docs && python3 -m http.server 8000

# 3. Open in browser
open http://localhost:8000/dashboard/
```

## Test Plan
- [ ] Run `python3 scripts/generate_quest_dashboard_data.py` and verify `docs/dashboard/dashboard-data.json` is valid JSON
- [ ] Serve locally and verify dashboard renders at `http://localhost:8000/dashboard/`
- [ ] Run `python3 -m pytest tests/unit/test_generate_quest_dashboard_data.py` — all tests pass
- [ ] Verify KPI counts match expected quest totals from journal + archive

---
Quest/Co-Authored by Claude Opus 4.6 via Claude Code On Behalf of KjellKod