### PR TITLE
Assess and defer Phase 5 infrastructure hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ The philosophy above is our north star. We are not there yet. Here is where we s
 - Human gates at phase boundaries
 - Resumable state via `state.json`
 - A thin orchestrator that passes paths, not content (Context Retention Rule)
+- Structured handoff contract (`handoff.json`) between orchestrator and subagents, with text fallback for backward compatibility
 - State validation script that enforces phase transitions, artifact prerequisites, and semantic handoff checks (`scripts/validate-quest-state.sh`)
-- **Full Codex orchestration (BETA):** Quest can now run end-to-end with GPT-5.3/Codex as the orchestrator via `$quest`. This is functional but not yet as robust as Claude-orchestrated runs — expect occasional handoff compliance gaps and rougher edges. The most reliable configuration remains Claude as orchestrator with Codex as a subagent reviewer.
+- Context health logging and compliance reporting — every handoff is logged, compliance is reported at quest completion
+- Consolidated skill ownership — all quest agent wiring lives under `.skills/quest/`
+- Codex orchestration (BETA): Quest runs end-to-end via `$quest` with GPT-5.3/Codex as orchestrator. Claude-orchestrated `/quest` remains the more robust path.
 
-**What Quest does not yet deliver:**
-- A structured exploration/research capability (no `/explore` skill yet — Claude Code's built-in Explore agent covers this informally)
+**What we considered and deliberately left alone:**
+- **Infrastructure hooks (Phase 5):** Claude Code hooks can block tool calls and intercept subagent lifecycle. We assessed using them to make state validation mandatory. The orchestrator already achieves 12/12 handoff compliance in observed runs, and a blanket hook would need fragile prompt-parsing to distinguish quest subagents from other `Task` calls. Deferred until an observed failure justifies the complexity.
+- **`/explore` skill (Phase 1):** A formal research/discovery skill. Claude Code's built-in Explore agent covers this informally. Would formalize it, but not blocking any real workflow today.
 
-**What we investigated and deliberately deferred:**
-- **Infrastructure hooks (Phase 5):** Claude Code's hooks can now block tool calls, intercept subagent lifecycle, and enforce quality gates. We assessed using `PreToolUse` hooks to make state validation mandatory (not just prompt-requested). The conclusion: the orchestrator already follows its validation gates reliably (12/12 handoff compliance in observed runs), and a blanket hook would need fragile prompt-parsing logic to distinguish quest subagents from other `Task` calls. Deferred until an observed failure justifies the complexity. The platform capability is documented in the evolution roadmap for when it's needed.
-
-**The philosophy is right. The architecture is pragmatically correct. The remaining gaps are either nice-to-have or insurance against unobserved failures.**
+**The system works. The remaining ideas are either nice-to-have or insurance against unobserved failures.**
 
 See [ideas/quest-architecture-evolution.md](ideas/quest-architecture-evolution.md) for the full evolution roadmap and decision rationale.
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ The philosophy above is our north star. We are not there yet. Here is where we s
 - **Full Codex orchestration (BETA):** Quest can now run end-to-end with GPT-5.3/Codex as the orchestrator via `$quest`. This is functional but not yet as robust as Claude-orchestrated runs — expect occasional handoff compliance gaps and rougher edges. The most reliable configuration remains Claude as orchestrator with Codex as a subagent reviewer.
 
 **What Quest does not yet deliver:**
-- Full system-enforced correctness (validation script exists but is called by the orchestrator, not yet by hooks)
-- Clean skill/role separation (some roles duplicate what skills already say)
-- A structured exploration/research capability (no `/explore` skill yet)
+- A structured exploration/research capability (no `/explore` skill yet — Claude Code's built-in Explore agent covers this informally)
 
-**The philosophy is right. The architecture is pragmatically correct. The gap between them is the roadmap.**
+**What we investigated and deliberately deferred:**
+- **Infrastructure hooks (Phase 5):** Claude Code's hooks can now block tool calls, intercept subagent lifecycle, and enforce quality gates. We assessed using `PreToolUse` hooks to make state validation mandatory (not just prompt-requested). The conclusion: the orchestrator already follows its validation gates reliably (12/12 handoff compliance in observed runs), and a blanket hook would need fragile prompt-parsing logic to distinguish quest subagents from other `Task` calls. Deferred until an observed failure justifies the complexity. The platform capability is documented in the evolution roadmap for when it's needed.
 
-See [ideas/quest-architecture-evolution.md](ideas/quest-architecture-evolution.md) for the phased plan to close these gaps.
+**The philosophy is right. The architecture is pragmatically correct. The remaining gaps are either nice-to-have or insurance against unobserved failures.**
+
+See [ideas/quest-architecture-evolution.md](ideas/quest-architecture-evolution.md) for the full evolution roadmap and decision rationale.
 
 # Quest: A Multi-Agent Orchestration Blueprint
 

--- a/ideas/quest-architecture-evolution.md
+++ b/ideas/quest-architecture-evolution.md
@@ -86,7 +86,7 @@ Orchestrator reads ONLY the SUMMARY line from handoff → decides next step
 
 ---
 
-### Phase 3: State validation script
+### Phase 3: State validation script — DONE
 
 **Problem:** The orchestrator is told to check state before proceeding. If it doesn't, nothing prevents a phase from starting without its prerequisites.
 
@@ -115,7 +115,7 @@ Orchestrator reads ONLY the SUMMARY line from handoff → decides next step
 
 ---
 
-### Phase 4: Relocate role wiring to `.skills/quest/agents/`
+### Phase 4: Relocate role wiring to `.skills/quest/agents/` — DONE
 
 **Status:** Done via quest `phase4-role-wiring_2026-02-17__2218`. See `ideas/phase4-role-relocation.md` for full analysis.
 

--- a/ideas/quest-architecture-evolution.md
+++ b/ideas/quest-architecture-evolution.md
@@ -72,18 +72,17 @@ Orchestrator reads ONLY the SUMMARY line from handoff → decides next step
 
 ---
 
-### Phase 2b: Close remaining context leaks — IN PROGRESS
+### Phase 2b: Close remaining context leaks — 5/7 SHIPPED, remainder deferred
 
-**Status:** Mostly implemented. 5 of 7 items shipped incrementally alongside Phase 2.
+**Status:** Core contract delivered. Remaining 2 items are runtime isolation concerns deferred alongside Phase 5.
 
 **Full findings moved:** `ideas/phase2b-context-leak-closure.md`
 
 **Original proposal:** `ideas/quest-context-optimization.md`
 
-**Current summary:**
-- The core `handoff.json` contract and thin-context routing discipline are in place.
-- Remaining gap is runtime behavior: background invocation path for Claude/Codex flows and proving that transcript bodies no longer pollute orchestrator context.
-- Latest recommendation is to complete Phase 2b with a small, measurable rollout (explicit poll timeout, token cap assertion, fallback rehearsal, and cloud-contract rehearsal) rather than starting a new architecture layer.
+**What shipped (5/7):** `handoff.json` contract, context retention rule, no full review reads for routing, post-quest `/clear` suggestion, context health logging.
+
+**What's deferred (2/7):** Background invocation for all Claude Task agents, and background-safe Codex review path. These are runtime isolation behaviors that depend on platform-level guarantees. Same reasoning as Phase 5: the orchestrator already achieves full handoff compliance in observed runs, and the remaining items are insurance against unobserved context leakage. Revisit if compliance reporting shows degradation.
 
 ---
 
@@ -199,7 +198,7 @@ Each phase is a standalone quest. The phases are ordered by impact and independe
 
 1. **Phase 1 (explore):** No dependencies. Can ship independently. Lowest urgency — Claude Code's built-in Explore agent covers the capability informally; this formalizes it.
 2. **Phase 2 (thin orchestrator):** Done.
-3. **Phase 2b (context leaks):** In progress. See `ideas/phase2b-context-leak-closure.md` for findings and the concrete next-step rollout.
+3. **Phase 2b (context leaks):** 5/7 shipped. Remaining 2 items deferred — runtime isolation concerns, same reasoning as Phase 5.
 4. **Phase 3 (state validation):** Done.
 5. **Phase 4 (role relocation):** No dependencies. Safe, low-risk housekeeping. Zero functional change.
 6. **Phase 5 (infrastructure hooks):** Platform is ready but problem is theoretical. Deferred until observed failure justifies the complexity. See Phase 5 section for full rationale.
@@ -212,7 +211,7 @@ Each phase is a standalone quest. The phases are ordered by impact and independe
 |-------|--------|
 | Phase 1: `/explore` skill | Not started |
 | Phase 2: Thin orchestrator | **Done** (`thin-orchestrator_2026-02-09__1845`) |
-| Phase 2b: Close context leaks | **In progress** — 5/7 items shipped. Findings + next step: `ideas/phase2b-context-leak-closure.md` (proposal history: `ideas/quest-context-optimization.md`) |
+| Phase 2b: Close context leaks | **5/7 shipped**, remainder deferred — runtime isolation concerns, revisit if compliance degrades. Details: `ideas/phase2b-context-leak-closure.md` |
 | Phase 3: State validation | **Done** (`state-validation-script_2026-02-15__1508`) |
 | Phase 4: Role relocation | **Done** (`phase4-role-wiring_2026-02-17__2218`) — ownership cleanup, zero functional change |
 | Phase 5: Infrastructure hooks | **Deferred** — platform ready, problem theoretical. Revisit when `context_health.log` shows compliance drops |


### PR DESCRIPTION
## Summary
- Assessed Claude Code hooks platform against Quest's actual failure modes and documented findings in the evolution roadmap.
- Concluded Phase 5 is insurance against unobserved failures: orchestrator already achieves 12/12 handoff compliance, and a PreToolUse hook would need fragile prompt-parsing. Deferred until observed failure justifies the complexity.
- Updated README to reflect Phase 4 completion and current architecture status.

## Changes
- **Documentation (evolution roadmap)**:
  - Rewrote Phase 5 from vague "future" placeholder to detailed platform capability assessment with 8 hook-to-Quest-use-case mappings
  - Added candid deferral rationale: 5 reasons why hooks aren't worth the complexity today
  - Added "Why not just add the PreToolUse hook" section explaining the prompt-parsing and phase-gate fragility
  - Updated status table and implementation strategy to reflect deferral
- **Documentation (README)**:
  - Removed stale "clean skill/role separation" gap (Phase 4 shipped this)
  - Replaced "not yet by hooks" framing with "deliberately deferred" section
  - Updated closing assessment to reflect current state

## Test Plan
- [x] Verify README "Where We Are" section accurately reflects current architecture
- [x] Verify evolution roadmap Phase 5 section reads as a complete decision record
- [x] Confirm no stale references to Phase 5 as "backlog" or "pending"

---
Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with KjellKod