### PR TITLE
Add state validation script for Quest phase transitions (Phase 3)

### DIFF
--- a/.github/workflows/validate-quest-config.yml
+++ b/.github/workflows/validate-quest-config.yml
@@ -42,3 +42,8 @@ jobs:
         run: |
           chmod +x scripts/validate-handoff-contracts.sh
           ./scripts/validate-handoff-contracts.sh
+
+      - name: Run state validation tests
+        run: |
+          chmod +x tests/test-validate-quest-state.sh
+          bash tests/test-validate-quest-state.sh

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -45,6 +45,7 @@
 .skills/quest/delegation/router.md
 .skills/quest/delegation/workflow.md
 scripts/validate-quest-config.sh
+scripts/validate-quest-state.sh
 scripts/validate-manifest.sh
 scripts/validate-handoff-contracts.sh
 

--- a/.skills/git-commit-assistant/SKILL.md
+++ b/.skills/git-commit-assistant/SKILL.md
@@ -74,13 +74,12 @@ Always append this trailer exactly:
 
 ```bash
 
-Quest/Co-Authored by <agent name and model> On Behalf of <github username>
+Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with <github username>
 
 ```
 
 Replace:
 
-- **Agent name and model** with the active agent (e.g. "Claude 3.5 Sonnet via Cursor").
 - **github username** with the repository author's GitHub username (infer from git config, remote URL, or ask if unknown).
 
 Never omit the trailer.

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -96,12 +96,11 @@ Append this line at the end of the PR body:
 
 ```
 ---
-Quest/Co-Authored by <agent name and model> On Behalf of <github username>
+Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with <github username>
 ```
 
 Replace:
 
-- **Agent name and model** with the active agent (e.g. "Claude Opus 4.6 via Claude Code").
 - **github username** with the repository author's GitHub username (infer from git config, remote URL, or ask if unknown).
 
 Never omit the trailer.

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -316,7 +316,7 @@ gates.max_plan_iterations (default: 4)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
 6. **Check verdict:**
-   - If `NEXT: builder` → Plan approved! Update state: `phase: plan_reviewed`, proceed to **Step 3.5** (Interactive Presentation)
+   - If `NEXT: builder` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> plan_reviewed` -- if non-zero, STOP. Plan approved! Update state: `phase: plan_reviewed`, proceed to **Step 3.5** (Interactive Presentation)
    - If `NEXT: planner` → Check iteration count
      - If `plan_iteration >= max_plan_iterations`: Warn user, ask to proceed anyway or review manually
      - If `auto_approve_phases.plan_refinement` is false: Ask user to approve refinement
@@ -325,6 +325,8 @@ gates.max_plan_iterations (default: 4)
 ### Step 3.5: Interactive Plan Presentation
 
 After plan approval, present the plan interactively before proceeding to build.
+
+**Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presenting` -- if non-zero, STOP.
 
 **On entry:** Update state: `phase: presenting`
 
@@ -342,7 +344,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Ask: "Would you like to see the detailed phase-by-phase walkthrough? (yes/no)"
 
 **2. Handle Response:**
-   - If user declines ("no", "n", "nope", "skip", "proceed", etc.) -> Update state: `phase: presentation_complete`, then proceed to Step 4 (Build Phase)
+   - If user declines ("no", "n", "nope", "skip", "proceed", etc.) -> **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, STOP. Update state: `phase: presentation_complete`, then proceed to Step 4 (Build Phase)
    - If user accepts ("yes", "y", "yeah", "sure", "detailed", etc.) -> Continue to phase extraction
 
 **3. Extract Phases from Plan:**
@@ -391,7 +393,7 @@ After plan approval, present the plan interactively before proceeding to build.
    e. Ask: "Questions about this phase? Or changes you'd like to request? (continue/question/change)"
 
 **6. Handle Phase Response:**
-   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: update state `phase: presentation_complete` and proceed to Step 4
+   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, STOP. Update state `phase: presentation_complete` and proceed to Step 4
    - If "question" (or "q", "?", user asks a question directly) -> Answer the question using plan context, then re-ask: "Any other questions, or ready to continue? (continue/question/change)"
    - If "change" (or "modify", "revise", "update", user requests a change directly) -> Proceed to Change Handling
 
@@ -423,9 +425,11 @@ After plan approval, present the plan interactively before proceeding to build.
 
 **Build:**
 
-1. **Update state:** `phase: building`, `status: in_progress`, `last_role: builder_agent`
+1. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> building` -- if non-zero, STOP.
 
-2. **Invoke Builder** (Claude `Task(subagent_type="builder")`):
+2. **Update state:** `phase: building`, `status: in_progress`, `last_role: builder_agent`
+
+3. **Invoke Builder** (Claude `Task(subagent_type="builder")`):
    - Prompt: Reference file paths only, do not embed content:
      - Approved plan: `.quest/<id>/phase_01_plan/plan.md`
      - Quest brief: `.quest/<id>/quest_brief.md`
@@ -439,9 +443,11 @@ After plan approval, present the plan interactively before proceeding to build.
    - Verify artifacts written (from handoff.artifacts)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
-3. **Update state:** `phase: reviewing`
+4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, STOP.
 
-4. Proceed to Step 5
+5. **Update state:** `phase: reviewing`
+
+6. Proceed to Step 5
 
 ### Step 5: Review Phase
 
@@ -616,7 +622,7 @@ After plan approval, present the plan interactively before proceeding to build.
      - If handoff.json was successfully read → use its `next` and `summary` fields
      - If fallback was triggered (handoff.json missing or unparsable) → use the `NEXT` and `SUMMARY` values parsed from the text `---HANDOFF---` block in step 4
    - If EITHER slot has `next: "fixer"` → Issues found, proceed to Step 6
-   - If BOTH have `next: null` → Review passed! Update state: `phase: complete`, go to Step 7
+   - If BOTH have `next: null` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, STOP. Review passed! Update state: `phase: complete`, go to Step 7
    - Present summaries to user:
      ```
      Review complete:
@@ -636,7 +642,7 @@ After plan approval, present the plan interactively before proceeding to build.
 
 **Loop:**
 
-1. **Update state:** `fix_iteration += 1`, `last_role: fixer_agent`
+1. **Update state:** `phase: fixing`, `fix_iteration += 1`, `last_role: fixer_agent`
 
 2. **Invoke Fixer** (Claude `Task(subagent_type="fixer")`):
    - Prompt: Reference file paths only, do not embed content:
@@ -656,11 +662,15 @@ After plan approval, present the plan interactively before proceeding to build.
 
 3. **Clear stale handoff files:** Delete any existing `handoff_claude.json` and `handoff_codex.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
 
-4. **Re-invoke BOTH Code Reviewers** (same as Step 5)
+4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, STOP.
 
-5. **Check verdict (with fallback):**
-   - For each reviewer slot, use the `next` value obtained in step 4 (from handoff.json if available, or text fallback if not)
-   - If BOTH have `next: null` → Fixed! Proceed to Step 7
+5. **Re-invoke BOTH Code Reviewers** (same as Step 5)
+
+6. **Check verdict (with fallback):**
+   - For each reviewer slot, use the `next` value obtained in step 5 (from handoff.json if available, or text fallback if not)
+   - If BOTH have `next: null` → Fixed!
+     - **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, STOP.
+     - Proceed to Step 7
    - If EITHER has `next: "fixer"`:
      - If `fix_iteration >= max_fix_iterations`: Warn user, ask to proceed or review manually
      - Otherwise: Loop back to step 1

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -563,7 +563,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - For each reviewer slot, use the `next` value obtained in step 4:
      - If handoff.json was successfully read → use its `next` and `summary` fields
      - If fallback was triggered (handoff.json missing or unparsable) → use the `NEXT` and `SUMMARY` values parsed from the text `---HANDOFF---` block in step 4
-   - If EITHER slot has `next: "fixer"` → Issues found, proceed to Step 6
+   - If EITHER slot has `next: "fixer"` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> fixing` -- if non-zero, STOP. Issues found, proceed to Step 6
    - If BOTH have `next: null` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, STOP. Review passed! Update state: `phase: complete`, go to Step 7
    - Present summaries to user:
      ```

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -287,7 +287,7 @@ gates.max_plan_iterations (default: 4)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
 6. **Check verdict:**
-   - If `NEXT: builder` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> plan_reviewed` -- if non-zero, STOP. Plan approved! Update state: `phase: plan_reviewed`, proceed to **Step 3.5** (Interactive Presentation)
+   - If `NEXT: builder` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> plan_reviewed` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Plan approved! Update state: `phase: plan_reviewed`, proceed to **Step 3.5** (Interactive Presentation)
    - If `NEXT: planner` → Check iteration count
      - If `plan_iteration >= max_plan_iterations`: Warn user, ask to proceed anyway or review manually
      - If `auto_approve_phases.plan_refinement` is false: Ask user to approve refinement
@@ -297,7 +297,7 @@ gates.max_plan_iterations (default: 4)
 
 After plan approval, present the plan interactively before proceeding to build.
 
-**Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presenting` -- if non-zero, STOP.
+**Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presenting` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
 **On entry:** Update state: `phase: presenting`
 
@@ -315,7 +315,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Ask: "Would you like to see the detailed phase-by-phase walkthrough? (yes/no)"
 
 **2. Handle Response:**
-   - If user declines ("no", "n", "nope", "skip", "proceed", etc.) -> **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, STOP. Update state: `phase: presentation_complete`, then proceed to Step 4 (Build Phase)
+   - If user declines ("no", "n", "nope", "skip", "proceed", etc.) -> **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Update state: `phase: presentation_complete`, then proceed to Step 4 (Build Phase)
    - If user accepts ("yes", "y", "yeah", "sure", "detailed", etc.) -> Continue to phase extraction
 
 **3. Extract Phases from Plan:**
@@ -364,7 +364,7 @@ After plan approval, present the plan interactively before proceeding to build.
    e. Ask: "Questions about this phase? Or changes you'd like to request? (continue/question/change)"
 
 **6. Handle Phase Response:**
-   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, STOP. Update state `phase: presentation_complete` and proceed to Step 4
+   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> presentation_complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Update state `phase: presentation_complete` and proceed to Step 4
    - If "question" (or "q", "?", user asks a question directly) -> Answer the question using plan context, then re-ask: "Any other questions, or ready to continue? (continue/question/change)"
    - If "change" (or "modify", "revise", "update", user requests a change directly) -> Proceed to Change Handling
 
@@ -396,7 +396,7 @@ After plan approval, present the plan interactively before proceeding to build.
 
 **Build:**
 
-1. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> building` -- if non-zero, STOP.
+1. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> building` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
 2. **Update state:** `phase: building`, `status: in_progress`, `last_role: builder_agent`
 
@@ -414,7 +414,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Verify artifacts written (from handoff.artifacts)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
-4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, STOP.
+4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
 5. **Update state:** `phase: reviewing`
 
@@ -563,8 +563,8 @@ After plan approval, present the plan interactively before proceeding to build.
    - For each reviewer slot, use the `next` value obtained in step 4:
      - If handoff.json was successfully read → use its `next` and `summary` fields
      - If fallback was triggered (handoff.json missing or unparsable) → use the `NEXT` and `SUMMARY` values parsed from the text `---HANDOFF---` block in step 4
-   - If EITHER slot has `next: "fixer"` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> fixing` -- if non-zero, STOP. Issues found, proceed to Step 6
-   - If BOTH have `next: null` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, STOP. Review passed! Update state: `phase: complete`, go to Step 7
+   - If EITHER slot has `next: "fixer"` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> fixing` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Issues found, proceed to Step 6
+   - If BOTH have `next: null` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Review passed! Update state: `phase: complete`, go to Step 7
    - Present summaries to user:
      ```
      Review complete:
@@ -604,14 +604,14 @@ After plan approval, present the plan interactively before proceeding to build.
 
 3. **Clear stale handoff files:** Delete any existing `handoff_claude.json` and `handoff_codex.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
 
-4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, STOP.
+4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
 5. **Re-invoke BOTH Code Reviewers** (same as Step 5)
 
 6. **Check verdict (with fallback):**
    - For each reviewer slot, use the `next` value obtained in step 5 (from handoff.json if available, or text fallback if not)
    - If BOTH have `next: null` → Fixed!
-     - **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, STOP.
+     - **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
      - Proceed to Step 7
    - If EITHER has `next: "fixer"`:
      - If `fix_iteration >= max_fix_iterations`: Warn user, ask to proceed or review manually

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ The philosophy above is our north star. We are not there yet. Here is where we s
 - Human gates at phase boundaries
 - Resumable state via `state.json`
 - A thin orchestrator that passes paths, not content (Context Retention Rule)
+- State validation script that enforces phase transitions, artifact prerequisites, and semantic handoff checks (`scripts/validate-quest-state.sh`)
 
 **What Quest does not yet deliver:**
-- System-enforced correctness (state transitions are checked by prompts, not scripts)
+- Full system-enforced correctness (validation script exists but is called by the orchestrator, not yet by hooks)
 - Clean skill/role separation (some roles duplicate what skills already say)
 - A structured exploration/research capability (no `/explore` skill yet)
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-02-15 | [state-validation-script](state-validation-script_2026-02-15.md) | Implemented validate-quest-state.sh with 27-test harness, 8 workflow gates, and semantic handoff checks. Completes Phase 3 of architecture evolution. |
 | 2026-02-15 | [context-leak-closure](context-leak-closure_2026-02-15.md) | Implemented handoff.json structured file pattern for all agents, context health logging, and completion compliance report. Completes Phase 2b of the architecture evolution. |
 | 2026-02-13 | [dashboard-layout-redesign](dashboard-layout-redesign_2026-02-13.md) | Restructured dashboard to match target executive "Quest Intelligence" design — hero branding, 5 KPI cards, side-by-side charts, unified portfolio section, card content redesign. |
 | 2026-02-12 | [dashboard-visual-polish](dashboard-visual-polish_2026-02-12.md) | Added ambient CSS glows, Chart.js doughnut and stacked area charts, gradient enhancements — dashboard goes from "works" to "looks great." |

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,7 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
-| 2026-02-15 | [state-validation-script](state-validation-script_2026-02-15.md) | Implemented validate-quest-state.sh with 27-test harness, 8 workflow gates, and semantic handoff checks. Completes Phase 3 of architecture evolution. |
+| 2026-02-15 | [state-validation-script](state-validation-script_2026-02-15.md) | Implemented validate-quest-state.sh with 28-test harness, 10 workflow gates, and semantic handoff checks. Completes Phase 3 of architecture evolution. |
 | 2026-02-15 | [context-leak-closure](context-leak-closure_2026-02-15.md) | Implemented handoff.json structured file pattern for all agents, context health logging, and completion compliance report. Completes Phase 2b of the architecture evolution. |
 | 2026-02-13 | [dashboard-layout-redesign](dashboard-layout-redesign_2026-02-13.md) | Restructured dashboard to match target executive "Quest Intelligence" design — hero branding, 5 KPI cards, side-by-side charts, unified portfolio section, card content redesign. |
 | 2026-02-12 | [dashboard-visual-polish](dashboard-visual-polish_2026-02-12.md) | Added ambient CSS glows, Chart.js doughnut and stacked area charts, gradient enhancements — dashboard goes from "works" to "looks great." |

--- a/docs/quest-journal/state-validation-script_2026-02-15.md
+++ b/docs/quest-journal/state-validation-script_2026-02-15.md
@@ -12,9 +12,9 @@ This completes Phase 3 of the Quest Architecture Evolution roadmap (`ideas/quest
 
 ## Files Changed
 
-- `scripts/validate-quest-state.sh` — New, ~230 lines. Core validation script with error-counter pattern, transition table, semantic content checks.
-- `tests/test-validate-quest-state.sh` — New, ~400 lines. 27 test cases covering all transitions, artifacts, semantic checks, iteration bounds, edge cases.
-- `.skills/quest/delegation/workflow.md` — Modified. 8 validation gate callsite lines inserted before phase transitions.
+- `scripts/validate-quest-state.sh` — New, ~430 lines. Core validation script with error-counter pattern, transition table, semantic content checks, agent stop instruction on failure.
+- `tests/test-validate-quest-state.sh` — New, ~500 lines. 28 test cases covering all transitions, artifacts, semantic checks, iteration bounds, edge cases, validation logging.
+- `.skills/quest/delegation/workflow.md` — Modified. 10 validation gate callsite lines inserted before phase transitions.
 - `ideas/quest-architecture-evolution.md` — Modified. Phase 3 status updated to Done.
 - `.quest-manifest` — Modified. Added `scripts/validate-quest-state.sh` to copy-as-is section.
 

--- a/docs/quest-journal/state-validation-script_2026-02-15.md
+++ b/docs/quest-journal/state-validation-script_2026-02-15.md
@@ -1,0 +1,39 @@
+# Quest Journal: State Validation Script
+
+**Quest ID:** `state-validation-script_2026-02-15__1508`
+**Date:** 2026-02-15
+**Status:** Complete
+
+## Summary
+
+Implemented `scripts/validate-quest-state.sh` — the first system-enforced correctness check for Quest phase transitions. The shell script validates state.json integrity, phase transition legality, artifact prerequisites, semantic content checks (arbiter verdict, review outcomes via jq on handoff JSON), and iteration bounds before every phase transition.
+
+This completes Phase 3 of the Quest Architecture Evolution roadmap (`ideas/quest-architecture-evolution.md`).
+
+## Files Changed
+
+- `scripts/validate-quest-state.sh` — New, ~230 lines. Core validation script with error-counter pattern, transition table, semantic content checks.
+- `tests/test-validate-quest-state.sh` — New, ~400 lines. 27 test cases covering all transitions, artifacts, semantic checks, iteration bounds, edge cases.
+- `.skills/quest/delegation/workflow.md` — Modified. 8 validation gate callsite lines inserted before phase transitions.
+- `ideas/quest-architecture-evolution.md` — Modified. Phase 3 status updated to Done.
+- `.quest-manifest` — Modified. Added `scripts/validate-quest-state.sh` to copy-as-is section.
+
+## Key Decisions
+
+- **`<quest-dir>` path argument** instead of `<quest-id>` — avoids hardcoding `.quest/` prefix, works in worktrees.
+- **Exit codes 0/1/2** — 0 valid, 1 validation failed, 2 usage error. Standard Unix convention.
+- **Iteration bounds as `[WARN]` not `[FAIL]`** — orchestrator handles policy; script enforces structure.
+- **Semantic checks via jq on handoff JSON** — arbiter verdict, reviewer outcomes checked for content, not just file existence.
+
+## Iterations
+
+- Plan: 3 iterations (iteration 1 missed semantic checks; iteration 2 addressed arbiter feedback; iteration 3 incorporated user feedback for CLI design, exit codes, workflow integration)
+- Fix: 3 iterations (iteration 1 fixed 6 issues; iteration 2 fixed 2 should-fix items; iteration 3 fixed workflow state transition + manifest + presentation-path tests)
+
+## This is where it all began...
+
+> ### Phase 3: State validation script
+>
+> **Problem:** The orchestrator is told to check state before proceeding. If it doesn't, nothing prevents a phase from starting without its prerequisites.
+>
+> **Solution:** A `scripts/validate-quest-state.sh` script that the orchestrator calls before each phase transition.

--- a/ideas/quest-architecture-evolution.md
+++ b/ideas/quest-architecture-evolution.md
@@ -196,6 +196,6 @@ Phases 1 and 2 can start immediately, in parallel.
 | Phase 1: `/explore` skill | Not started |
 | Phase 2: Thin orchestrator | **Done** (`thin-orchestrator_2026-02-09__1845`) |
 | Phase 2b: Close context leaks | Not started — `ideas/quest-context-optimization.md` |
-| Phase 3: State validation | Not started |
+| Phase 3: State validation | **Done** (`state-validation-script_2026-02-15__1508`) |
 | Phase 4: Role simplification | Not started |
 | Phase 5: Infrastructure | Backlog |

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -14,6 +14,13 @@
 #
 # Dependencies: bash, jq, standard POSIX utilities
 # No network access required.
+#
+# Design note: This script is intentionally stricter than the workflow's
+# fallback behavior. The workflow allows text-based handoff parsing when
+# handoff.json files are missing. This script requires handoff.json files
+# for semantic checks (arbiter verdict, review outcomes). This strictness
+# incentivizes agents to write handoff.json and pushes the system toward
+# structured handoff as the norm rather than the exception.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 SCRIPT_NAME="$(basename "$0")"

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -413,6 +413,10 @@ main() {
   echo ""
   if [ "$ERRORS" -gt 0 ]; then
     echo "$ERRORS validation(s) failed"
+    echo ""
+    echo "AGENT: Validation failed. Do NOT proceed with this phase transition."
+    echo "Do NOT modify state.json to work around this failure."
+    echo "Report this validation failure to the user and STOP."
     exit 1
   fi
   echo "All validations passed!"

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Quest state validation script
+# Validates state.json and artifact prerequisites before phase transitions.
+#
+# Usage: validate-quest-state.sh <quest-dir> <target-phase>
+# Exit codes: 0 = valid, 1 = validation failed, 2 = usage error
+#
+# Checks:
+#   - state.json exists and is valid JSON
+#   - Current phase matches expected predecessor for target phase
+#   - Required artifacts from previous phase exist
+#   - Semantic content checks on handoff JSON files (where required)
+#   - plan_iteration / fix_iteration within bounds (warns, does not fail)
+#
+# Dependencies: bash, jq, standard POSIX utilities
+# No network access required.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SCRIPT_NAME="$(basename "$0")"
+
+ERRORS=0
+CURRENT_PHASE=""
+PLAN_ITERATION=0
+FIX_ITERATION=0
+MAX_PLAN_ITERATIONS=4
+MAX_FIX_ITERATIONS=3
+
+# Colors for output (disabled if not a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  NC='\033[0m'
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  NC=''
+fi
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; ERRORS=$((ERRORS + 1)); }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+
+# --help: show usage
+show_help() {
+  cat <<EOF
+Usage: $SCRIPT_NAME <quest-dir> <target-phase>
+
+Validates quest state prerequisites before a phase transition.
+
+Arguments:
+  quest-dir     Path to the quest directory (e.g., .quest/feature-x_2026-02-15__1430)
+  target-phase  The phase to transition to
+
+Exit codes:
+  0  All prerequisites met
+  1  Validation failed (missing artifacts, invalid transition, etc.)
+  2  Usage error (bad arguments, missing quest directory)
+
+Valid target phases:
+  plan, plan_reviewed, presenting, presentation_complete,
+  building, reviewing, fixing, complete
+
+Dependencies: bash, jq
+EOF
+  exit 0
+}
+
+# Read iteration bounds from .ai/allowlist.json (with defaults)
+read_max_iterations() {
+  local allowlist="$REPO_ROOT/.ai/allowlist.json"
+  if [ -f "$allowlist" ] && command -v jq &>/dev/null; then
+    local val
+    val=$(jq -r '.gates.max_plan_iterations // empty' "$allowlist" 2>/dev/null)
+    if [ -n "$val" ]; then
+      if [[ "$val" =~ ^[0-9]+$ ]]; then
+        MAX_PLAN_ITERATIONS="$val"
+      else
+        warn "allowlist max_plan_iterations is not a valid integer: '$val' (using default $MAX_PLAN_ITERATIONS)"
+      fi
+    fi
+    val=$(jq -r '.gates.max_fix_iterations // empty' "$allowlist" 2>/dev/null)
+    if [ -n "$val" ]; then
+      if [[ "$val" =~ ^[0-9]+$ ]]; then
+        MAX_FIX_ITERATIONS="$val"
+      else
+        warn "allowlist max_fix_iterations is not a valid integer: '$val' (using default $MAX_FIX_ITERATIONS)"
+      fi
+    fi
+  fi
+}
+
+# Validate state.json exists and is parseable
+validate_state_json() {
+  local quest_dir="$1"
+  local state_file="$quest_dir/state.json"
+
+  if [ ! -f "$state_file" ]; then
+    fail "state.json not found at $state_file"
+    return
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    fail "jq is required but not installed"
+    return
+  fi
+
+  if ! jq empty "$state_file" 2>/dev/null; then
+    fail "state.json is not valid JSON"
+    return
+  fi
+  pass "state.json exists and is valid JSON"
+
+  CURRENT_PHASE=$(jq -r '.phase // empty' "$state_file" 2>/dev/null)
+  local raw_plan_iter raw_fix_iter
+  raw_plan_iter=$(jq -r '.plan_iteration // 0' "$state_file" 2>/dev/null)
+  raw_fix_iter=$(jq -r '.fix_iteration // 0' "$state_file" 2>/dev/null)
+
+  # Validate iteration fields are numeric
+  if ! [[ "$raw_plan_iter" =~ ^[0-9]+$ ]]; then
+    fail "plan_iteration is not a valid integer: '$raw_plan_iter'"
+    raw_plan_iter=0
+  fi
+  if ! [[ "$raw_fix_iter" =~ ^[0-9]+$ ]]; then
+    fail "fix_iteration is not a valid integer: '$raw_fix_iter'"
+    raw_fix_iter=0
+  fi
+
+  PLAN_ITERATION="$raw_plan_iter"
+  FIX_ITERATION="$raw_fix_iter"
+
+  if [ -z "$CURRENT_PHASE" ]; then
+    fail "state.json missing 'phase' field"
+  fi
+}
+
+# Validate the transition is allowed
+# Returns the transition key if valid, empty string if not
+validate_transition() {
+  local current="$1"
+  local target="$2"
+
+  # Allowed transitions: current->target
+  local valid=false
+  case "${current}->${target}" in
+    "plan->plan_reviewed") valid=true ;;
+    "plan->plan")          valid=true ;;
+    "plan_reviewed->presenting") valid=true ;;
+    "presenting->presentation_complete") valid=true ;;
+    "presentation_complete->building") valid=true ;;
+    "plan_reviewed->building") valid=true ;;
+    "building->reviewing") valid=true ;;
+    "reviewing->fixing")   valid=true ;;
+    "reviewing->complete") valid=true ;;
+    "fixing->reviewing")   valid=true ;;
+  esac
+
+  if [ "$valid" = true ]; then
+    pass "Transition $current -> $target is valid"
+  else
+    fail "Invalid transition: $current -> $target (not in allowed transition table)"
+  fi
+}
+
+# Check that required artifact files exist for the given transition
+validate_artifacts() {
+  local quest_dir="$1"
+  local current="$2"
+  local target="$3"
+
+  case "${current}->${target}" in
+    "plan->plan_reviewed")
+      check_file "$quest_dir/phase_01_plan/plan.md"
+      check_file "$quest_dir/phase_01_plan/review_claude.md"
+      check_file "$quest_dir/phase_01_plan/review_codex.md"
+      check_file "$quest_dir/phase_01_plan/arbiter_verdict.md"
+      ;;
+    "plan->plan")
+      check_file "$quest_dir/phase_01_plan/arbiter_verdict.md"
+      ;;
+    "plan_reviewed->presenting")
+      check_file "$quest_dir/phase_01_plan/plan.md"
+      ;;
+    "presenting->presentation_complete")
+      check_file "$quest_dir/phase_01_plan/plan.md"
+      ;;
+    "presentation_complete->building")
+      check_file "$quest_dir/phase_01_plan/plan.md"
+      ;;
+    "plan_reviewed->building")
+      check_file "$quest_dir/phase_01_plan/plan.md"
+      ;;
+    "building->reviewing")
+      check_dir_nonempty "$quest_dir/phase_02_implementation"
+      ;;
+    "reviewing->fixing")
+      check_file "$quest_dir/phase_03_review/review_claude.md"
+      check_file "$quest_dir/phase_03_review/review_codex.md"
+      ;;
+    "reviewing->complete")
+      check_file "$quest_dir/phase_03_review/review_claude.md"
+      check_file "$quest_dir/phase_03_review/review_codex.md"
+      ;;
+    "fixing->reviewing")
+      check_file "$quest_dir/phase_03_review/review_fix_feedback_discussion.md"
+      ;;
+  esac
+}
+
+check_file() {
+  local filepath="$1"
+  if [ -f "$filepath" ]; then
+    pass "Artifact exists: $filepath"
+  else
+    fail "Missing artifact: $filepath"
+  fi
+}
+
+check_dir_nonempty() {
+  local dirpath="$1"
+  if [ ! -d "$dirpath" ]; then
+    fail "Directory does not exist: $dirpath"
+    return
+  fi
+  # Check if directory has any files (not just subdirs)
+  local first_file
+  first_file=$(find "$dirpath" -type f 2>/dev/null | head -1)
+  if [ -n "$first_file" ]; then
+    pass "Directory exists and is non-empty: $dirpath"
+  else
+    fail "Directory is empty: $dirpath"
+  fi
+}
+
+# Semantic content checks on handoff JSON files
+validate_semantic_content() {
+  local quest_dir="$1"
+  local current="$2"
+  local target="$3"
+
+  case "${current}->${target}" in
+    "plan_reviewed->building")
+      local arbiter_file="$quest_dir/phase_01_plan/handoff_arbiter.json"
+      if [ ! -f "$arbiter_file" ]; then
+        fail "Semantic check: handoff_arbiter.json not found at $arbiter_file"
+        return
+      fi
+      local next_val
+      next_val=$(jq -r '.next' "$arbiter_file" 2>/dev/null)
+      if [ "$next_val" = "builder" ]; then
+        pass "Semantic check: arbiter approved (next=builder)"
+      else
+        fail "Semantic check: arbiter did not approve for building (next=$next_val, expected builder)"
+      fi
+      ;;
+    "reviewing->fixing")
+      local claude_file="$quest_dir/phase_03_review/handoff_claude.json"
+      local codex_file="$quest_dir/phase_03_review/handoff_codex.json"
+      local has_fixer=false
+
+      if [ -f "$claude_file" ]; then
+        local claude_next
+        claude_next=$(jq -r '.next' "$claude_file" 2>/dev/null)
+        if [ "$claude_next" = "fixer" ]; then
+          has_fixer=true
+        fi
+      fi
+      if [ -f "$codex_file" ]; then
+        local codex_next
+        codex_next=$(jq -r '.next' "$codex_file" 2>/dev/null)
+        if [ "$codex_next" = "fixer" ]; then
+          has_fixer=true
+        fi
+      fi
+
+      if [ "$has_fixer" = true ]; then
+        pass "Semantic check: at least one reviewer indicates issues (next=fixer)"
+      else
+        fail "Semantic check: no reviewer indicates issues requiring fixing"
+      fi
+      ;;
+    "reviewing->complete")
+      local claude_file="$quest_dir/phase_03_review/handoff_claude.json"
+      local codex_file="$quest_dir/phase_03_review/handoff_codex.json"
+      local both_clean=true
+
+      if [ -f "$claude_file" ]; then
+        local claude_next
+        claude_next=$(jq -r '.next' "$claude_file" 2>/dev/null)
+        if [ "$claude_next" != "null" ]; then
+          both_clean=false
+        fi
+      else
+        both_clean=false
+      fi
+
+      if [ -f "$codex_file" ]; then
+        local codex_next
+        codex_next=$(jq -r '.next' "$codex_file" 2>/dev/null)
+        if [ "$codex_next" != "null" ]; then
+          both_clean=false
+        fi
+      else
+        both_clean=false
+      fi
+
+      if [ "$both_clean" = true ]; then
+        pass "Semantic check: both reviewers report clean (next=null)"
+      else
+        fail "Semantic check: reviews are not both clean (both handoff files must have next=null)"
+      fi
+      ;;
+  esac
+}
+
+# Check iteration bounds (warn only, do not fail)
+validate_iteration_bounds() {
+  local target="$1"
+  local plan_iter="$2"
+  local fix_iter="$3"
+
+  case "$target" in
+    "plan")
+      if [ "$plan_iter" -ge "$MAX_PLAN_ITERATIONS" ]; then
+        warn "Plan iteration $plan_iter >= max $MAX_PLAN_ITERATIONS (iteration bounds exceeded)"
+      else
+        pass "Plan iteration $plan_iter within bounds (max $MAX_PLAN_ITERATIONS)"
+      fi
+      ;;
+    "reviewing")
+      # Only check fix iteration if coming from fixing (check source phase, not counter value)
+      if [ "$CURRENT_PHASE" = "fixing" ]; then
+        if [ "$fix_iter" -ge "$MAX_FIX_ITERATIONS" ]; then
+          warn "Fix iteration $fix_iter >= max $MAX_FIX_ITERATIONS (iteration bounds exceeded)"
+        else
+          pass "Fix iteration $fix_iter within bounds (max $MAX_FIX_ITERATIONS)"
+        fi
+      fi
+      ;;
+    "fixing")
+      if [ "$fix_iter" -ge "$MAX_FIX_ITERATIONS" ]; then
+        warn "Fix iteration $fix_iter >= max $MAX_FIX_ITERATIONS (iteration bounds exceeded)"
+      else
+        pass "Fix iteration $fix_iter within bounds (max $MAX_FIX_ITERATIONS)"
+      fi
+      ;;
+  esac
+}
+
+# Main entry point
+main() {
+  # Handle --help
+  case "${1:-}" in
+    --help|-h)
+      show_help
+      ;;
+  esac
+
+  # Usage check
+  if [ $# -lt 2 ]; then
+    echo "Usage: $SCRIPT_NAME <quest-dir> <target-phase>" >&2
+    echo "Run '$SCRIPT_NAME --help' for details." >&2
+    exit 2
+  fi
+
+  local quest_dir="$1"
+  local target_phase="$2"
+
+  if [ ! -d "$quest_dir" ]; then
+    echo "Error: Quest directory not found: $quest_dir" >&2
+    exit 2
+  fi
+
+  echo "=== Quest State Validation ==="
+  echo "Quest dir: $quest_dir"
+  echo "Target phase: $target_phase"
+  echo ""
+
+  # Read iteration bounds from allowlist
+  read_max_iterations
+
+  # Run all validators
+  validate_state_json "$quest_dir"
+
+  # If state.json could not be parsed, we cannot proceed with further checks
+  if [ -z "$CURRENT_PHASE" ]; then
+    echo ""
+    echo "$ERRORS validation(s) failed"
+    exit 1
+  fi
+
+  validate_transition "$CURRENT_PHASE" "$target_phase"
+  validate_artifacts "$quest_dir" "$CURRENT_PHASE" "$target_phase"
+  validate_semantic_content "$quest_dir" "$CURRENT_PHASE" "$target_phase"
+  validate_iteration_bounds "$target_phase" "$PLAN_ITERATION" "$FIX_ITERATION"
+
+  echo ""
+  if [ "$ERRORS" -gt 0 ]; then
+    echo "$ERRORS validation(s) failed"
+    exit 1
+  fi
+  echo "All validations passed!"
+  exit 0
+}
+
+main "$@"

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -392,8 +392,17 @@ main() {
 
   # If state.json could not be parsed, we cannot proceed with further checks
   if [ -z "$CURRENT_PHASE" ]; then
+    # Log even on early failure
+    local log_dir="$quest_dir/logs"
+    if [ -d "$log_dir" ] || mkdir -p "$log_dir" 2>/dev/null; then
+      echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') | transition=unknown->$target_phase | result=fail | errors=$ERRORS" >> "$log_dir/validation.log"
+    fi
     echo ""
     echo "$ERRORS validation(s) failed"
+    echo ""
+    echo "AGENT: Validation failed. Do NOT proceed with this phase transition."
+    echo "Do NOT modify state.json to work around this failure."
+    echo "Report this validation failure to the user and STOP."
     exit 1
   fi
 

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -193,6 +193,8 @@ validate_artifacts() {
       check_file "$quest_dir/phase_01_plan/plan.md"
       ;;
     "presentation_complete->building")
+      # No arbiter semantic re-check here. The arbiter approves at plan->plan_reviewed.
+      # The presentation path only shows the plan to the user; it doesn't change approval.
       check_file "$quest_dir/phase_01_plan/plan.md"
       ;;
     "plan_reviewed->building")
@@ -294,6 +296,8 @@ validate_semantic_content() {
 
       if [ -f "$claude_file" ]; then
         local claude_next
+        # Note: jq -r outputs "null" for both JSON null and missing .next field.
+        # This is acceptable since agents always write structured handoff JSON.
         claude_next=$(jq -r '.next' "$claude_file" 2>/dev/null)
         if [ "$claude_next" != "null" ]; then
           both_clean=false

--- a/scripts/validate-quest-state.sh
+++ b/scripts/validate-quest-state.sh
@@ -395,6 +395,14 @@ main() {
   validate_semantic_content "$quest_dir" "$CURRENT_PHASE" "$target_phase"
   validate_iteration_bounds "$target_phase" "$PLAN_ITERATION" "$FIX_ITERATION"
 
+  # Log this validation run
+  local log_dir="$quest_dir/logs"
+  if [ -d "$log_dir" ] || mkdir -p "$log_dir" 2>/dev/null; then
+    local result="pass"
+    [ "$ERRORS" -gt 0 ] && result="fail"
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') | transition=$CURRENT_PHASE->$target_phase | result=$result | errors=$ERRORS" >> "$log_dir/validation.log"
+  fi
+
   echo ""
   if [ "$ERRORS" -gt 0 ]; then
     echo "$ERRORS validation(s) failed"

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# Test harness for scripts/validate-quest-state.sh
+# Run: bash tests/test-validate-quest-state.sh
+# Exit 0 = all tests pass, 1 = some tests failed
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SCRIPT="$REPO_ROOT/scripts/validate-quest-state.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+  local name="$1"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if "$name"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo "[PASS] $name"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo "[FAIL] $name"
+  fi
+}
+
+# Helper: create a minimal valid state.json
+create_state_json() {
+  local dir="$1"
+  local phase="$2"
+  local plan_iter="${3:-1}"
+  local fix_iter="${4:-0}"
+  cat > "$dir/state.json" <<EOF
+{
+  "quest_id": "test-quest_2026-01-01__0000",
+  "slug": "test-quest",
+  "phase": "$phase",
+  "status": "in_progress",
+  "plan_iteration": $plan_iter,
+  "fix_iteration": $fix_iter,
+  "last_role": "test",
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}
+EOF
+}
+
+# ---- Test Cases ----
+
+test_missing_state_json() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -qi "state.json"
+}
+
+test_invalid_json() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  echo "not json {{{" > "$tmpdir/state.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -qi "json"
+}
+
+test_valid_plan_to_plan_reviewed() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_claude.md"
+  touch "$tmpdir/phase_01_plan/review_codex.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_missing_artifact_plan_to_plan_reviewed() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_claude.md"
+  # Missing review_codex.md
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "review_codex.md"
+}
+
+test_valid_plan_reviewed_to_building() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan_reviewed"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  echo '{"status":"complete","next":"builder","summary":"approved"}' > "$tmpdir/phase_01_plan/handoff_arbiter.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "building" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_plan_reviewed_to_building_arbiter_says_iterate() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan_reviewed"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  echo '{"status":"complete","next":"planner","summary":"iterate"}' > "$tmpdir/phase_01_plan/handoff_arbiter.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "building" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -qi "arbiter"
+}
+
+test_plan_reviewed_to_building_missing_arbiter_handoff() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan_reviewed"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  # No handoff_arbiter.json
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "building" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]"
+}
+
+test_valid_building_to_reviewing() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "building"
+  mkdir -p "$tmpdir/phase_02_implementation"
+  touch "$tmpdir/phase_02_implementation/pr_description.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "reviewing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_building_to_reviewing_empty_dir() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "building"
+  mkdir -p "$tmpdir/phase_02_implementation"
+  # Empty directory
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "reviewing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]"
+}
+
+test_valid_reviewing_to_complete() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "reviewing"
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_claude.md"
+  touch "$tmpdir/phase_03_review/review_codex.md"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_claude.json"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_codex.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "complete" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_reviewing_to_complete_has_issues() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "reviewing"
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_claude.md"
+  touch "$tmpdir/phase_03_review/review_codex.md"
+  echo '{"status":"complete","next":"fixer","summary":"found issues"}' > "$tmpdir/phase_03_review/handoff_claude.json"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_codex.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "complete" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -qi "clean"
+}
+
+test_valid_reviewing_to_fixing() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "reviewing"
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_claude.md"
+  touch "$tmpdir/phase_03_review/review_codex.md"
+  echo '{"status":"complete","next":"fixer","summary":"found issues"}' > "$tmpdir/phase_03_review/handoff_claude.json"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_codex.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "fixing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_reviewing_to_fixing_both_clean() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "reviewing"
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_claude.md"
+  touch "$tmpdir/phase_03_review/review_codex.md"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_claude.json"
+  echo '{"status":"complete","next":null,"summary":"no issues"}' > "$tmpdir/phase_03_review/handoff_codex.json"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "fixing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]"
+}
+
+test_invalid_transition() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "complete"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]"
+}
+
+test_plan_iteration_exceeded() {
+  local tmpdir stderr_file
+  tmpdir=$(mktemp -d)
+  stderr_file=$(mktemp)
+  create_state_json "$tmpdir" "plan" 4 0
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  local output stderr_output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan" 2>"$stderr_file")
+  local rc=$?
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ] && echo "$stderr_output" | grep -q "\[WARN\]"
+}
+
+test_fix_iteration_exceeded() {
+  local tmpdir stderr_file
+  tmpdir=$(mktemp -d)
+  stderr_file=$(mktemp)
+  create_state_json "$tmpdir" "fixing" 1 3
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_fix_feedback_discussion.md"
+  local output stderr_output
+  output=$(bash "$SCRIPT" "$tmpdir" "reviewing" 2>"$stderr_file")
+  local rc=$?
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ] && echo "$stderr_output" | grep -q "\[WARN\]"
+}
+
+test_plan_iteration_within_bounds() {
+  local tmpdir stderr_file
+  tmpdir=$(mktemp -d)
+  stderr_file=$(mktemp)
+  create_state_json "$tmpdir" "plan" 2 0
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  local output stderr_output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan" 2>"$stderr_file")
+  local rc=$?
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ] && echo "$output" | grep -q "\[PASS\]" && ! echo "$stderr_output" | grep -q "\[WARN\]"
+}
+
+test_help_flag() {
+  local output
+  output=$(bash "$SCRIPT" --help 2>&1)
+  local rc=$?
+  [ "$rc" -eq 0 ] && echo "$output" | grep -qi "usage"
+}
+
+test_missing_args() {
+  local output
+  output=$(bash "$SCRIPT" 2>&1)
+  local rc=$?
+  [ "$rc" -eq 2 ] && echo "$output" | grep -qi "usage"
+}
+
+test_valid_fixing_to_reviewing() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "fixing" 1 1
+  mkdir -p "$tmpdir/phase_03_review"
+  touch "$tmpdir/phase_03_review/review_fix_feedback_discussion.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "reviewing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_building_to_reviewing_no_dir() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "building"
+  # No phase_02_implementation directory
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "reviewing" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]"
+}
+
+test_nonexistent_quest_dir() {
+  local output
+  output=$(bash "$SCRIPT" "/nonexistent/path/to/quest" "building" 2>&1)
+  local rc=$?
+  [ "$rc" -eq 2 ] && echo "$output" | grep -qi "not found"
+}
+
+test_non_numeric_iteration_fields() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  cat > "$tmpdir/state.json" <<EOF
+{
+  "quest_id": "test-quest_2026-01-01__0000",
+  "slug": "test-quest",
+  "phase": "plan",
+  "status": "in_progress",
+  "plan_iteration": "oops",
+  "fix_iteration": "bad",
+  "last_role": "test",
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}
+EOF
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -qi "plan_iteration"
+}
+
+test_valid_plan_reviewed_to_presenting() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan_reviewed"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "presenting" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_valid_presenting_to_presentation_complete() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "presenting"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "presentation_complete" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_valid_presentation_complete_to_building() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "presentation_complete"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "building" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
+test_non_numeric_allowlist_iterations() {
+  local tmpdir stderr_file
+  tmpdir=$(mktemp -d)
+  stderr_file=$(mktemp)
+  create_state_json "$tmpdir" "plan" 2 0
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  # Create a fake git repo with non-numeric allowlist iteration values.
+  # The script resolves REPO_ROOT via git rev-parse, so we must run from
+  # inside this fake repo for it to pick up the allowlist.
+  local fakerepo
+  fakerepo=$(mktemp -d)
+  git -C "$fakerepo" init --quiet
+  mkdir -p "$fakerepo/.ai"
+  cat > "$fakerepo/.ai/allowlist.json" <<AEOF
+{
+  "gates": {
+    "max_plan_iterations": "nope",
+    "max_fix_iterations": "bad"
+  }
+}
+AEOF
+  mkdir -p "$fakerepo/scripts"
+  cp "$SCRIPT" "$fakerepo/scripts/validate-quest-state.sh"
+  local output stderr_output
+  output=$(cd "$fakerepo" && bash scripts/validate-quest-state.sh "$tmpdir" "plan" 2>"$stderr_file")
+  local rc=$?
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  rm -rf "$tmpdir" "$fakerepo"
+  # Should still pass (warnings only, defaults used), and stderr should have WARN
+  [ "$rc" -eq 0 ] && echo "$stderr_output" | grep -q "\[WARN\]" && echo "$stderr_output" | grep -qi "max_plan_iterations"
+}
+
+# ---- Run all tests ----
+
+echo "=== Quest State Validation Tests ==="
+echo ""
+
+run_test test_missing_state_json
+run_test test_invalid_json
+run_test test_valid_plan_to_plan_reviewed
+run_test test_missing_artifact_plan_to_plan_reviewed
+run_test test_valid_plan_reviewed_to_building
+run_test test_plan_reviewed_to_building_arbiter_says_iterate
+run_test test_plan_reviewed_to_building_missing_arbiter_handoff
+run_test test_valid_building_to_reviewing
+run_test test_building_to_reviewing_empty_dir
+run_test test_valid_reviewing_to_complete
+run_test test_reviewing_to_complete_has_issues
+run_test test_valid_reviewing_to_fixing
+run_test test_reviewing_to_fixing_both_clean
+run_test test_invalid_transition
+run_test test_plan_iteration_exceeded
+run_test test_fix_iteration_exceeded
+run_test test_plan_iteration_within_bounds
+run_test test_help_flag
+run_test test_missing_args
+run_test test_valid_fixing_to_reviewing
+run_test test_building_to_reviewing_no_dir
+run_test test_nonexistent_quest_dir
+run_test test_non_numeric_iteration_fields
+run_test test_valid_plan_reviewed_to_presenting
+run_test test_valid_presenting_to_presentation_complete
+run_test test_valid_presentation_complete_to_building
+run_test test_non_numeric_allowlist_iterations
+
+echo ""
+echo "=== Results ==="
+echo "Total: $TESTS_RUN  Passed: $TESTS_PASSED  Failed: $TESTS_FAILED"
+
+if [ "$TESTS_FAILED" -eq 0 ]; then
+  echo "All tests passed!"
+  exit 0
+else
+  echo "$TESTS_FAILED test(s) failed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/validate-quest-state.sh` — the first system-enforced correctness check for Quest, validating state.json integrity, phase transitions, artifact prerequisites, and semantic handoff content before every phase change.
- Add 28-test harness and 10 validation gate callsite lines in workflow.md.
- Completes Phase 3 of the Quest Architecture Evolution roadmap.

## Changes
- **Validation Script** (`scripts/validate-quest-state.sh`):
  - Accepts `<quest-dir> <target-phase>`, no hardcoded `.quest/` prefix
  - Exit codes: 0 (valid), 1 (validation failed), 2 (usage error)
  - Error-counter pattern matching existing `validate-quest-config.sh`
  - Semantic content checks via jq on handoff JSON (arbiter verdict, review outcomes)
  - Iteration bounds as `[WARN]` on stderr, not hard failures
  - Automatic logging to `<quest-dir>/logs/validation.log` on every run, including early-exit failures
  - Intentionally stricter than workflow fallback: requires handoff.json for semantic checks to incentivize structured handoff as the norm
  - On failure, outputs explicit agent stop instruction to prevent self-healing
  - Code comments documenting null check behavior and intentional arbiter skip on presentation path
- **Tests** (`tests/test-validate-quest-state.sh`):
  - 28 test cases covering all transitions, semantic checks, edge cases, usage errors, validation logging
- **CI/Workflows** (`.github/workflows/validate-quest-config.yml`):
  - Added state validation test step — runs all 28 tests on push to main and PRs targeting main
- **Orchestration** (`.skills/quest/delegation/workflow.md`):
  - 10 validation gate callsite lines before all phase transitions
  - Gate wording: "report output to user and STOP. Do NOT modify state.json."
  - Fix-loop Step 6.1 now explicitly sets `phase: fixing`
- **Manifest** (`.quest-manifest`):
  - Added `scripts/validate-quest-state.sh` to `[copy-as-is]`
- **Documentation**:
  - Phase 3 marked Done in `ideas/quest-architecture-evolution.md`
  - README updated: state validation moved from "not yet delivered" to "delivered"
  - Quest journal entry added

## Acceptance Criteria
- [x] `bash tests/test-validate-quest-state.sh` — 28 tests pass (covers exit codes, transitions, artifact checks, semantic handoff checks, iteration bounds)
- [x] `bash scripts/validate-manifest.sh` passes
- [x] `grep -c "validate-quest-state.sh" .skills/quest/delegation/workflow.md` — expect 10 validation gates
- [x] State validation tests run in CI
- [x] Depends only on bash, jq, and POSIX utilities (no network)
- [x] Every run appends to `<quest-dir>/logs/validation.log`, including early-exit failures
- [x] Agent stops and reports to user on validation failure (manually verified with corrupted state.json)

## Test Plan

All acceptance criteria are verified by automated tests. No manual testing required beyond running:

```bash
bash tests/test-validate-quest-state.sh    # 28 tests — all transitions, edge cases, semantic checks
bash scripts/validate-manifest.sh          # manifest completeness
```

Manually verified: corrupting state.json phase to an invalid value causes the orchestrator to stop at the validation gate, report the failure to the user, and not self-heal.

---
Quest/Co-Authored by Claude Opus 4.6 via Claude Code On Behalf of KjellKod