### PR TITLE
Add observability timestamps to verify parallel reviewer execution

### DIFF
--- a/.ai/roles/code_review_agent.md
+++ b/.ai/roles/code_review_agent.md
@@ -36,7 +36,20 @@ There are **two** Code Review Agent invocations on each review pass. They run **
 - Quest brief and plan
 
 ## Output Contract
-End your response with:
+
+**Timestamp front matter:** Your review file MUST begin with YAML front matter containing timing metadata:
+
+```yaml
+---
+reviewer: Claude (Slot A) | Codex (Slot B)
+started: <ISO 8601 timestamp when you began reviewing>
+completed: <ISO 8601 timestamp when you finished reviewing>
+---
+```
+
+Record `started` before you begin analysis and `completed` after writing the review body. These timestamps are used by the orchestrator to verify parallel execution.
+
+**Handoff:** End your response with:
 
 ```text
 ---HANDOFF---

--- a/.ai/roles/plan_review_agent.md
+++ b/.ai/roles/plan_review_agent.md
@@ -42,7 +42,20 @@ There are **two** Plan Review Agent invocations on every plan iteration. They ru
 - Optional context digest (`.ai/context_digest.md`) when orchestrator supplies it
 
 ## Output Contract
-End your response with:
+
+**Timestamp front matter:** Your review file MUST begin with YAML front matter containing timing metadata:
+
+```yaml
+---
+reviewer: Claude (Slot A) | Codex (Slot B)
+started: <ISO 8601 timestamp when you began reviewing>
+completed: <ISO 8601 timestamp when you finished reviewing>
+---
+```
+
+Record `started` before you begin analysis and `completed` after writing the review body. These timestamps are used by the orchestrator to verify parallel execution.
+
+**Handoff:** End your response with:
 
 ```text
 ---HANDOFF---

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -127,6 +127,13 @@ gates.max_plan_iterations (default: 4)
 
      Write your review to: .quest/<id>/phase_01_plan/review_claude.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Claude (Slot A)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
    )
@@ -143,6 +150,13 @@ gates.max_plan_iterations (default: 4)
 
      List up to 5 issues, highest severity first.
      Write your review to: .quest/<id>/phase_01_plan/review_claude.md
+
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Claude (Slot A)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -166,6 +180,13 @@ gates.max_plan_iterations (default: 4)
 
      Write your review to: .quest/<id>/phase_01_plan/review_codex.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Codex (Slot B)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
    )
@@ -183,12 +204,30 @@ gates.max_plan_iterations (default: 4)
      List up to 5 issues, highest severity first.
      Write your review to: .quest/<id>/phase_01_plan/review_codex.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Codex (Slot B)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
    )
    ```
    - Issue BOTH calls in the SAME message for parallel execution
    - Wait for BOTH responses, verify both review files written
+
+   **Parallelism check:** After both review files are written, check for time overlap:
+   1. Parse YAML front matter from both review files to extract `started` and `completed` timestamps
+   2. Check for overlap: `started_B < completed_A AND started_A < completed_B`
+   3. Calculate overlap duration if parallel
+   4. Create `.quest/<id>/logs/` directory if it doesn't exist
+   5. Append a line to `.quest/<id>/logs/parallelism.log`:
+      ```
+      Plan review: parallel=<true|false> (Slot A: <HH:MM:SS>-<HH:MM:SS>, Slot B: <HH:MM:SS>-<HH:MM:SS>, overlap: <N>s)
+      ```
+   6. If timestamps are missing or unparseable, log: `Plan review: parallel=unknown (timestamp parse error)`
 
 5. **Invoke Arbiter** (Claude `Task(subagent_type="arbiter")`):
    - Use a short prompt with path references only:
@@ -379,6 +418,13 @@ After plan approval, present the plan interactively before proceeding to build.
      Review ONLY the files listed above. Use git diff for details.
      Write review to: .quest/<id>/phase_03_review/review_claude.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Claude (Slot A)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
    )
@@ -399,6 +445,13 @@ After plan approval, present the plan interactively before proceeding to build.
      Review ONLY the files listed above.
      List up to 5 issues, highest severity first.
      Write review to: .quest/<id>/phase_03_review/review_claude.md
+
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Claude (Slot A)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -426,6 +479,13 @@ After plan approval, present the plan interactively before proceeding to build.
      Review ONLY the files listed above. Use git diff for details.
      Write review to: .quest/<id>/phase_03_review/review_codex.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Codex (Slot B)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
    )
@@ -447,6 +507,13 @@ After plan approval, present the plan interactively before proceeding to build.
      List up to 5 issues, highest severity first.
      Write review to: .quest/<id>/phase_03_review/review_codex.md
 
+     IMPORTANT: Start your review file with YAML front matter timestamps:
+     ---
+     reviewer: Codex (Slot B)
+     started: <ISO 8601 timestamp when you begin reviewing>
+     completed: <ISO 8601 timestamp when you finish reviewing>
+     ---
+
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
    )
@@ -454,6 +521,17 @@ After plan approval, present the plan interactively before proceeding to build.
    - **Note:** The `<file list>` and `<git diff --stat>` values embedded in these prompts are intentional small metadata (summary statistics and file names, typically a few lines). This is operational data for scoping the review, not subagent artifact content, and does not conflict with the Context Retention Rule.
    - Issue BOTH calls in the SAME message for parallel execution
    - Wait for BOTH responses, verify both review files written
+
+   **Parallelism check:** After both review files are written, check for time overlap:
+   1. Parse YAML front matter from both review files to extract `started` and `completed` timestamps
+   2. Check for overlap: `started_B < completed_A AND started_A < completed_B`
+   3. Calculate overlap duration if parallel
+   4. Create `.quest/<id>/logs/` directory if it doesn't exist
+   5. Append a line to `.quest/<id>/logs/parallelism.log`:
+      ```
+      Code review: parallel=<true|false> (Slot A: <HH:MM:SS>-<HH:MM:SS>, Slot B: <HH:MM:SS>-<HH:MM:SS>, overlap: <N>s)
+      ```
+   6. If timestamps are missing or unparseable, log: `Code review: parallel=unknown (timestamp parse error)`
 
 5. **Check verdicts:**
    - If EITHER reviewer says `NEXT: fixer` → Issues found, proceed to Step 6
@@ -516,6 +594,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Quest ID
    - Files changed (from `git diff --name-only` and `state.json` artifact paths)
    - Total iterations (plan + fix, from `state.json`)
+   - Parallel execution stats (read from `.quest/<id>/logs/parallelism.log` if it exists — show each line)
    - Location of artifacts (now in `.quest/archive/<id>/`)
    - Location of journal entry
 


### PR DESCRIPTION
## Summary
- Reviewers now write YAML front matter with started/completed timestamps in their review files
- Orchestrator checks for time overlap after each review phase and logs to parallelism.log
- Completion summary includes parallel execution stats

## Changes
- **Reviewer prompts**:
  - All 8 prompt templates (plan + code review, Slot A/B, full/fast) instruct agents to write timestamp front matter
- **Role contracts**:
  - plan_review_agent.md and code_review_agent.md output contracts require YAML front matter with reviewer, started, completed fields
- **Orchestrator workflow**:
  - Parallelism check after plan review (Step 3) and code review (Step 5): parse timestamps, check overlap, log result
  - Step 7 completion summary reads and displays parallelism.log

## Test Plan
- [ ] Run a quest and verify review files contain timestamp YAML front matter
- [ ] Check .quest/<id>/logs/parallelism.log exists with overlap data
- [ ] Verify completion summary mentions parallel execution stats

---
Quest/Co-Authored by Claude Opus 4.6 via Claude Code On Behalf of KjellKod