### PR TITLE
Add Codex  thin wrapper integration

### DIFF
--- a/.agents/skills/quest/SKILL.md
+++ b/.agents/skills/quest/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: quest
+description: Multi-agent quest orchestration. Plans, reviews, builds, and fixes features through coordinated agent handoffs. Use when the user invokes $quest or asks to run/resume Quest workflow.
+---
+
+Read and follow the instructions in `.skills/quest/SKILL.md`.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -25,7 +25,7 @@ This repository uses **layered documentation** for AI agent context management.
 
 ## Quick Navigation
 
-- **Multi-agent orchestration?** → Use `.skills/quest/` skill
+- **Multi-agent orchestration?** → Use `$quest` (thin wrapper in `.agents/skills/quest/SKILL.md`, which delegates to `.skills/quest/SKILL.md`)
 - **Building a feature?** → Use `.skills/implementer/` skill
 - **Reviewing an implementation plan?** → Use `.skills/plan-reviewer/` skill
 - **Reviewing code?** → Use `.skills/code-reviewer/` skill

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -30,6 +30,7 @@
 .claude/skills/pr-assistant/SKILL.md
 .claude/skills/quest/SKILL.md
 .claude/AGENTS.md
+.agents/skills/quest/SKILL.md
 .skills/BOOTSTRAP.md
 .skills/README.md
 .skills/SKILLS.md

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -7,7 +7,7 @@ This directory contains specialized skills for AI agents working in this reposit
 ### quest
 **Purpose:** Multi-agent orchestration for non-trivial features. Coordinates Planner, dual Plan Reviewers (Claude + Codex), Arbiter, Builder, Code Reviewer, and Fixer through structured handoffs with human approval gates.
 
-**Use when:** The user invokes `/quest` or describes a feature that needs planning, review, implementation, and code review as separate coordinated phases. Also use when resuming an existing quest by ID.
+**Use when:** The user invokes `/quest` or `$quest`, or describes a feature that needs planning, review, implementation, and code review as separate coordinated phases. Also use when resuming an existing quest by ID.
 
 **Location:** `.skills/quest/SKILL.md`
 

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -6,6 +6,7 @@ Multi-agent workflow for planning, reviewing, building, and fixing features thro
 
 ```
 /quest "Add a loading skeleton to the candidate list"
+$quest "Add a loading skeleton to the candidate list"
 /quest "Implement the transparency audit plan"
 /quest transparency-v2_2026-02-02__1831
 /quest transparency-v2_2026-02-02__1831 "now review the code"
@@ -24,7 +25,7 @@ If the user provides a quest ID (matches pattern `*_YYYY-MM-DD__HHMM`):
 1. Read `.quest/<id>/state.json` and resume from the recorded phase
 2. Delegate to `delegation/workflow.md`
 
-If the user says `/quest status`, handle as a utility command (see `delegation/workflow.md` Utility Commands).
+If the user says `/quest status` or `$quest status`, handle as a utility command (see `delegation/workflow.md` Utility Commands).
 
 ### Step 2: Classify Input (New Quest)
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The installer:
 Copy these folders to your repository root:
 - `.ai/` - Source of truth (permissions, roles, templates)
 - `.skills/` - Skill procedures (plan-maker, code-reviewer, etc.)
+- `.agents/` - Codex skill wrappers (thin wrappers -> `.skills/`)
 - `.claude/` - Claude Code integration (agents, hooks)
 - `.cursor/` - Cursor integration
 - `.codex/` - Codex integration
@@ -199,12 +200,19 @@ Edit `.ai/allowlist.json` to match your project:
 ### Use it
 
 ```bash
+# Claude Code
 claude
 /quest "Add a loading skeleton to the user list"
 # or
 /quest "use my specification <path>"
 # or if you have mcp/jira or similar installed, with skills etc to retrieve them
 /quest "lets work with <jira ticket>"
+```
+
+```bash
+# Codex (thin wrapper in .agents/skills/quest/SKILL.md)
+codex
+$quest "Add a loading skeleton to the user list"
 ```
 
 Quest scales from simple to complex — just describe what you want:
@@ -461,6 +469,8 @@ your-repo/
 │   ├── code-reviewer/SKILL.md    # Code review checklist
 │   ├── implementer/SKILL.md      # Implementation methodology
 │   └── git-commit-assistant/SKILL.md  # Commit message from staged diff + trailer
+├── .agents/                      # Codex skill wrappers
+│   └── skills/quest/SKILL.md     # Thin wrapper → .skills/quest/
 ├── .claude/                      # Claude Code integration
 │   ├── agents/                   # Thin wrappers → .ai/roles/
 │   ├── hooks/                    # Permission enforcement

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -1,6 +1,6 @@
 # Quest Setup Guide
 
-How to add the `/quest` multi-agent orchestration system to your repository.
+How to add the `/quest` and `$quest` multi-agent orchestration system to your repository.
 
 ## Prerequisites
 
@@ -98,6 +98,9 @@ Copy these folders to your repository root:
 .skills/quest/                    # Full skill procedure (AI-agnostic)
   SKILL.md
 
+.agents/skills/quest/             # Codex thin wrapper layer
+  SKILL.md                        # Thin wrapper → .skills/quest/
+
 .claude/                          # Claude Code integration layer
   skills/quest/SKILL.md           # Thin wrapper → .skills/quest/
   agents/                         # Thin wrappers → .ai/roles/
@@ -194,6 +197,7 @@ After setup, verify everything is in place:
 1. **Check files exist:**
    ```bash
    ls -la .ai/allowlist.json
+   ls -la .agents/skills/quest/SKILL.md
    ls -la .claude/skills/quest/SKILL.md
    ls -la .claude/agents/
    ls -la .claude/hooks/enforce-allowlist.sh
@@ -212,14 +216,16 @@ After setup, verify everything is in place:
 4. **Test the skill loads:**
    ```
    /quest status
+   $quest status
    ```
 
 ## Usage
 
-Once set up, use the `/quest` command in Claude Code:
+Once set up, use the Quest command from your client:
 
 ```
 /quest "Add a loading skeleton to the candidate list"
+$quest "Add a loading skeleton to the candidate list"
 ```
 
 See `.ai/quest.md` for full usage documentation.
@@ -311,6 +317,9 @@ your-repo/
 ├── .skills/
 │   └── quest/
 │       └── SKILL.md              # Full skill procedure (AI-agnostic)
+├── .agents/
+│   └── skills/quest/
+│       └── SKILL.md              # Thin wrapper → .skills/quest/ (Codex)
 ├── .claude/
 │   ├── agents/                   # Thin wrappers (reference only)
 │   ├── hooks/
@@ -329,4 +338,4 @@ your-repo/
         └── logs/                 # Raw agent outputs
 ```
 
-**Note:** Source of truth is always in AI-agnostic locations (`.ai/`, `.skills/`). The `.claude/` folder contains thin wrappers that delegate to the portable definitions.
+**Note:** Source of truth is always in AI-agnostic locations (`.ai/`, `.skills/`). Wrapper folders (`.claude/`, `.agents/`) delegate to the portable definitions.

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -8,6 +8,7 @@ Future work items not yet ready for a full quest. When an idea is ready, run `/q
 |--------|------|---------------|
 | | [user-feedback](user-feedback.md) | Real-world user feedback on Quest UX: cost transparency, smart pausing, status clarity, plan navigation. |
 | in-progress | [quest-architecture-evolution](quest-architecture-evolution.md) | 5-phase roadmap to close the gap between Quest's philosophy and implementation. Phase 2 done, 2b in progress. |
+| in-progress | [phase2b-context-leak-closure](phase2b-context-leak-closure.md) | Candid findings and concrete completion plan for Phase 2b context leak closure. |
 | in-progress | [quest-context-optimization](quest-context-optimization.md) | Close remaining context leaks: handoff.json pattern, background agents, /clear suggestion. |
 | | [quest-step-numbering-cleanup](quest-step-numbering-cleanup.md) | Fix step numbering overlap between SKILL.md and workflow.md after the delegation refactor. |
 | | [quest-council-mode](quest-council-mode.md) | `/quest council` — two competing plans, independent reviews, council arbiter comparison report, human picks winner + optional golden nuggets. |

--- a/ideas/phase2b-context-leak-closure.md
+++ b/ideas/phase2b-context-leak-closure.md
@@ -1,0 +1,175 @@
+# Idea: Phase 2b - Context Leak Closure Findings
+
+## Scope
+
+This document captures the latest Phase 2b findings after candid review and arbitration, then defines the minimal next step that gives real improvement without adding architecture complexity.
+
+Related docs:
+- `ideas/quest-architecture-evolution.md` (roadmap)
+- `ideas/quest-context-optimization.md` (original Phase 2b proposal)
+
+## Executive Verdict
+
+Phase 2b is the highest-value remaining architecture step.
+
+- Do not start a new orchestration layer yet.
+- Do not spend time on cosmetic restructuring first.
+- Complete Phase 2b with measurable guardrails and rehearsals.
+
+Reason: this is the only remaining step that directly improves the stated goals (laser-focused orchestration, low context pollution, KISS).
+
+## Current Status (Candid)
+
+### What already shipped (5/7)
+
+| Item | Status |
+|------|--------|
+| `handoff.json` contract (agents write, orchestrator reads) | Done |
+| Context retention rule (status/path/summary only) | Done |
+| No full review reads for routing decisions | Done |
+| Post-quest `/clear` suggestion | Done |
+| Context health logging + compliance report pattern | Done |
+
+### What is not done (2/7)
+
+| Item | Status | Why it matters |
+|------|--------|----------------|
+| Background invocation for all Claude Task agents | Not done | Without this, full response bodies can still enter orchestrator context depending on runtime behavior |
+| Background-safe Codex review path (or equivalent isolation) | Not done | Synchronous Codex response bodies can still add context pressure |
+
+## Core Findings
+
+1. The design pattern is mostly correct already.
+- The contract and routing rules are in place.
+- The gap is runtime isolation behavior, not missing architecture concepts.
+
+2. "Do nothing" is only acceptable if context pollution is now an accepted tradeoff.
+- If laser-focus and bounded context are non-negotiable, doing nothing is misaligned.
+
+3. A remote orchestrator shim is premature.
+- It may become useful later, but right now it adds glue and moving parts before the current contract is fully validated.
+
+4. The right next step is a narrow, measurable completion pass.
+- Keep the current architecture.
+- Tighten behavior and validation.
+- Defer optional enhancements.
+
+## Options Assessed (Pros/Cons)
+
+### Option 1: Do nothing
+
+Pros:
+- No engineering effort.
+- No migration risk.
+
+Cons:
+- Context leakage remains.
+- Thin-orchestrator claim stays partially unproven at runtime.
+
+Verdict:
+- Only choose if this problem is no longer important.
+
+### Option 2: Complete Phase 2b (recommended)
+
+Pros:
+- Directly addresses remaining context leak behavior.
+- Preserves current architecture (KISS).
+- Portable contract for both local and cloud-style orchestrators.
+
+Cons:
+- Requires prompt/contract tightening and validation harness work.
+- Background behavior may be platform-sensitive and needs explicit rehearsal.
+
+Verdict:
+- Best improvement-per-complexity ratio.
+
+### Option 3: Add remote orchestrator shim now
+
+Pros:
+- Stronger long-term separation possibility.
+
+Cons:
+- More components and operational overhead now.
+- Solves future concerns before finishing current runtime validation.
+
+Verdict:
+- Defer until after Phase 2b completion proves insufficient.
+
+## Compatibility Findings
+
+### Codex as orchestrator (local flow)
+
+- Fully compatible with the Phase 2b contract.
+- Polling `handoff.json` and appending `context_health.log` fits current file-based quest flow.
+
+### Cloud or service orchestrator
+
+- Also compatible if the same minimal handoff schema is preserved.
+- Requires a shared URI/storage contract and polling semantics.
+- No major redesign needed if contract discipline stays strict.
+
+## Concrete Next Step (Implementation)
+
+1. Enforce handoff polling guardrails in orchestrator flow.
+- Poll window: 30 seconds total.
+- Poll interval: 5 seconds.
+- On missing/malformed JSON: mark `unparsable`, attempt legacy `---HANDOFF---` fallback, then fail clearly.
+
+2. Enforce contract output from all participating agents.
+- Every role writes `handoff.json` with: `status`, `artifacts`, `next`, `summary`.
+- Every role still emits text `---HANDOFF---` for fallback compatibility.
+
+3. Add explicit context leakage assertion.
+- Add harness test(s) to fail when post-handoff context exceeds threshold.
+- Threshold: 9000 tokens max after each handoff event.
+
+4. Rehearse cloud-compatible contract locally.
+- Validate shared-path or metadata endpoint polling behavior.
+- Confirm same handoff schema works without local-only assumptions.
+
+5. Run deliberate failure rehearsal.
+- Omit/corrupt one handoff file.
+- Verify fallback and operator-visible failure path are deterministic.
+
+## Validation Requirements
+
+- Automated:
+  - Add a handoff context harness (for example `scripts/tests/test_handoff_context.py`).
+  - Must fail on missing handoff, missing fallback behavior, or token cap violations.
+
+- Manual:
+  - Failure/fallback drill (missing or malformed handoff).
+  - Cloud-contract rehearsal against shared path or mock metadata endpoint.
+
+- Exit criteria:
+  - Full run completes with handoff-only routing.
+  - Context-health entries are complete and coherent.
+  - Failure case is explicit and recoverable by design (fallback then hard fail).
+
+## Empirical Signals from Latest Review Run
+
+From the latest Phase 2b review cycle:
+- `context_health.log` recorded 12/12 `handoff_json=found` events across planner, reviewers, and arbiter iterations.
+- Parallel review dispatch records showed concurrent reviewer launches across all plan iterations.
+- Arbiter approved on iteration 3 after adding concrete runtime guardrails (timeout and token cap).
+
+Interpretation:
+- The contract discipline is working.
+- Remaining work is implementation hardening, not conceptual redesign.
+
+## Non-Blocking Follow-Ups (Defer)
+
+- Whether to rotate/delete historical handoff files per iteration.
+- Whether to auto-generate a richer compliance summary report from `context_health.log`.
+- Whether to provide helper tooling for older quests that predate `handoff.json`.
+
+These are useful, but none are blockers for Phase 2b completion.
+
+## Decision
+
+Proceed with Option 2 now.
+
+- Keep architecture simple.
+- Complete runtime isolation checks.
+- Validate with hard thresholds and rehearsals.
+- Reassess only after those measurements are in place.

--- a/ideas/phase4-role-relocation.md
+++ b/ideas/phase4-role-relocation.md
@@ -1,0 +1,306 @@
+# Idea: Phase 4 — Relocate Role Wiring to `.skills/quest/agents/`
+
+## Problem
+
+Four layers between intent and execution:
+```
+Quest SKILL.md → Task(planner) → .ai/roles/planner_agent.md → plan-maker/SKILL.md → writes plan
+```
+
+Roles that are 1:1 with skills add indirection. But the Quest-specific wiring in each role is **substantial** — not just 10 lines. Each role defines: handoff contracts (JSON + text), output paths, slot assignments (Claude vs Codex), phase routing (`NEXT` values), iteration rules, write scopes, and allowed commands. Inlining all of this into `workflow.md` or orchestrator prompts would bloat `workflow.md` from ~880 lines to ~1200+ and interleave wiring with orchestration logic.
+
+## Proposed Solution
+
+Move role files from `.ai/roles/` to `.skills/quest/agents/`, keeping them as separate files owned by the Quest skill. The wiring is Quest's concern, not a top-level project concern.
+
+Before:
+```
+.ai/roles/planner_agent.md          # Quest wiring, lives outside Quest skill
+.ai/roles/plan_review_agent.md
+.ai/roles/code_review_agent.md
+.ai/roles/builder_agent.md
+.ai/roles/fixer_agent.md
+.ai/roles/arbiter_agent.md          # Pure Quest logic, no matching skill
+.ai/roles/quest_agent.md            # Routing meta-layer, no matching skill
+```
+
+After:
+```
+.skills/quest/agents/planner.md        # Quest wiring: paths, handoff, iteration rules
+.skills/quest/agents/plan-reviewer.md  # Quest wiring: slots, paths, NEXT: arbiter
+.skills/quest/agents/code-reviewer.md  # Quest wiring: slots, paths, NEXT: fixer|null
+.skills/quest/agents/builder.md        # Quest wiring: paths, pr_description, NEXT: code_review
+.skills/quest/agents/fixer.md          # Quest wiring: paths, fix-only constraint, NEXT: code_review
+.skills/quest/agents/arbiter.md        # Pure Quest logic (no matching skill)
+.ai/roles/quest_agent.md              # Stays — routing meta-layer used by SKILL.md before workflow starts
+```
+
+### File mapping (6 relocations)
+
+| From | To |
+|------|-----|
+| `.ai/roles/planner_agent.md` | `.skills/quest/agents/planner.md` |
+| `.ai/roles/plan_review_agent.md` | `.skills/quest/agents/plan-reviewer.md` |
+| `.ai/roles/code_review_agent.md` | `.skills/quest/agents/code-reviewer.md` |
+| `.ai/roles/builder_agent.md` | `.skills/quest/agents/builder.md` |
+| `.ai/roles/fixer_agent.md` | `.skills/quest/agents/fixer.md` |
+| `.ai/roles/arbiter_agent.md` | `.skills/quest/agents/arbiter.md` |
+
+### What stays in `.ai/roles/` (1)
+
+`quest_agent.md` — routing logic consumed by `SKILL.md` before `workflow.md` runs. Legitimate top-level role.
+
+---
+
+## Is It OK to Have Agents Under a Skill?
+
+Nothing in the skill conventions prohibits it, but it stretches the model slightly. The conventions define skill resources as "scripts, references, assets" — agent persona definitions with contracts and routing rules are wiring, not knowledge.
+
+**However, the precedent is already set.** The quest skill's `delegation/` subdirectory already contains operational wiring files — `router.md`, `questioner.md`, `workflow.md` — none of which are "skills" in the conventional sense. They're Quest internals. The agent role files are the same category: Quest-specific wiring consumed exclusively by `workflow.md` prompts.
+
+**The ownership argument is the real justification.** These 6 role files are consumed only by Quest. No other skill, user workflow, or external tool references them. Putting them under `.skills/quest/agents/` makes ownership truthful — these belong to Quest, not to the project at large. Leaving them in `.ai/roles/` makes them look like a project-level concern when they're really Quest internals that happen to live outside their parent.
+
+---
+
+## Blast Radius Analysis
+
+The evolution doc originally described this as "move 6 files, update ~20 path references in workflow.md." The actual blast radius is significantly larger.
+
+### Runtime references (will break quests if wrong)
+
+| File | References | What breaks |
+|------|-----------|-------------|
+| `.skills/quest/delegation/workflow.md` | 6 path refs (lines 178, 219, 272, 456, 505, 805) | Subagent prompts: "Read your instructions: .ai/roles/X_agent.md" |
+| `.claude/agents/planner.md` | 1 ref | Claude Code subagent type definition |
+| `.claude/agents/plan-reviewer.md` | 1 ref | Claude Code subagent type definition |
+| `.claude/agents/code-reviewer.md` | 1 ref | Claude Code subagent type definition |
+| `.claude/agents/builder.md` | 1 ref | Claude Code subagent type definition |
+| `.claude/agents/fixer.md` | 1 ref | Claude Code subagent type definition |
+| `.claude/agents/arbiter.md` | 1 ref | Claude Code subagent type definition |
+
+### Validation scripts (will fail)
+
+| File | What it checks |
+|------|---------------|
+| `scripts/validate-manifest.sh` | Checks files listed in `.quest-manifest` exist |
+| `scripts/validate-handoff-contracts.sh` | Hardcoded glob: `.ai/roles/{planner,plan_review,arbiter,builder,code_review,fixer}_agent.md` |
+| `scripts/validate-quest-config.sh` | Checks `.ai/roles/` directory exists, checks role files exist, validates required sections |
+
+### Metadata (stale references, non-breaking but misleading)
+
+| File | References |
+|------|-----------|
+| `.quest-manifest` | 7 entries listing role file paths |
+| `.ai/quest.md` | Role-to-path mapping table (8 rows) |
+| `CONTRIBUTING.md` | Mentions required sections in `.ai/roles/*.md` |
+
+### Documentation (stale references, non-breaking)
+
+| File | References |
+|------|-----------|
+| `README.md` | Directory tree showing `.claude/agents/` → `.ai/roles/` |
+| `PROVENANCE.md` | Lists role files |
+| `docs/guides/quest_setup.md` | Multiple refs, explains roles as source of truth |
+| `docs/guides/quest_presentation.md` | Directory tree |
+| `ideas/quest-council-mode.md` | References arbiter role path (3 refs) |
+| `ideas/codex-quest-skill.md` | Mentions `.ai/roles/*.md` |
+
+### Historical (leave as-is, they describe past state)
+
+| File | References |
+|------|-----------|
+| `docs/quest-journal/handoff-contract-fix_2026-02-09.md` | 6 role file paths |
+| `docs/quest-journal/context-leak-closure_2026-02-15.md` | 6 role file paths |
+
+### Total: ~15+ files need updates (beyond the 6 being moved)
+
+This is not "6-file move + workflow.md path changes." It's a moderate refactor touching runtime, validation, metadata, and documentation.
+
+---
+
+## Pre-Move Validation Baseline
+
+These scripts must pass before AND after the move. Baseline captured 2026-02-17:
+
+### `scripts/validate-quest-config.sh`
+```
+=== Quest Configuration Validation ===
+
+[PASS] .quest/ is in .gitignore
+[PASS] .ai/allowlist.json is valid JSON
+[WARN] Schema validation skipped (ajv not installed)
+[PASS] code_review_agent.md has all required sections
+[PASS] plan_review_agent.md has all required sections
+[PASS] quest_agent.md has all required sections
+[PASS] arbiter_agent.md has all required sections
+[PASS] builder_agent.md has all required sections
+[PASS] planner_agent.md has all required sections
+[PASS] fixer_agent.md has all required sections
+
+All validations passed!
+```
+
+### `scripts/validate-handoff-contracts.sh`
+```
+=== Handoff Contract Validation ===
+
+1. Checking all role files have text format (not JSON)...
+   ✅ No JSON contracts found in role files
+
+2. Checking all role files have ---HANDOFF--- format...
+   ⚠️  Found 0/6 role files with ---HANDOFF--- format
+   (This is informational - role files define the contract, they don't need to contain literal examples)
+
+3. Checking for 'Context Is In Your Prompt' contradictions...
+   ✅ No 'Context Is In Your Prompt' found
+
+4. Checking workflow has Codex-only invocations...
+   ✅ No Task tool invocations found (Codex-only: 11)
+
+5. Checking ARTIFACTS field in minimal example...
+   ✅ Minimal example includes ARTIFACTS
+
+=== Validation Complete ===
+
+✅ All checks passed
+```
+
+### `scripts/validate-manifest.sh`
+```
+Checking Quest files are listed in .quest-manifest...
+[OK] All Quest files are listed in .quest-manifest
+
+Checking for stale manifest entries...
+[OK] No stale entries in manifest
+
+Manifest validation complete.
+```
+
+---
+
+## Validation Plan (if we proceed)
+
+### Step 1: Pre-move baseline (done — see above)
+
+Run all 3 validation scripts, capture passing output:
+```bash
+bash scripts/validate-quest-config.sh
+bash scripts/validate-handoff-contracts.sh
+bash scripts/validate-manifest.sh
+```
+All three pass as of 2026-02-17 (output captured in "Pre-Move Validation Baseline" section above).
+
+### Step 2: Move files + update all references
+
+**2a. Move the 6 role files:**
+```bash
+mkdir -p .skills/quest/agents
+git mv .ai/roles/planner_agent.md      .skills/quest/agents/planner.md
+git mv .ai/roles/plan_review_agent.md  .skills/quest/agents/plan-reviewer.md
+git mv .ai/roles/code_review_agent.md  .skills/quest/agents/code-reviewer.md
+git mv .ai/roles/builder_agent.md      .skills/quest/agents/builder.md
+git mv .ai/roles/fixer_agent.md        .skills/quest/agents/fixer.md
+git mv .ai/roles/arbiter_agent.md      .skills/quest/agents/arbiter.md
+```
+
+**2b. Update runtime references (breaks quests if missed):**
+
+| File | Change |
+|------|--------|
+| `.skills/quest/delegation/workflow.md` | 6 path refs: `.ai/roles/X_agent.md` → `.skills/quest/agents/X.md` |
+| `.claude/agents/planner.md` | Point to `.skills/quest/agents/planner.md` |
+| `.claude/agents/plan-reviewer.md` | Point to `.skills/quest/agents/plan-reviewer.md` |
+| `.claude/agents/code-reviewer.md` | Point to `.skills/quest/agents/code-reviewer.md` |
+| `.claude/agents/builder.md` | Point to `.skills/quest/agents/builder.md` |
+| `.claude/agents/fixer.md` | Point to `.skills/quest/agents/fixer.md` |
+| `.claude/agents/arbiter.md` | Point to `.skills/quest/agents/arbiter.md` |
+
+**2c. Update validation scripts (will fail if not updated):**
+
+| File | Change |
+|------|--------|
+| `scripts/validate-quest-config.sh` | Update `.ai/roles/` directory check → `.skills/quest/agents/` (keep `quest_agent.md` check in `.ai/roles/`) |
+| `scripts/validate-handoff-contracts.sh` | Update hardcoded glob from `.ai/roles/{planner,...}_agent.md` → `.skills/quest/agents/{planner,...}.md` |
+| `scripts/validate-manifest.sh` | No code change needed — it reads `.quest-manifest` entries |
+
+**2d. Update metadata (stale if not updated):**
+
+| File | Change |
+|------|--------|
+| `.quest-manifest` | Update 6 role file paths, add new paths |
+| `.ai/quest.md` | Update role-to-path mapping table (8 rows) |
+| `CONTRIBUTING.md` | Update `.ai/roles/*.md` reference |
+
+**2e. Update documentation (stale if not updated):**
+
+| File | Change |
+|------|--------|
+| `README.md` | Update directory tree |
+| `PROVENANCE.md` | Update role file references |
+| `docs/guides/quest_setup.md` | Update multiple refs, "source of truth" explanation |
+| `docs/guides/quest_presentation.md` | Update directory tree |
+
+**2f. Leave as-is (historical, describe past state):**
+- `docs/quest-journal/handoff-contract-fix_2026-02-09.md`
+- `docs/quest-journal/context-leak-closure_2026-02-15.md`
+- `ideas/quest-council-mode.md` (references arbiter — update if/when council mode is implemented)
+
+### Step 3: Post-move validation
+
+Run the same 3 scripts — all must pass:
+```bash
+bash scripts/validate-quest-config.sh
+bash scripts/validate-handoff-contracts.sh
+bash scripts/validate-manifest.sh
+```
+
+Additionally, verify the moved files are readable:
+```bash
+# Quick sanity: all 6 new files exist and have content
+for f in planner plan-reviewer code-reviewer builder fixer arbiter; do
+  test -s ".skills/quest/agents/$f.md" && echo "OK: $f" || echo "MISSING: $f"
+done
+
+# quest_agent.md still in .ai/roles/
+test -s ".ai/roles/quest_agent.md" && echo "OK: quest_agent" || echo "MISSING: quest_agent"
+```
+
+### Step 4: Smoke test — run a real quest
+
+This is the only true validation. The paths are consumed at runtime by LLM subagents reading files. A passing validation script proves the scripts were updated, not that the agents can find their instructions.
+
+Run a small, low-risk quest end-to-end:
+```
+/quest "Add a comment to README.md explaining the .skills/quest/agents/ directory"
+```
+
+**What to watch for:**
+- Planner agent finds its instructions (no "file not found" or confused behavior)
+- Plan reviewers (both Claude and Codex slots) find their instructions
+- Arbiter finds its instructions
+- Builder finds its instructions
+- Code reviewers find their instructions
+- If fixes needed: fixer finds its instructions
+
+**Pass criteria:** Quest completes through all phases without any agent failing to read its role file. The context_health.log should show normal handoff.json compliance — no degradation from baseline.
+
+**Fail criteria:** Any agent produces output that suggests it didn't read its role file (missing handoff format, wrong output paths, no handoff.json written). If this happens: `git checkout .ai/roles/` to restore originals, investigate which reference was missed.
+
+---
+
+## Candid Assessment
+
+**Pros:**
+- Ownership becomes truthful — Quest internals live under the Quest skill
+- `.ai/roles/` shrinks from 7 files to 1, reducing project-root noise
+- Makes Quest more self-contained and portable
+- Codex-compatible — agents read paths from prompts, path just changes
+
+**Cons:**
+- **Zero functional improvement.** Pipeline behaves identically before and after.
+- Blast radius is ~15+ files, not the ~2 originally estimated
+- Risk of breaking existing quests during transition
+- Validation scripts need updating (they hardcode `.ai/roles/` paths)
+- Churn for churn's sake if the current structure isn't causing problems
+
+**Verdict:** Safe but larger than it looks. Do it if the misplaced ownership bothers you enough to touch 15+ files for zero functional gain. Skip it if not.

--- a/scripts/validate-manifest.sh
+++ b/scripts/validate-manifest.sh
@@ -43,6 +43,7 @@ EXPECTED_PATTERNS=(
   ".skills/*.md"
   ".skills/*/*.md"
   ".skills/*/*/*.md"
+  ".agents/*/*/*.md"
   ".claude/*.md"
   ".claude/agents/*.md"
   ".claude/hooks/*.sh"


### PR DESCRIPTION
## Summary
- add Codex quest thin wrapper at .agents/skills/quest/SKILL.md delegating to .skills/quest/SKILL.md
- register wrapper in .quest-manifest and manifest validation patterns
- update docs to include  usage and .agents/ copy/setup steps

## Validation
- ./scripts/validate-manifest.sh
