### PR TITLE
Improve pr-assistant skill with richer description guidance

### DIFF
--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -37,11 +37,16 @@ Use this format:
 
 ```
 ## Summary
-- 1-3 bullet points explaining what this PR does and why.
+<Single sentence capturing the full intent — what this PR does and why.>
+- Supporting bullet with additional context if needed.
+- Supporting bullet with additional context if needed.
+
+> [!WARNING or !IMPORTANT or !NOTE — only if applicable]
+> Alert content here. Most PRs should have NO callouts.
 
 ## Changes
 - **<Category>**:
-  - Description of change
+  - Description of change referencing `specific_file.js` or `functionName()` where helpful
   - Description of change
 - **<Category>**:
   - Description of change
@@ -50,13 +55,36 @@ Use this format:
 - [ ] Checklist of how to verify the changes.
 ```
 
+### Summary section
+
+- Start with a single sentence that captures the full "what + why" of the PR. This is the line a reviewer reads to decide how deeply to engage.
+- Follow with 1-2 supporting bullets if needed for additional context.
+
+### Callouts (optional — use sparingly)
+
+Use GitHub callout syntax **only when something needs to jump out** before a reviewer digs into the details. Most PRs should have zero callouts.
+
+| Callout | Use when... |
+|---------|-------------|
+| `> [!WARNING]` | Breaking change, data migration, or irreversible action |
+| `> [!IMPORTANT]` | Reviewer must do something specific (e.g. "needs env var set before deploy") |
+| `> [!NOTE]` | Non-obvious context that prevents confusion (e.g. "intentionally duplicates X because...") |
+
+Rules:
+- Place callouts between `## Summary` and `## Changes`.
+- If every PR has a callout, reviewers start ignoring them. Reserve them for exceptions.
+- Do not use callouts as decoration or to repeat what the summary already says.
+
 ### Changes section formatting
 
 Group changes by domain or concern, not by git operation (add/modify/remove).
 Choose category names that reflect what area of the system is affected.
 
+Reference specific file names, function names, config keys, and constants inline with backticks where they help a reviewer understand or locate the change.
+
 Common categories (use what fits, invent others as needed):
 - **Behavior** — user-facing or system behavior changes
+- **API / Functions** — new, changed, or removed function signatures
 - **Skills** — skill definitions and skill catalog
 - **Config** — configuration, schemas, allowlist
 - **Manifest** — `.quest-manifest` updates
@@ -70,6 +98,10 @@ Rules:
 - Keep descriptions concise — one line per change, focus on what and why.
 - Omit categories with no changes. Only include what is relevant.
 - If the PR is very small (1-2 files), a flat bullet list is fine — do not force categories.
+
+### Bot-generated content
+
+If a bot (e.g. Ellipsis) appends an auto-generated summary to the PR, leave it in place. Do not duplicate or conflict with its content in the human-written sections.
 
 ### Draft mode (required)
 

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -52,7 +52,9 @@ Use this format:
   - Description of change
 
 ## Test Plan
-- [ ] Checklist of how to verify the changes.
+- [ ] Concrete verification step describing what to do and what to expect
+- [ ] Another verification step
+Watch for: <known risk or edge case, if any>
 ```
 
 ### Summary section
@@ -98,6 +100,17 @@ Rules:
 - Keep descriptions concise — one line per change, focus on what and why.
 - Omit categories with no changes. Only include what is relevant.
 - If the PR is very small (1-2 files), a flat bullet list is fine — do not force categories.
+
+### Test Plan section
+
+Each checkbox should be a concrete verification step — what to do and what result to expect. A reviewer reading the list should be able to pull the branch and verify without guessing.
+
+Rules:
+- Use checkboxes (`- [ ]`) for every verification step.
+- Describe the action and the expected outcome in one line (e.g. "Run X, confirm Y").
+- Only include steps that a human needs to perform. Skip anything CI already covers (linting, syntax checks, type checks).
+- If there is a known risk or edge case worth watching, add a `Watch for:` line at the end — no checkbox, just a heads-up.
+- Keep it short. 2-5 steps is typical. If you need more, the PR may be too large.
 
 ### Bot-generated content
 


### PR DESCRIPTION
## Summary
Enhance the pr-assistant skill template and rules to produce more informative, reviewer-friendly PR descriptions.

## Changes
- Reworked Summary section template from plain bullets to a lead sentence + supporting bullets format
- Added callout guidance with a table of when to use `WARNING`, `IMPORTANT`, and `NOTE` callouts, with rules to prevent overuse
- Added inline code reference guidance encouraging backtick references to specific files, functions, and config keys in the Changes section
- Added `API / Functions` to the common categories list
- Added bot-generated content rule to preserve auto-generated summaries from tools like Ellipsis

## Test Plan
- [x] Review the updated SKILL.md template for clarity and completeness
- [x] Create a PR using the updated skill and verify the output follows the new format

---
Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with KjellKod