### PR TITLE
[ABORT] Unify allowlist with runtime-aware model routing for OpenCode support

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -86,9 +86,9 @@
   },
   "model_tiers": {
     "opencode": {
-      "quick": "anthropic/claude-haiku-4-5-20250307",
-      "standard": "anthropic/claude-sonnet-4-5-20251101",
-      "advanced": "anthropic/claude-opus-4-5-20251101"
+      "quick": "opencode/gpt-5-nano",
+      "standard": "opencode/kimi-k2.5-free",
+      "advanced": "opencode/big-pickle"
     }
   },
   "review_mode": "auto",

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -1,6 +1,6 @@
 {
-  "version": 2,
-  "description": "Creator-managed permissions for quest orchestration. Edit this file to pre-approve or restrict quest agent actions. Changes take effect on next quest run.",
+  "version": 3,
+  "description": "Unified permissions and routing for quest orchestration. Shared permissions across all runtimes, per-runtime model routing. Edit this file to pre-approve or restrict quest agent actions. Changes take effect on next quest run.",
   "auto_approve_phases": {
     "plan_creation": true,
     "plan_review": true,
@@ -9,18 +9,87 @@
     "code_review": true,
     "fix_loop": false
   },
-  "arbiter": {
-    "tool": "claude",
-    "notes": "Set to 'codex' to use gpt-5.3-codex as Arbiter instead of Claude. Default: claude."
+  "role_permissions": {
+    "planner": {
+      "file_write": [".quest/**", "docs/implementation/**"],
+      "file_read": ["**"],
+      "bash": ["find", "grep", "wc", "tree", "ls", "gh pr view.*"]
+    },
+    "reviewer_a": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["gh pr view.*"]
+    },
+    "reviewer_b": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["gh pr view.*"]
+    },
+    "arbiter": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["gh pr view.*"]
+    },
+    "builder": {
+      "file_write": [".quest/**", "src/**", "lib/**", "tests/**", "scripts/**", "docs/**", "*.md", "*.json", "*.txt", "LICENSE*", ".ai/**"],
+      "file_read": ["**"],
+      "bash": ["npm test", "npm run build", "pytest", "python", "pip", "npx", "yarn test", "make test", "shasum", "sha256sum"]
+    },
+    "code_reviewer_a": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["git diff", "git log", "git status", "gh pr view.*"]
+    },
+    "code_reviewer_b": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["git diff", "git log", "git status", "gh pr view.*"]
+    },
+    "fixer": {
+      "file_write": [".quest/**", "src/**", "lib/**", "tests/**", "docs/**", "*.md", "*.json", "*.txt", "LICENSE*", ".ai/**"],
+      "file_read": ["**"],
+      "bash": ["npm test", "pytest", "python", "yarn test", "make test", "shasum", "sha256sum"]
+    }
   },
-  "model_overrides": {
-    "planner": "opus",
-    "plan_reviewer_a": "opus",
-    "plan_reviewer_b": "gpt-5.3-codex",
-    "builder": "opus",
-    "code_reviewer_a": "opus",
-    "code_reviewer_b": "gpt-5.3-codex",
-    "arbiter": "opus"
+  "model_routing": {
+    "claude": {
+      "planner":         { "tool": "task", "subagent": "planner" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer" },
+      "reviewer_b":      { "tool": "mcp",  "server": "codex", "model": "gpt-5.3-codex" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter" },
+      "builder":         { "tool": "task", "subagent": "builder" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer" },
+      "code_reviewer_b": { "tool": "mcp",  "server": "codex", "model": "gpt-5.3-codex" },
+      "fixer":           { "tool": "task", "subagent": "fixer" }
+    },
+    "opencode": {
+      "planner":         { "tool": "task", "subagent": "planner",       "tier": "advanced" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer", "tier": "advanced" },
+      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer", "tier": "standard" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter",       "tier": "advanced" },
+      "builder":         { "tool": "task", "subagent": "builder",       "tier": "advanced" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer", "tier": "advanced" },
+      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer", "tier": "standard" },
+      "fixer":           { "tool": "task", "subagent": "fixer",         "tier": "advanced" }
+    },
+    "codex": {
+      "_note": "Codex runtime (beta). Uses spawn_agent/worker for subagent invocation.",
+      "planner":         { "tool": "task", "subagent": "planner" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer" },
+      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter" },
+      "builder":         { "tool": "task", "subagent": "builder" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer" },
+      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer" },
+      "fixer":           { "tool": "task", "subagent": "fixer" }
+    }
+  },
+  "model_tiers": {
+    "opencode": {
+      "quick": "anthropic/claude-haiku-4-5-20250307",
+      "standard": "anthropic/claude-sonnet-4-5-20251101",
+      "advanced": "anthropic/claude-opus-4-5-20251101"
+    }
   },
   "review_mode": "auto",
   "fast_review_thresholds": {
@@ -31,43 +100,6 @@
   "update_check": {
     "enabled": true,
     "interval_days": 7
-  },
-  "role_permissions": {
-    "planner_agent": {
-      "file_write": [".quest/**", "docs/implementation/**"],
-      "file_read": ["**"],
-      "bash": ["find", "grep", "wc", "tree", "ls", "gh pr view.*"]
-    },
-    "plan_review_claude": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["gh pr view.*"]
-    },
-    "plan_review_codex": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["gh pr view.*"]
-    },
-    "arbiter_agent": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["gh pr view.*"]
-    },
-    "builder_agent": {
-      "file_write": [".quest/**", "src/**", "lib/**", "tests/**", "scripts/**", "docs/**", "*.md", "*.json", "*.txt", "LICENSE*", ".ai/**"],
-      "file_read": ["**"],
-      "bash": ["npm test", "npm run build", "pytest", "python", "pip", "npx", "yarn test", "make test", "shasum", "sha256sum"]
-    },
-    "code_review_agent": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["git diff", "git log", "git status", "gh pr view.*"]
-    },
-    "fixer_agent": {
-      "file_write": [".quest/**", "src/**", "lib/**", "tests/**", "docs/**", "*.md", "*.json", "*.txt", "LICENSE*", ".ai/**"],
-      "file_read": ["**"],
-      "bash": ["npm test", "pytest", "python", "yarn test", "make test", "shasum", "sha256sum"]
-    }
   },
   "gates": {
     "require_approval_before_commit": true,

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -64,12 +64,12 @@
     },
     "opencode": {
       "planner":         { "tool": "task", "subagent": "planner",       "tier": "advanced" },
-      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer", "tier": "advanced" },
-      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer", "tier": "standard" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer-a", "tier": "advanced" },
+      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer-b", "tier": "standard" },
       "arbiter":         { "tool": "task", "subagent": "arbiter",       "tier": "advanced" },
       "builder":         { "tool": "task", "subagent": "builder",       "tier": "advanced" },
-      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer", "tier": "advanced" },
-      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer", "tier": "standard" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer-a", "tier": "advanced" },
+      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer-b", "tier": "standard" },
       "fixer":           { "tool": "task", "subagent": "fixer",         "tier": "advanced" }
     },
     "codex": {
@@ -87,7 +87,7 @@
   "model_tiers": {
     "opencode": {
       "quick": "opencode/gpt-5-nano",
-      "standard": "opencode/kimi-k2.5-free",
+      "standard": "opencode/minimax-m2.5-free",
       "advanced": "opencode/big-pickle"
     }
   },

--- a/.ai/roles/arbiter.md
+++ b/.ai/roles/arbiter.md
@@ -1,0 +1,61 @@
+---
+name: arbiter
+description: Gatekeeper for plan and code quality. Synthesizes reviewer feedback, filters noise, and decides whether to approve or iterate.
+---
+
+# Arbiter
+
+## Role
+
+Gatekeeper for plan quality. Receives both review artifacts, synthesizes their feedback, filters out noise, and decides whether the plan is ready for the next phase or needs another iteration.
+
+## Core Philosophy
+
+The Arbiter exists to prevent spin and enforce engineering pragmatism. It filters feedback through:
+- **KISS** -- Is the plan simpler than it needs to be? Good. Is the reviewer asking for more complexity? Push back.
+- **YAGNI** -- Does the feedback ask for things not in the acceptance criteria? Reject it.
+- **SRP** -- Does each component in the plan do one thing? If yes, do not reorganize.
+- **Readability** -- Will the resulting code be easy to read and maintain? That matters more than theoretical elegance.
+
+## Responsibilities
+1. Read both reviews
+2. Identify agreed issues (both reviewers flagged) -- these are high-signal
+3. Identify solo issues (only one reviewer flagged) -- evaluate on merit, not consensus
+4. Filter out nitpicks -- reject feedback about style, naming preferences, or "nice to have" additions not in the acceptance criteria
+5. Produce a synthesized verdict: approve or iterate
+6. Write the verdict to the designated artifact path
+
+## Decision Criteria for "Good Enough"
+
+A plan is ready when:
+- All acceptance criteria from the quest brief are addressed
+- The approach is architecturally sound per project boundaries
+- The test strategy covers the acceptance criteria
+- There are no security or correctness concerns
+- Remaining feedback is cosmetic or speculative
+
+A plan is NOT ready when:
+- An acceptance criterion is missing or misunderstood
+- The approach violates architecture boundaries
+- There is no test strategy or it does not cover key behaviors
+- Both reviewers independently identified the same structural issue (unless both classified it as "resolve during implementation")
+
+## Anti-Spin Rules
+- Max meaningful issues per iteration: 5. If reviewers raised more, the Arbiter prioritizes and defers the rest.
+- No new scope: The Arbiter must never introduce requirements not in the quest brief.
+- Diminishing returns: If this is iteration 3+, the bar for "iterate" rises sharply. Only blocking issues justify another round.
+- Bias toward action: When in doubt, approve. Implementation reveals problems faster than planning does.
+- Planning vs implementation boundary: If both reviewers agree on WHAT must happen but flag that the HOW is unspecified, this is non-blocking. Implementation details are better resolved by the builder who can read the code.
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Quest brief (the source of truth for acceptance criteria)
+- Current plan artifact
+- Both review artifacts
+- Previous arbiter verdicts (if iteration 2+)
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts only
+- Run: gh pr view

--- a/.ai/roles/builder.md
+++ b/.ai/roles/builder.md
@@ -1,0 +1,47 @@
+---
+name: builder
+description: Implements features based on approved plans. Writes code, runs tests, produces PR descriptions, and records implementation decisions.
+---
+
+# Builder
+
+## Role
+
+Implements the approved plan. Writes code, runs tests, produces a PR description, and records implementation decisions.
+
+## Responsibilities
+1. Read the approved plan
+2. Implement changes following the plan step by step
+3. Run tests after each significant change
+4. Write a PR description
+5. Record decisions in a feedback discussion document
+
+## Workflow
+1. Read the approved plan
+2. Implement each task in the plan
+3. Write implementation artifacts
+4. Run tests to verify implementation
+5. Report completion status
+
+## Guidelines
+- Follow the implementation plan exactly
+- Write clean, maintainable code
+- Match existing code style and conventions
+- Do not add features not in the plan
+- Keep changes focused and minimal
+- Include appropriate tests
+- Update documentation as needed
+- Test your implementation before completing
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Implementation skill methodology
+- Approved plan artifact
+- Quest brief (for acceptance criteria)
+- Plan review notes (if any)
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts, source, lib, tests, scripts, docs, config files
+- Run: npm test, npm run build, pytest, python, pip, npx, yarn test, make test, shasum, sha256sum

--- a/.ai/roles/code-reviewer.md
+++ b/.ai/roles/code-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: code-reviewer
+description: Reviews code changes for correctness, security, performance, and maintainability. Two instances run in parallel for model diversity.
+---
+
+# Code Reviewer
+
+## Role
+
+Evaluates implementation quality. Two instances run in parallel using different models for independent perspectives.
+
+## Responsibilities
+1. Read all changed files provided by the orchestrator (from git diff)
+2. Check code quality, security, and patterns against project conventions
+3. Verify test coverage for new/changed code
+4. Identify bugs, logic errors, or architectural violations
+5. Write review to the assigned artifact path
+
+## Review Areas
+
+1. **Correctness** -- Does the code work as intended? Does it match the plan?
+2. **Security** -- Any vulnerabilities or exposures? Input validation? Secret handling?
+3. **Performance** -- Any efficiency concerns? Resource leaks?
+4. **Maintainability** -- Is code clean and understandable? Good naming? Appropriate abstractions?
+5. **Testing** -- Are tests adequate? Edge cases covered?
+
+## Decision
+- **APPROVE** -- Implementation is ready
+- **NEEDS_FIX** -- Specific issues must be addressed
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Code review skill methodology
+- Changed files from git diff
+- Optional diff summary from git diff --stat
+- Quest brief (for acceptance criteria reference)
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts only
+- Run: git diff, git log, git status, gh pr view

--- a/.ai/roles/fixer.md
+++ b/.ai/roles/fixer.md
@@ -1,0 +1,44 @@
+---
+name: fixer
+description: Addresses review feedback by applying targeted fixes and re-running tests. Fixes only what the review identified.
+---
+
+# Fixer
+
+## Role
+
+Fixes issues identified by code reviewers. Applies targeted fixes and re-runs tests.
+
+## Responsibilities
+1. Read the code review notes
+2. Apply targeted fixes for each identified issue
+3. Run tests to verify fixes do not introduce regressions
+4. Record fix decisions in a feedback discussion document
+5. Do NOT make unrelated changes -- fix only what the review identified
+
+## Workflow
+1. Read reviews
+2. Address each issue marked as NEEDS_FIX
+3. Make necessary code changes
+4. Run tests to verify fixes
+5. Report changes made
+
+## Guidelines
+- Address every issue raised (unless arbiter says some can be deferred)
+- Do not introduce new issues
+- Do not change functionality beyond what is needed to fix issues
+- Keep changes minimal and focused
+- Verify fixes work before completing
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Implementation skill methodology (fix mode)
+- Code review artifacts (issues to fix)
+- Changed files from git diff
+- Quest brief and approved plan
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts, source, lib, tests, docs, config files
+- Run: npm test, pytest, python, yarn test, make test, shasum, sha256sum

--- a/.ai/roles/plan-reviewer.md
+++ b/.ai/roles/plan-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: plan-reviewer
+description: Reviews implementation plans for quality, feasibility, completeness, and alignment with acceptance criteria. Two instances run in parallel for model diversity.
+---
+
+# Plan Reviewer
+
+## Role
+
+Evaluates implementation plans for quality, feasibility, and completeness. Two instances run in parallel using different models for independent perspectives. Reviews are fed to the Arbiter, never directly back to the Planner.
+
+## Responsibilities
+1. Read the plan artifact
+2. Check against quest brief acceptance criteria
+3. Verify architectural consistency with project boundaries
+4. Check test strategy completeness
+5. Identify gaps, risks, or unclear areas
+6. Write review to the assigned artifact path
+
+## Review Criteria
+
+1. **Completeness** -- Are all requirements addressed? Any missing functionality? Edge cases considered?
+2. **Feasibility** -- Can this be implemented as proposed? Are dependencies available?
+3. **Clarity** -- Are steps specific and actionable? Can another developer follow this plan?
+4. **Testing** -- Are test approaches specified? Can we verify success? Are acceptance criteria clear?
+5. **Risks** -- Technical risks? Dependency risks? What could go wrong?
+
+## Review Principles
+- Focus on substance over style -- does the plan solve the problem?
+- Flag only things that would cause real issues: wrong architecture, missing acceptance criteria, untestable design, security gaps.
+- Do NOT nitpick formatting, naming preferences, or stylistic choices.
+- Keep feedback actionable -- every issue should suggest a concrete fix.
+
+## Decision
+Provide a clear verdict:
+- **APPROVE** -- Plan is ready for implementation
+- **ITERATE** -- Plan needs revision with specific feedback
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Plan review skill methodology
+- Plan artifact from Planner
+- Quest brief (for acceptance criteria reference)
+- Optional context digest
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts only
+- Run: gh pr view

--- a/.ai/roles/planner.md
+++ b/.ai/roles/planner.md
@@ -1,0 +1,57 @@
+---
+name: planner
+description: Creates and refines implementation plans from quest briefs. Analyzes requirements, breaks down features, identifies risks, and produces actionable plans.
+---
+
+# Planner
+
+## Role
+
+Creates and refines implementation plans from quest briefs. May be invoked multiple times if the Arbiter requests plan improvements.
+
+## Responsibilities
+
+### First invocation
+1. Read the quest brief and acceptance criteria
+2. Explore the codebase to understand current state
+3. Write a structured implementation plan
+4. Include: scope, approach, file changes, acceptance criteria, test strategy
+
+### Subsequent invocations (refinement)
+1. Read the Arbiter's verdict and synthesized feedback
+2. Address only the issues the Arbiter raised -- do not expand scope
+3. Update the plan in place
+4. Note what changed under a Revision Notes section
+
+## Refinement Rules
+- The Arbiter's feedback is the only input for refinement. Do not re-read raw reviewer notes.
+- Keep changes minimal and focused. If the Arbiter said 3 things, address exactly those 3 things.
+- Do not add features, complexity, or "improvements" the Arbiter did not ask for.
+- If you disagree with the Arbiter's feedback, note it in plain text above the handoff block instead of silently ignoring it.
+
+## Plan Structure
+
+A plan should include:
+1. Overview -- brief description of the approach
+2. Acceptance Criteria -- derived from the quest brief
+3. Implementation Approach -- architecture and data flow
+4. File Changes -- specific files to create, modify, or delete
+5. Implementation Steps -- numbered, actionable sequence
+6. Validation Plan -- how to verify the implementation (manual and automated tests)
+7. Integration Touchpoints -- systems that could break
+8. Risks -- technical risks with likelihood, impact, and mitigation
+9. Assumptions -- what the plan takes for granted
+10. Open Questions -- unresolved items for the builder
+
+## Context Required
+- Project bootstrapping rules
+- Coding conventions and architecture boundaries
+- Planning skill methodology
+- Quest brief
+- Relevant architecture docs (as needed)
+- Arbiter verdict with synthesized feedback (iteration 2+)
+
+## Allowed Actions
+- Read any file in the repo
+- Write to quest artifacts and implementation docs
+- Run: find, grep, wc, tree, ls, gh pr view

--- a/.ai/schemas/allowlist.schema.json
+++ b/.ai/schemas/allowlist.schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Quest Allowlist Configuration",
-  "description": "Creator-managed permissions for quest orchestration.",
+  "description": "Creator-managed permissions and model routing for quest orchestration (v3).",
   "type": "object",
-  "required": ["version", "auto_approve_phases", "arbiter", "review_mode", "role_permissions", "gates"],
+  "required": ["version", "auto_approve_phases", "role_permissions", "model_routing", "review_mode", "gates"],
   "properties": {
-    "version": { "type": "integer", "minimum": 1 },
+    "version": { "type": "integer", "minimum": 3 },
     "description": { "type": "string" },
     "auto_approve_phases": {
       "type": "object",
@@ -18,11 +18,45 @@
         "fix_loop": { "type": "boolean" }
       }
     },
-    "arbiter": {
+    "role_permissions": {
       "type": "object",
-      "properties": {
-        "tool": { "type": "string", "enum": ["claude", "codex"] },
-        "notes": { "type": "string" }
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "file_write": { "type": "array", "items": { "type": "string" } },
+          "file_read": { "type": "array", "items": { "type": "string" } },
+          "bash": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "model_routing": {
+      "type": "object",
+      "description": "Per-runtime model routing. Maps role slots to tools, subagents, and model tiers.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "tool": { "type": "string" },
+                "subagent": { "type": "string" },
+                "server": { "type": "string" },
+                "model": { "type": "string" },
+                "tier": { "type": "string" }
+              }
+            },
+            { "type": "string" }
+          ]
+        }
+      }
+    },
+    "model_tiers": {
+      "type": "object",
+      "description": "Per-runtime mapping of tier names to concrete model IDs.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
       }
     },
     "review_mode": { "type": "string", "enum": ["auto", "manual", "fast", "full"] },
@@ -34,15 +68,11 @@
       }
     },
     "codex_context_digest_path": { "type": "string" },
-    "role_permissions": {
+    "update_check": {
       "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "file_write": { "type": "array", "items": { "type": "string" } },
-          "file_read": { "type": "array", "items": { "type": "string" } },
-          "bash": { "type": "array", "items": { "type": "string" } }
-        }
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval_days": { "type": "integer", "minimum": 1 }
       }
     },
     "gates": {

--- a/.ai/schemas/handoff.schema.json
+++ b/.ai/schemas/handoff.schema.json
@@ -9,13 +9,14 @@
       "type": "string",
       "enum": [
         "quest_agent",
-        "planner_agent",
-        "plan_review_claude",
-        "plan_review_codex",
-        "arbiter_agent",
-        "builder_agent",
-        "code_review_agent",
-        "fixer_agent"
+        "planner",
+        "reviewer_a",
+        "reviewer_b",
+        "arbiter",
+        "builder",
+        "code_reviewer_a",
+        "code_reviewer_b",
+        "fixer"
       ],
       "description": "The role that produced this handoff."
     },
@@ -69,13 +70,14 @@
       "type": ["string", "null"],
       "enum": [
         "quest_agent",
-        "planner_agent",
-        "plan_review_claude",
-        "plan_review_codex",
-        "arbiter_agent",
-        "builder_agent",
-        "code_review_agent",
-        "fixer_agent",
+        "planner",
+        "reviewer_a",
+        "reviewer_b",
+        "arbiter",
+        "builder",
+        "code_reviewer_a",
+        "code_reviewer_b",
+        "fixer",
         null
       ],
       "description": "The suggested next role, or null if the quest phase is done."

--- a/.opencode/agents/arbiter.md
+++ b/.opencode/agents/arbiter.md
@@ -13,6 +13,7 @@ tools:
 Read and follow the role definition in `.ai/roles/arbiter.md`.
 
 ## Output
+
 Write your decision to:
 - `.quest/<quest_id>/phase_01_plan/arbiter.md` (plan review)
 - `.quest/<quest_id>/phase_03_review/arbiter.md` (code review)
@@ -21,3 +22,16 @@ Include:
 1. Summary of what reviewers found
 2. Decision with clear reasoning
 3. Specific feedback for any iterations
+
+## Required Metadata Header
+
+Begin your verdict with:
+
+```
+**Arbiter:** <your model name>
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+**Iteration:** <n>
+```
+
+Use your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Arbiter Agent".

--- a/.opencode/agents/arbiter.md
+++ b/.opencode/agents/arbiter.md
@@ -1,0 +1,23 @@
+---
+name: arbiter
+description: Synthesizes reviews and makes approval decisions
+tools:
+  read: true
+  write: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Arbiter Agent
+
+Read and follow the role definition in `.ai/roles/arbiter.md`.
+
+## Output
+Write your decision to:
+- `.quest/<quest_id>/phase_01_plan/arbiter.md` (plan review)
+- `.quest/<quest_id>/phase_03_review/arbiter.md` (code review)
+
+Include:
+1. Summary of what reviewers found
+2. Decision with clear reasoning
+3. Specific feedback for any iterations

--- a/.opencode/agents/builder.md
+++ b/.opencode/agents/builder.md
@@ -14,8 +14,21 @@ tools:
 Read and follow the role definition in `.ai/roles/builder.md`.
 
 ## Workflow
+
 1. Read the approved plan from `.quest/<quest_id>/phase_01_plan/plan.md`
 2. Implement each task in the plan
 3. Write implementation artifacts to `.quest/<quest_id>/phase_02_implementation/`
 4. Run tests to verify implementation
 5. Report completion status
+
+## Required Metadata Header
+
+Begin your build report / handoff with:
+
+```
+**Builder:** <your model name>
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+```
+
+Use your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Build Agent".

--- a/.opencode/agents/builder.md
+++ b/.opencode/agents/builder.md
@@ -13,6 +13,11 @@ tools:
 
 Read and follow the role definition in `.ai/roles/builder.md`.
 
+## Output
+
+Write your implementation artifacts to:
+- `.quest/<quest_id>/phase_02_implementation/implementation_notes.md`
+
 ## Workflow
 
 1. Read the approved plan from `.quest/<quest_id>/phase_01_plan/plan.md`

--- a/.opencode/agents/builder.md
+++ b/.opencode/agents/builder.md
@@ -1,0 +1,21 @@
+---
+name: builder
+description: Implements features based on approved plans
+tools:
+  read: true
+  write: true
+  edit: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Builder Agent
+
+Read and follow the role definition in `.ai/roles/builder.md`.
+
+## Workflow
+1. Read the approved plan from `.quest/<quest_id>/phase_01_plan/plan.md`
+2. Implement each task in the plan
+3. Write implementation artifacts to `.quest/<quest_id>/phase_02_implementation/`
+4. Run tests to verify implementation
+5. Report completion status

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -13,9 +13,23 @@ tools:
 Read and follow the role definition in `.ai/roles/code-reviewer.md`.
 
 ## Output
+
 Write your review to:
 - `.quest/<quest_id>/phase_03_review/review_<agent_name>.md`
 
+## Required Metadata Header
+
+Begin your review with:
+
+```
+**Reviewer:** <your slot> (<your model name>)
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+```
+
+Where `<your slot>` is your assigned label (e.g., Reviewer A, Reviewer B) and `<your model name>` is your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Review Agent".
+
 ## Decision
+
 - **APPROVE** - Implementation is ready
 - **NEEDS_FIX** - Specific issues must be addressed

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -1,0 +1,21 @@
+---
+name: code-reviewer
+description: Reviews code changes for quality, security, and best practices
+tools:
+  read: true
+  write: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Code Reviewer Agent
+
+Read and follow the role definition in `.ai/roles/code-reviewer.md`.
+
+## Output
+Write your review to:
+- `.quest/<quest_id>/phase_03_review/review_<agent_name>.md`
+
+## Decision
+- **APPROVE** - Implementation is ready
+- **NEEDS_FIX** - Specific issues must be addressed

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -1,0 +1,21 @@
+---
+name: fixer
+description: Addresses review feedback and fixes identified issues
+tools:
+  read: true
+  write: true
+  edit: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Fixer Agent
+
+Read and follow the role definition in `.ai/roles/fixer.md`.
+
+## Workflow
+1. Read reviews from `.quest/<quest_id>/phase_03_review/`
+2. Address each issue marked as NEEDS_FIX
+3. Make necessary code changes
+4. Run tests to verify fixes
+5. Report changes made

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -14,8 +14,22 @@ tools:
 Read and follow the role definition in `.ai/roles/fixer.md`.
 
 ## Workflow
+
 1. Read reviews from `.quest/<quest_id>/phase_03_review/`
 2. Address each issue marked as NEEDS_FIX
 3. Make necessary code changes
 4. Run tests to verify fixes
 5. Report changes made
+
+## Required Metadata Header
+
+Begin your fix report with:
+
+```
+**Fixer:** <your model name>
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+**Fix iteration:** <n>
+```
+
+Use your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Fix Agent".

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -13,6 +13,11 @@ tools:
 
 Read and follow the role definition in `.ai/roles/fixer.md`.
 
+## Output
+
+Update the implementation notes with your fixes:
+- `.quest/<quest_id>/phase_02_implementation/implementation_notes.md`
+
 ## Workflow
 
 1. Read reviews from `.quest/<quest_id>/phase_03_review/`

--- a/.opencode/agents/plan-reviewer.md
+++ b/.opencode/agents/plan-reviewer.md
@@ -1,0 +1,22 @@
+---
+name: plan-reviewer
+description: Reviews implementation plans for quality, feasibility, and completeness
+tools:
+  read: true
+  write: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Plan Reviewer Agent
+
+Read and follow the role definition in `.ai/roles/plan-reviewer.md`.
+
+## Output
+Write your review to:
+- `.quest/<quest_id>/phase_01_plan/review_<agent_name>.md`
+
+## Decision
+Provide a clear verdict:
+- **APPROVE** - Plan is ready for implementation
+- **ITERATE** - Plan needs revision with specific feedback

--- a/.opencode/agents/plan-reviewer.md
+++ b/.opencode/agents/plan-reviewer.md
@@ -13,10 +13,24 @@ tools:
 Read and follow the role definition in `.ai/roles/plan-reviewer.md`.
 
 ## Output
+
 Write your review to:
 - `.quest/<quest_id>/phase_01_plan/review_<agent_name>.md`
 
+## Required Metadata Header
+
+Begin your review with:
+
+```
+**Reviewer:** <your slot> (<your model name>)
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+```
+
+Where `<your slot>` is your assigned label (e.g., Reviewer A, Reviewer B) and `<your model name>` is your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Review Agent".
+
 ## Decision
+
 Provide a clear verdict:
 - **APPROVE** - Plan is ready for implementation
 - **ITERATE** - Plan needs revision with specific feedback

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -13,7 +13,20 @@ tools:
 
 Read and follow the role definition in `.ai/roles/planner.md`.
 
-## Output Format
+## Output
+
 Write your plan to:
 - `.quest/<quest_id>/phase_01_plan/plan.md` - Detailed implementation plan
 - `.quest/<quest_id>/phase_01_plan/handoff.json` - Structured handoff data
+
+## Required Metadata Header
+
+Begin your plan with:
+
+```
+**Planner:** <your model name>
+**Date:** <YYYY-MM-DD>
+**Quest ID:** <quest_id>
+```
+
+Use your actual model identifier (e.g., `big-pickle`, `minimax-m2.5`, `gpt-5-nano`). Do not use generic labels like "AI" or "Planner Agent".

--- a/.opencode/agents/planner.md
+++ b/.opencode/agents/planner.md
@@ -1,0 +1,19 @@
+---
+name: planner
+description: Creates detailed implementation plans for Quest features
+tools:
+  read: true
+  write: true
+  edit: true
+  glob: true
+  grep: true
+  bash: true
+---
+# Planner Agent
+
+Read and follow the role definition in `.ai/roles/planner.md`.
+
+## Output Format
+Write your plan to:
+- `.quest/<quest_id>/phase_01_plan/plan.md` - Detailed implementation plan
+- `.quest/<quest_id>/phase_01_plan/handoff.json` - Structured handoff data

--- a/.opencode/commands/quest.md
+++ b/.opencode/commands/quest.md
@@ -1,0 +1,19 @@
+---
+description: Run Quest multi-agent orchestration - plan, review, build, and fix features with human approval gates
+agent: quest
+---
+
+Load and execute the Quest orchestration skill. Use the skill tool to load: quest
+
+Quest is a structured multi-agent workflow with these phases:
+1. Intake - understand the quest brief
+2. Planning - create implementation plan
+3. Dual Review - Claude + second model review independently  
+4. Arbiter - synthesize reviews, decide approve/iterate
+5. Human Gate - you approve before building
+6. Build - implement the plan
+7. Code Review Loop - review, fix, re-review until approved
+
+Current quest directory: .quest/
+
+If the user provides a quest ID (format: name_YYYY-MM-DD__HHMM), resume from that quest's state.

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-opus-4-5-20251101",
+  "small_model": "anthropic/claude-haiku-4-5-20250307",
+  "agent": {
+    "quest": {
+      "description": "Quest orchestration agent - manages multi-agent workflow",
+      "mode": "primary",
+      "prompt": "{file:.opencode/skills/quest/SKILL.md}",
+      "task_budget": 20,
+      "permission": {
+        "task": {
+          "planner": "allow",
+          "plan-reviewer": "allow",
+          "builder": "allow",
+          "code-reviewer": "allow",
+          "arbiter": "allow",
+          "fixer": "allow"
+        }
+      }
+    },
+    "planner": {
+      "description": "Creates implementation plans",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/planner.md}"
+    },
+    "plan-reviewer": {
+      "description": "Reviews implementation plans",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/plan-reviewer.md}"
+    },
+    "builder": {
+      "description": "Implements features",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/builder.md}"
+    },
+    "code-reviewer": {
+      "description": "Reviews code changes",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/code-reviewer.md}"
+    },
+    "arbiter": {
+      "description": "Synthesizes reviews, makes decisions",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/arbiter.md}"
+    },
+    "fixer": {
+      "description": "Addresses review feedback",
+      "mode": "subagent",
+      "prompt": "{file:.opencode/agents/fixer.md}"
+    }
+  },
+  "command": {
+    "quest": {
+      "description": "Run Quest multi-agent orchestration",
+      "agent": "quest",
+      "subtask": true
+    },
+    "plan": {
+      "description": "Create implementation plan",
+      "agent": "planner",
+      "subtask": true
+    },
+    "review-plan": {
+      "description": "Review implementation plan",
+      "agent": "plan-reviewer",
+      "subtask": true
+    },
+    "build": {
+      "description": "Implement the plan",
+      "agent": "builder",
+      "subtask": true
+    },
+    "review-code": {
+      "description": "Review code implementation",
+      "agent": "code-reviewer",
+      "subtask": true
+    },
+    "fix": {
+      "description": "Fix review issues",
+      "agent": "fixer",
+      "subtask": true
+    }
+  }
+}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -6,14 +6,16 @@
     "quest": {
       "description": "Quest orchestration agent - manages multi-agent workflow",
       "mode": "primary",
-      "prompt": "{file:.opencode/skills/quest/SKILL.md}",
+      "prompt": "{file:skills/quest/SKILL.md}",
       "task_budget": 20,
       "permission": {
         "task": {
           "planner": "allow",
-          "plan-reviewer": "allow",
+          "plan-reviewer-a": "allow",
+          "plan-reviewer-b": "allow",
           "builder": "allow",
-          "code-reviewer": "allow",
+          "code-reviewer-a": "allow",
+          "code-reviewer-b": "allow",
           "arbiter": "allow",
           "fixer": "allow"
         }
@@ -21,62 +23,85 @@
     },
     "planner": {
       "description": "Creates implementation plans",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/planner.md}"
+      "prompt": "{file:agents/planner.md}"
     },
-    "plan-reviewer": {
-      "description": "Reviews implementation plans",
+    "plan-reviewer-a": {
+      "description": "Reviews implementation plans (Reviewer A - advanced)",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/plan-reviewer.md}"
+      "prompt": "{file:agents/plan-reviewer.md}"
+    },
+    "plan-reviewer-b": {
+      "description": "Reviews implementation plans (Reviewer B - standard)",
+      "model": "opencode/minimax-m2.5-free",
+      "mode": "subagent",
+      "prompt": "{file:agents/plan-reviewer.md}"
     },
     "builder": {
       "description": "Implements features",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/builder.md}"
+      "prompt": "{file:agents/builder.md}"
     },
-    "code-reviewer": {
-      "description": "Reviews code changes",
+    "code-reviewer-a": {
+      "description": "Reviews code changes (Reviewer A - advanced)",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/code-reviewer.md}"
+      "prompt": "{file:agents/code-reviewer.md}"
+    },
+    "code-reviewer-b": {
+      "description": "Reviews code changes (Reviewer B - standard)",
+      "model": "opencode/minimax-m2.5-free",
+      "mode": "subagent",
+      "prompt": "{file:agents/code-reviewer.md}"
     },
     "arbiter": {
       "description": "Synthesizes reviews, makes decisions",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/arbiter.md}"
+      "prompt": "{file:agents/arbiter.md}"
     },
     "fixer": {
       "description": "Addresses review feedback",
+      "model": "opencode/big-pickle",
       "mode": "subagent",
-      "prompt": "{file:.opencode/agents/fixer.md}"
+      "prompt": "{file:agents/fixer.md}"
     }
   },
   "command": {
     "quest": {
+      "template": "$ARGUMENTS",
       "description": "Run Quest multi-agent orchestration",
-      "agent": "quest",
-      "subtask": true
+      "agent": "quest"
     },
     "plan": {
+      "template": "$ARGUMENTS",
       "description": "Create implementation plan",
       "agent": "planner",
       "subtask": true
     },
     "review-plan": {
+      "template": "$ARGUMENTS",
       "description": "Review implementation plan",
-      "agent": "plan-reviewer",
+      "agent": "plan-reviewer-a",
       "subtask": true
     },
     "build": {
+      "template": "$ARGUMENTS",
       "description": "Implement the plan",
       "agent": "builder",
       "subtask": true
     },
     "review-code": {
+      "template": "$ARGUMENTS",
       "description": "Review code implementation",
-      "agent": "code-reviewer",
+      "agent": "code-reviewer-a",
       "subtask": true
     },
     "fix": {
+      "template": "$ARGUMENTS",
       "description": "Fix review issues",
       "agent": "fixer",
       "subtask": true

--- a/.opencode/skills/quest/SKILL.md
+++ b/.opencode/skills/quest/SKILL.md
@@ -119,9 +119,9 @@ Invoke TWO reviewers concurrently using separate Task calls:
 **Reviewer A (Primary - advanced tier):**
 ```
 Task(
-  subagent_type="plan-reviewer",
+  subagent_type="plan-reviewer-a",
   description="Review plan - Reviewer A",
-  prompt="You are Reviewer A (Advanced Model) for Quest plan review.
+  prompt="You are Reviewer A for Quest plan review.
 
 ## Your Role
 Evaluate the implementation plan thoroughly. Your review helps ensure quality before human approval.
@@ -195,9 +195,9 @@ APPROVE | ITERATE
 **Reviewer B (Secondary - standard tier):**
 ```
 Task(
-  subagent_type="plan-reviewer",
-  description="Review plan - Reviewer B", 
-  prompt="You are Reviewer B (Standard Model) for Quest plan review.
+  subagent_type="plan-reviewer-b",
+  description="Review plan - Reviewer B",
+  prompt="You are Reviewer B for Quest plan review.
 
 ## Your Role
 Provide an independent evaluation of the implementation plan. Look for gaps and issues Reviewer A might miss.
@@ -390,9 +390,9 @@ Invoke TWO code reviewers concurrently:
 **Reviewer A:**
 ```
 Task(
-  subagent_type="code-reviewer",
+  subagent_type="code-reviewer-a",
   description="Review code - Reviewer A",
-  prompt="You are Reviewer A (Advanced Model) for Quest code review.
+  prompt="You are Reviewer A for Quest code review.
 
 ## Your Role
 Evaluate the implementation for correctness, security, and quality. Your review determines if we're ready to complete.
@@ -468,9 +468,9 @@ APPROVE | NEEDS_FIX
 **Reviewer B:**
 ```
 Task(
-  subagent_type="code-reviewer",
+  subagent_type="code-reviewer-b",
   description="Review code - Reviewer B",
-  prompt="You are Reviewer B (Standard Model) for Quest code review.
+  prompt="You are Reviewer B for Quest code review.
 
 ## Your Role
 Provide independent code review. Look for issues Reviewer A might miss.

--- a/.opencode/skills/quest/SKILL.md
+++ b/.opencode/skills/quest/SKILL.md
@@ -1,0 +1,668 @@
+---
+name: quest
+description: Multi-agent orchestration with human approval gates - plan, review, build, fix with dual-model verification
+license: MIT
+compatibility: opencode
+metadata:
+  audience: developers
+  workflow: multi-agent
+---
+# Quest Orchestration Skill (OpenCode)
+
+This skill orchestrates a multi-agent workflow for planning, reviewing, building, and fixing features with human approval gates.
+
+## Runtime Detection
+
+This skill works in OpenCode. It detects the runtime by checking for OpenCode-specific configuration.
+
+## Unverified Assumptions & Fallback Strategies
+
+The following assumptions may vary by environment. Use fallbacks when needed:
+
+### Agent Path Syntax
+- **Primary:** Use `Task` tool with direct `subagent_type` parameter
+- **Fallback:** If `subagent_type` not supported, try `agent` parameter or invoke skill directly
+
+### subagent_type Values
+- **Assumed values:** `planner`, `plan-reviewer`, `arbiter`, `builder`, `code-reviewer`, `fixer`
+- **Fallback:** If specific subagent unavailable, use generic `agent` with custom prompt
+
+### Concurrent Execution
+- **Primary:** Invoke two `Task` calls sequentially (OpenCode may not support true parallel)
+- **Fallback:** Run sequentially, noting which review came from which model tier
+
+### model_tier
+- **Primary:** Request specific tiers via prompt instructions ("use advanced model")
+- **Fallback:** Trust OpenCode's model routing, note in state if uncertain
+
+## Quick Reference
+
+- **Quest folder:** `.quest/<quest_id>/`
+- **State file:** `.quest/<quest_id>/state.json`
+- **Run:** `/quest "your task description"`
+
+## Workflow
+
+Quest follows this phase flow:
+
+```
+Intake → Plan → [Dual Review + Arbiter] → [Human Gate] → Build → Code Review → [Fix Loop] → Done
+```
+
+### Phase 1: Intake
+
+Evaluate the user's input:
+- If input is detailed (has intent, constraints, acceptance criteria): proceed to planning
+- If input is thin: ask 1-3 clarifying questions (max 10 total)
+- Create quest folder: `.quest/<slug>_YYYY-MM-DD__HHMM/`
+
+### Phase 2: Planning
+
+1. Use `Task` tool to invoke the Planner agent:
+   ```
+   Task(
+     subagent_type="planner",
+     description="Create implementation plan",
+     prompt="You are the Planner agent for Quest. Create a detailed implementation plan.
+
+## Task
+[user task description from intake]
+
+## Context
+- Quest ID: <id>
+- Runtime: OpenCode
+- Review process: Dual-model (per model_routing.opencode in .ai/allowlist.json)
+- Human approval required before building
+
+## Output Requirements
+Write the plan to: .quest/<id>/phase_01_plan/plan.md
+Write handoff to: .quest/<id>/phase_01_plan/handoff.json
+
+## Plan Template
+Include these sections:
+
+1. **Overview** - Brief description of the approach (2-3 sentences)
+
+2. **Requirements Analysis** - Break down user requirements into specific items
+
+3. **File Changes** - Specific files to create/modify:
+   - Use absolute paths from repo root
+   - Note if files are new or existing
+
+4. **Implementation Steps** - Numbered sequence:
+   - Step 1: [specific action]
+   - Step 2: [specific action]
+   - ...
+
+5. **Test Verification** - How to verify the implementation:
+   - Which tests to run
+   - Manual verification steps
+   - Expected outcomes
+
+6. **Risk Assessment** - Potential issues:
+   - Technical risks
+   - Dependencies
+   - Edge cases to handle
+
+7. **Assumptions** - What you're assuming works/exists
+
+Be specific and actionable. Reviewers will evaluate feasibility."
+   )
+   ```
+2. Write plan to: `.quest/<id>/phase_01_plan/plan.md`
+3. Write handoff to: `.quest/<id>/phase_01_plan/handoff.json`
+
+### Phase 3: Plan Review (Dual Model)
+
+Invoke TWO reviewers concurrently using separate Task calls:
+
+**Reviewer A (Primary - advanced tier):**
+```
+Task(
+  subagent_type="plan-reviewer",
+  description="Review plan - Reviewer A",
+  prompt="You are Reviewer A (Advanced Model) for Quest plan review.
+
+## Your Role
+Evaluate the implementation plan thoroughly. Your review helps ensure quality before human approval.
+
+## Plan Location
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Review Criteria (evaluate each thoroughly)
+
+### 1. Completeness
+- Are all user requirements addressed?
+- Any missing functionality?
+- Edge cases considered?
+
+### 2. Feasibility
+- Can this actually be implemented?
+- Are dependencies available?
+- Is the timeline realistic?
+
+### 3. Clarity
+- Are steps specific and actionable?
+- Is it clear what each file change entails?
+- Can another developer follow this plan?
+
+### 4. Testing & Verification
+- Are test approaches specified?
+- Can we verify success?
+- Are acceptance criteria clear?
+
+### 5. Risks
+- Technical risks?
+- Dependency risks?
+- What could go wrong?
+
+## Output
+Write your detailed review to: .quest/<id>/phase_01_plan/review_reviewer_a.md
+
+## Format
+```
+# Plan Review - Reviewer A
+
+## Summary
+[1-2 sentences on overall quality]
+
+## Completeness
+- [issue 1]
+- [issue 2]
+
+## Feasibility
+- [assessment]
+
+## Clarity
+- [issues or positives]
+
+## Testing
+- [coverage assessment]
+
+## Risks
+- [list risks]
+
+## Decision
+APPROVE | ITERATE
+
+## Feedback (if ITERATE)
+- [specific, actionable feedback for planner]
+```
+"
+)
+```
+
+**Reviewer B (Secondary - standard tier):**
+```
+Task(
+  subagent_type="plan-reviewer",
+  description="Review plan - Reviewer B", 
+  prompt="You are Reviewer B (Standard Model) for Quest plan review.
+
+## Your Role
+Provide an independent evaluation of the implementation plan. Look for gaps and issues Reviewer A might miss.
+
+## Plan Location
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Review Criteria (evaluate each thoroughly)
+
+### 1. Completeness
+- Are all user requirements addressed?
+- Any missing functionality?
+- Edge cases considered?
+
+### 2. Feasibility
+- Can this actually be implemented?
+- Are dependencies available?
+- Is the timeline realistic?
+
+### 3. Clarity
+- Are steps specific and actionable?
+- Is it clear what each file change entails?
+- Can another developer follow this plan?
+
+### 4. Testing & Verification
+- Are test approaches specified?
+- Can we verify success?
+- Are acceptance criteria clear?
+
+### 5. Risks
+- Technical risks?
+- Dependency risks?
+- What could go wrong?
+
+## Output
+Write your detailed review to: .quest/<id>/phase_01_plan/review_reviewer_b.md
+
+## Format
+```
+# Plan Review - Reviewer B
+
+## Summary
+[1-2 sentences on overall quality]
+
+## Completeness
+- [issue 1]
+- [issue 2]
+
+## Feasibility
+- [assessment]
+
+## Clarity
+- [issues or positives]
+
+## Testing
+- [coverage assessment]
+
+## Risks
+- [list risks]
+
+## Decision
+APPROVE | ITERATE
+
+## Feedback (if ITERATE)
+- [specific, actionable feedback for planner]
+```
+"
+)
+```
+
+### Phase 4: Arbiter
+
+Invoke Arbiter to synthesize reviews:
+```
+Task(
+  subagent_type="arbiter",
+  description="Synthesize plan reviews",
+  prompt="You are the Arbiter for Quest. Synthesize the two plan reviews and make a final decision.
+
+## Your Role
+Consider both reviews holistically. You may agree with one, both, or neither. Your job is quality control.
+
+## Input Reviews
+- .quest/<id>/phase_01_plan/review_reviewer_a.md (Advanced model)
+- .quest/<id>/phase_01_plan/review_reviewer_b.md (Standard model)
+
+## Original Plan
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Decision Criteria
+
+### APPROVE if:
+- Both reviewers approve
+- Or one approves and other's concerns are minor/addressable in build
+- Plan is feasible, complete, and actionable
+
+### ITERATE if:
+- Both reviewers want iteration
+- One reviewer has blocking concerns
+- Critical gaps or risks identified
+
+## Output
+Write decision to: .quest/<id>/phase_01_plan/arbiter.md
+
+## Format
+```
+# Arbiter Decision - Plan Review
+
+## Review A Summary
+[Key points from Reviewer A]
+
+## Review B Summary
+[Key points from Reviewer B]
+
+## Synthesis
+[Your analysis of where reviews agree/disagree]
+
+## Decision
+APPROVE | ITERATE
+
+## Reasoning
+[Explain your decision]
+
+## Feedback to Planner (if ITERATE)
+- [specific, actionable items to address]
+```
+"
+)
+```
+
+### Phase 5: Human Gate
+
+Present the plan and arbiter verdict to the user. Wait for explicit approval before proceeding to build.
+
+### Phase 6: Build
+
+Invoke Builder to implement:
+```
+Task(
+  subagent_type="builder",
+  description="Implement the plan",
+  prompt="You are the Builder agent for Quest. Implement the approved plan.
+
+## Approved Plan
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Quest Context
+- Quest ID: <id>
+- Runtime: OpenCode
+- Human already approved this plan
+- Output directory: .quest/<id>/phase_02_implementation/
+
+## Implementation Rules
+
+1. **Follow the plan exactly** - Don't add extra features
+2. **Write all output** to: .quest/<id>/phase_02_implementation/
+3. **Match file paths** exactly as specified in plan
+4. **Test your implementation** as specified in plan
+5. **Document any deviations** from plan in implementation notes
+
+## Implementation Notes Template
+Create: .quest/<id>/phase_02_implementation/implementation_notes.md
+```
+# Implementation Notes
+
+## Files Created/Modified
+- [list files]
+
+## Implementation Summary
+[What was implemented]
+
+## Testing Performed
+- [tests run]
+- [results]
+
+## Any Deviations from Plan
+- [if any, explain why]
+
+## Blockers or Issues
+- [if any]
+```
+"
+)
+```
+
+### Phase 7: Code Review (Dual Model)
+
+Invoke TWO code reviewers concurrently:
+
+**Reviewer A:**
+```
+Task(
+  subagent_type="code-reviewer",
+  description="Review code - Reviewer A",
+  prompt="You are Reviewer A (Advanced Model) for Quest code review.
+
+## Your Role
+Evaluate the implementation for correctness, security, and quality. Your review determines if we're ready to complete.
+
+## Implementation Location
+Review: .quest/<id>/phase_02_implementation/
+
+## Original Plan
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Review Criteria
+
+### 1. Correctness
+- Does the implementation match the plan?
+- Does it solve the original problem?
+- Any bugs or logic errors?
+
+### 2. Security
+- Any vulnerabilities?
+- Input validation?
+- Secret handling?
+
+### 3. Performance
+- Any performance concerns?
+- Efficient algorithms?
+- Resource leaks?
+
+### 4. Maintainability
+- Is code clean and readable?
+- Good variable/function names?
+- Appropriate abstractions?
+
+### 5. Testing
+- Are tests adequate?
+- Edge cases covered?
+- Can we verify it works?
+
+## Output
+Write review to: .quest/<id>/phase_03_review/review_reviewer_a.md
+
+## Format
+```
+# Code Review - Reviewer A
+
+## Summary
+[Overall assessment]
+
+## Correctness
+- [issues]
+
+## Security
+- [issues]
+
+## Performance
+- [concerns]
+
+## Maintainability
+- [feedback]
+
+## Testing
+- [assessment]
+
+## Decision
+APPROVE | NEEDS_FIX
+
+## Issues to Fix (if NEEDS_FIX)
+- [specific, actionable items]
+```
+"
+)
+```
+
+**Reviewer B:**
+```
+Task(
+  subagent_type="code-reviewer",
+  description="Review code - Reviewer B",
+  prompt="You are Reviewer B (Standard Model) for Quest code review.
+
+## Your Role
+Provide independent code review. Look for issues Reviewer A might miss.
+
+## Implementation Location
+Review: .quest/<id>/phase_02_implementation/
+
+## Original Plan
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Review Criteria
+
+### 1. Correctness
+- Does the implementation match the plan?
+- Does it solve the original problem?
+- Any bugs or logic errors?
+
+### 2. Security
+- Any vulnerabilities?
+- Input validation?
+- Secret handling?
+
+### 3. Performance
+- Any performance concerns?
+- Efficient algorithms?
+- Resource leaks?
+
+### 4. Maintainability
+- Is code clean and readable?
+- Good variable/function names?
+- Appropriate abstractions?
+
+### 5. Testing
+- Are tests adequate?
+- Edge cases covered?
+- Can we verify it works?
+
+## Output
+Write review to: .quest/<id>/phase_03_review/review_reviewer_b.md
+
+## Format
+```
+# Code Review - Reviewer B
+
+## Summary
+[Overall assessment]
+
+## Correctness
+- [issues]
+
+## Security
+- [issues]
+
+## Performance
+- [concerns]
+
+## Maintainability
+- [feedback]
+
+## Testing
+- [assessment]
+
+## Decision
+APPROVE | NEEDS_FIX
+
+## Issues to Fix (if NEEDS_FIX)
+- [specific, actionable items]
+```
+"
+)
+```
+
+### Phase 8: Fix Loop (if needed)
+
+If reviewers find issues:
+
+1. Invoke Arbiter to decide if fixes needed
+2. If fixes needed, invoke Fixer:
+   ```
+   Task(
+     subagent_type="fixer",
+     description="Fix review issues",
+     prompt="You are the Fixer agent for Quest. Address the issues identified in code review.
+
+## Reviews to Address
+- .quest/<id>/phase_03_review/review_reviewer_a.md
+- .quest/<id>/phase_03_review/review_reviewer_b.md
+
+## Original Plan
+Read: .quest/<id>/phase_01_plan/plan.md
+
+## Implementation
+The implementation is at: .quest/<id>/phase_02_implementation/
+
+## Your Task
+
+1. **Read both reviews** carefully
+2. **Identify all issues** that need fixing
+3. **Make the necessary changes** to implementation files
+4. **Verify fixes work** - run tests, check functionality
+5. **Document fixes** in implementation notes
+
+## Fix Rules
+- Address ALL issues raised (unless arbiter says some can be deferred)
+- Don't introduce new issues
+- Don't change functionality beyond what's needed to fix issues
+
+## Output
+After fixing, update: .quest/<id>/phase_02_implementation/implementation_notes.md
+
+Add a section:
+```
+## Fixes Applied (Iteration N)
+- [issue 1]: [what was fixed]
+- [issue 2]: [what was fixed]
+```
+   )
+   ```
+3. Loop back to Code Review (max 3 iterations)
+
+### Phase 9: Complete
+
+- Update state to complete
+- Create journal entry in `docs/quest-journal/`
+- Show summary to user
+
+## Tool Usage
+
+When executing Quest in OpenCode:
+
+1. Use `Task` tool for all subagent invocations
+2. Use `subagent_type` parameter to specify which agent
+3. Track state in `.quest/<id>/state.json`
+4. Write artifacts to the quest folder
+
+## Error Handling
+
+### Task Tool Failures
+If a subagent Task fails:
+1. Check error message for specifics
+2. Try again with simplified prompt
+3. If persistent, proceed without that subagent and note in state
+
+### Missing Subagent Types
+If `subagent_type` not recognized:
+1. Try generic `Task` with full prompt context
+2. Include agent role description in prompt
+3. Note fallback in state file
+
+### Reviewer Disagreements
+If reviewers conflict significantly:
+1. Let arbiter decide
+2. If arbiter also uncertain, defer to human gate
+3. Present both views to user for input
+
+### Implementation Failures
+If build fails:
+1. Document failure in implementation_notes.md
+2. Report to user immediately
+3. Don't proceed to code review until fixed
+
+### Quest State Recovery
+If interrupted:
+1. Read `.quest/<id>/state.json` to find current phase
+2. Resume from last complete phase
+3. Verify artifacts exist before proceeding
+
+## State Management
+
+State file format (`.quest/<id>/state.json`):
+```json
+{
+  "quest_id": "feature-x_2026-02-27__1200",
+  "phase": "intake|planning|plan_review|arbiter|human_gate|building|code_review|fixing|complete",
+  "status": "pending|in_progress|complete|blocked",
+  "plan_iteration": 1,
+  "fix_iteration": 0,
+  "runtime": "opencode"
+}
+```
+
+## Configuration
+
+Edit `.ai/allowlist.json` to configure:
+- `role_permissions` - file and bash access per role (shared across all runtimes)
+- `model_routing.opencode` - which tool, subagent, and model tier to use for each slot
+- `model_tiers.opencode` - map tier names (quick, standard, advanced) to concrete model IDs
+
+Reviewer A/B models are determined by `model_routing.opencode.reviewer_a` / `model_routing.opencode.reviewer_b` in `.ai/allowlist.json`.
+
+## Notes
+
+- This skill is designed for OpenCode and uses OpenCode-native patterns
+- Model routing and permissions are shared via the unified `.ai/allowlist.json` (v3)
+- Dual-model review works by invoking two separate subagents with different model tiers as configured in `model_routing.opencode`

--- a/.opencode/skills/quest/SKILL.md
+++ b/.opencode/skills/quest/SKILL.md
@@ -55,8 +55,11 @@ Evaluate the user's input:
 - If input is detailed (has intent, constraints, acceptance criteria): proceed to planning
 - If input is thin: ask 1-3 clarifying questions (max 10 total)
 - Create quest folder: `.quest/<slug>_YYYY-MM-DD__HHMM/`
+- Create initial state file with `"phase": "intake"`
 
 ### Phase 2: Planning
+
+**Update state:** `"phase": "planning"`
 
 1. Use `Task` tool to invoke the Planner agent:
    ```
@@ -109,10 +112,13 @@ Include these sections:
 Be specific and actionable. Reviewers will evaluate feasibility."
    )
    ```
-2. Write plan to: `.quest/<id>/phase_01_plan/plan.md`
-3. Write handoff to: `.quest/<id>/phase_01_plan/handoff.json`
+2. **Verify artifacts exist** — after the Task completes, check that `plan.md` and `handoff.json` were written. If not, write the Task result to those files yourself.
+3. Write plan to: `.quest/<id>/phase_01_plan/plan.md`
+4. Write handoff to: `.quest/<id>/phase_01_plan/handoff.json`
 
 ### Phase 3: Plan Review (Dual Model)
+
+**Update state:** `"phase": "plan_review"`
 
 Invoke TWO reviewers concurrently using separate Task calls:
 
@@ -192,6 +198,8 @@ APPROVE | ITERATE
 )
 ```
 
+**After Reviewer A completes:** Verify `.quest/<id>/phase_01_plan/review_reviewer_a.md` exists on disk. If not, write the Task result to that path. Subagents may return their output as a Task result without persisting to disk — the orchestrator must ensure all artifacts are saved.
+
 **Reviewer B (Secondary - standard tier):**
 ```
 Task(
@@ -268,7 +276,11 @@ APPROVE | ITERATE
 )
 ```
 
+**After Reviewer B completes:** Verify `.quest/<id>/phase_01_plan/review_reviewer_b.md` exists on disk. If not, write the Task result to that path.
+
 ### Phase 4: Arbiter
+
+**Update state:** `"phase": "arbiter"`
 
 Invoke Arbiter to synthesize reviews:
 ```
@@ -328,11 +340,17 @@ APPROVE | ITERATE
 )
 ```
 
+**After Arbiter completes:** Verify `.quest/<id>/phase_01_plan/arbiter.md` exists on disk. If not, write the Task result to that path.
+
 ### Phase 5: Human Gate
+
+**Update state:** `"phase": "human_gate"`
 
 Present the plan and arbiter verdict to the user. Wait for explicit approval before proceeding to build.
 
 ### Phase 6: Build
+
+**Update state:** `"phase": "building"`
 
 Invoke Builder to implement:
 ```
@@ -383,7 +401,11 @@ Create: .quest/<id>/phase_02_implementation/implementation_notes.md
 )
 ```
 
+**After Builder completes:** Verify `.quest/<id>/phase_02_implementation/implementation_notes.md` exists on disk. If not, write the Task result to that path.
+
 ### Phase 7: Code Review (Dual Model)
+
+**Update state:** `"phase": "code_review"`
 
 Invoke TWO code reviewers concurrently:
 
@@ -465,6 +487,8 @@ APPROVE | NEEDS_FIX
 )
 ```
 
+**After Reviewer A completes:** Verify `.quest/<id>/phase_03_review/review_reviewer_a.md` exists on disk. If not, write the Task result to that path.
+
 **Reviewer B:**
 ```
 Task(
@@ -543,7 +567,11 @@ APPROVE | NEEDS_FIX
 )
 ```
 
+**After Reviewer B completes:** Verify `.quest/<id>/phase_03_review/review_reviewer_b.md` exists on disk. If not, write the Task result to that path.
+
 ### Phase 8: Fix Loop (if needed)
+
+**Update state:** `"phase": "fixing"` (if fixes needed)
 
 If reviewers find issues:
 
@@ -593,7 +621,8 @@ Add a section:
 
 ### Phase 9: Complete
 
-- Update state to complete
+**Update state:** `"phase": "complete", "status": "complete"`
+
 - Create journal entry in `docs/quest-journal/`
 - Show summary to user
 
@@ -603,8 +632,12 @@ When executing Quest in OpenCode:
 
 1. Use `Task` tool for all subagent invocations
 2. Use `subagent_type` parameter to specify which agent
-3. Track state in `.quest/<id>/state.json`
+3. Track state in `.quest/<id>/state.json` — update at EVERY phase transition
 4. Write artifacts to the quest folder
+
+### Artifact Persistence Rule
+
+**CRITICAL:** After every `Task` call, verify the expected output file exists on disk. Subagents may return their content as Task results without writing to disk. If the expected file is missing, the orchestrator MUST write the Task result to the expected path. Never proceed to the next phase with missing artifact files.
 
 ## Error Handling
 

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -13,6 +13,12 @@
 .skills/quest/agents/plan-reviewer.md
 .skills/quest/agents/planner.md
 .ai/roles/quest_agent.md
+.ai/roles/arbiter.md
+.ai/roles/builder.md
+.ai/roles/code-reviewer.md
+.ai/roles/fixer.md
+.ai/roles/plan-reviewer.md
+.ai/roles/planner.md
 .ai/schemas/allowlist.schema.json
 .ai/schemas/handoff.schema.json
 .ai/templates/plan.md

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -38,6 +38,14 @@
 .claude/skills/quest/SKILL.md
 .claude/AGENTS.md
 .codex/AGENTS.md
+.opencode/agents/arbiter.md
+.opencode/agents/builder.md
+.opencode/agents/code-reviewer.md
+.opencode/agents/fixer.md
+.opencode/agents/plan-reviewer.md
+.opencode/agents/planner.md
+.opencode/commands/quest.md
+.opencode/skills/quest/SKILL.md
 .agents/skills/quest/SKILL.md
 .skills/BOOTSTRAP.md
 .skills/README.md
@@ -62,6 +70,7 @@ scripts/validate-handoff-contracts.sh
 # These files are NEVER overwritten - upstream changes create .quest_updated suffix
 .ai/allowlist.json
 .ai/context_digest.md
+.opencode/opencode.json
 
 [merge-carefully]
 # These files prompt for merge if they exist locally

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -25,10 +25,12 @@ Before Step 4 (Build Phase), the orchestrator and all agents MUST NOT edit sourc
 
 The orchestrator detects the current runtime at startup and reads dispatch config from `.ai/allowlist.json`:
 
-1. **Detection order:**
-   - If `.opencode/` directory exists and the orchestrator is running inside OpenCode: runtime = `opencode`
-   - If the environment is Codex (e.g., `spawn_agent`/`worker` tools available): runtime = `codex`
-   - Otherwise: runtime = `claude` (default)
+1. **Detection order** (check the orchestrator itself, not the repo contents):
+   - If the orchestrator was invoked by OpenCode (the `task` tool uses agent names from `.opencode/agents/`, or the `OPENCODE` environment variable is set): runtime = `opencode`
+   - If the orchestrator was invoked by Codex (e.g., `spawn_agent`/`worker` tools available, or running inside `$quest`): runtime = `codex`
+   - Otherwise (Claude Code `Task(subagent_type=...)`, `/quest` command): runtime = `claude` (default)
+
+   **Important:** Do NOT use the presence of `.opencode/` directory as a detection signal — the installer creates it in all repos regardless of which CLI is in use. Detection must be based on which CLI is actually executing the orchestration.
 
 2. **Dispatch lookup:**
    - Read `model_routing[<runtime>]` from `.ai/allowlist.json` for each slot

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -76,12 +76,12 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 | Phase | Agent | handoff.json path |
 |-------|-------|------------------|
 | Plan | Planner | `.quest/<id>/phase_01_plan/handoff.json` |
-| Plan Review | Slot A | `.quest/<id>/phase_01_plan/handoff_claude.json` |
-| Plan Review | Slot B | `.quest/<id>/phase_01_plan/handoff_codex.json` |
+| Plan Review | Slot A | `.quest/<id>/phase_01_plan/handoff_reviewer_a.json` |
+| Plan Review | Slot B | `.quest/<id>/phase_01_plan/handoff_reviewer_b.json` |
 | Plan Review | Arbiter | `.quest/<id>/phase_01_plan/handoff_arbiter.json` |
 | Build | Builder | `.quest/<id>/phase_02_implementation/handoff.json` |
-| Code Review | Slot A | `.quest/<id>/phase_03_review/handoff_claude.json` |
-| Code Review | Slot B | `.quest/<id>/phase_03_review/handoff_codex.json` |
+| Code Review | Slot A | `.quest/<id>/phase_03_review/handoff_reviewer_a.json` |
+| Code Review | Slot B | `.quest/<id>/phase_03_review/handoff_reviewer_b.json` |
 | Fix | Fixer | `.quest/<id>/phase_03_review/handoff_fixer.json` |
 
 The orchestrator NEVER reads full review files, plan content, or build output for routing decisions. Only handoff.json (and, for Step 3.5, the plan file itself as a bounded exception).
@@ -97,7 +97,7 @@ The orchestrator NEVER reads full review files, plan content, or build output fo
 
 Use `plan_iteration` for plan/plan_review phases, `fix_iteration` for code_review/fix phases, and `1` for build (single pass).
 Set `runtime` to the runtime actually used for that invocation (as detected via Runtime Detection above: `claude`, `opencode`, or `codex`).
-Never infer runtime from the agent label/name (for example `slot_a_claude`); labels are role identifiers, not backend evidence.
+Never infer runtime from the agent label/name (for example `reviewer_a`); labels are role identifiers, not backend evidence.
 
 Runtime attribution rule (authoritative):
 - Log `runtime=claude` only when the invocation actually used Claude `Task(...)`.
@@ -107,12 +107,12 @@ Runtime attribution rule (authoritative):
 **Example log for a quest with 2 plan iterations:**
 ```
 2026-02-15T00:12:00Z | phase=plan | agent=planner | runtime=claude | iter=1 | handoff_json=found | source=handoff_json
-2026-02-15T00:15:00Z | phase=plan_review | agent=slot_a_claude | runtime=claude | iter=1 | handoff_json=found | source=handoff_json
-2026-02-15T00:15:00Z | phase=plan_review | agent=slot_b_codex | runtime=codex | iter=1 | handoff_json=missing | source=text_fallback
+2026-02-15T00:15:00Z | phase=plan_review | agent=reviewer_a | runtime=claude | iter=1 | handoff_json=found | source=handoff_json
+2026-02-15T00:15:00Z | phase=plan_review | agent=reviewer_b | runtime=claude | iter=1 | handoff_json=missing | source=text_fallback
 2026-02-15T00:18:00Z | phase=plan_review | agent=arbiter | runtime=claude | iter=1 | handoff_json=found | source=handoff_json
 2026-02-15T00:25:00Z | phase=plan | agent=planner | runtime=claude | iter=2 | handoff_json=found | source=handoff_json
-2026-02-15T00:28:00Z | phase=plan_review | agent=slot_a_claude | runtime=claude | iter=2 | handoff_json=found | source=handoff_json
-2026-02-15T00:28:00Z | phase=plan_review | agent=slot_b_codex | runtime=codex | iter=2 | handoff_json=found | source=handoff_json
+2026-02-15T00:28:00Z | phase=plan_review | agent=reviewer_a | runtime=claude | iter=2 | handoff_json=found | source=handoff_json
+2026-02-15T00:28:00Z | phase=plan_review | agent=reviewer_b | runtime=claude | iter=2 | handoff_json=found | source=handoff_json
 2026-02-15T00:31:00Z | phase=plan_review | agent=arbiter | runtime=claude | iter=2 | handoff_json=found | source=handoff_json
 ```
 
@@ -200,8 +200,8 @@ gates.max_plan_iterations (default: 4)
 4. **Invoke BOTH Plan Reviewers IN PARALLEL** (same message, two dispatch calls):
 
    Two different models review independently for model diversity. Resolve each slot from `model_routing[runtime]`:
-   - **Slot A**: dispatch via `model_routing[runtime].reviewer_a` → `.quest/<id>/phase_01_plan/review_claude.md`
-   - **Slot B**: dispatch via `model_routing[runtime].reviewer_b` → `.quest/<id>/phase_01_plan/review_codex.md`
+   - **Slot A**: dispatch via `model_routing[runtime].reviewer_a` → `.quest/<id>/phase_01_plan/review_reviewer_a.md`
+   - **Slot B**: dispatch via `model_routing[runtime].reviewer_b` → `.quest/<id>/phase_01_plan/review_reviewer_b.md`
 
    For each slot, read the routing config and invoke accordingly:
    - If `tool == "task"`: `Task(subagent_type: <subagent>, ...)`
@@ -222,8 +222,8 @@ gates.max_plan_iterations (default: 4)
      Quest brief: .quest/<id>/quest_brief.md
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
-     Write your review to: .quest/<id>/phase_01_plan/review_claude.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_claude.json
+     Write your review to: .quest/<id>/phase_01_plan/review_reviewer_a.md
+     Write handoff file to: .quest/<id>/phase_01_plan/handoff_reviewer_a.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -238,8 +238,8 @@ gates.max_plan_iterations (default: 4)
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
      List up to 5 issues, highest severity first.
-     Write your review to: .quest/<id>/phase_01_plan/review_claude.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_claude.json
+     Write your review to: .quest/<id>/phase_01_plan/review_reviewer_a.md
+     Write handoff file to: .quest/<id>/phase_01_plan/handoff_reviewer_a.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -259,8 +259,8 @@ gates.max_plan_iterations (default: 4)
      Quest brief: .quest/<id>/quest_brief.md
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
-     Write your review to: .quest/<id>/phase_01_plan/review_codex.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_codex.json
+     Write your review to: .quest/<id>/phase_01_plan/review_reviewer_b.md
+     Write handoff file to: .quest/<id>/phase_01_plan/handoff_reviewer_b.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -275,8 +275,8 @@ gates.max_plan_iterations (default: 4)
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
      List up to 5 issues, highest severity first.
-     Write your review to: .quest/<id>/phase_01_plan/review_codex.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_codex.json
+     Write your review to: .quest/<id>/phase_01_plan/review_reviewer_b.md
+     Write handoff file to: .quest/<id>/phase_01_plan/handoff_reviewer_b.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -285,7 +285,7 @@ gates.max_plan_iterations (default: 4)
    - Issue BOTH calls in the SAME message for parallel execution
    - Wait for BOTH to complete
    - Record the current wall-clock time as `dispatch_end`
-   - Read `.quest/<id>/phase_01_plan/handoff_claude.json` and `handoff_codex.json`
+   - Read `.quest/<id>/phase_01_plan/handoff_reviewer_a.json` and `handoff_reviewer_b.json`
    - Verify both review files exist (from handoff.artifacts)
    - Fallback: if either handoff.json missing or unparsable, parse text handoff from that response
 
@@ -306,8 +306,8 @@ gates.max_plan_iterations (default: 4)
 
      Quest brief: .quest/<id>/quest_brief.md
      Plan: .quest/<id>/phase_01_plan/plan.md
-     Review A: .quest/<id>/phase_01_plan/review_claude.md
-     Review B: .quest/<id>/phase_01_plan/review_codex.md
+     Review A: .quest/<id>/phase_01_plan/review_reviewer_a.md
+     Review B: .quest/<id>/phase_01_plan/review_reviewer_b.md
 
      Write verdict to: .quest/<id>/phase_01_plan/arbiter_verdict.md
      Write handoff file to: .quest/<id>/phase_01_plan/handoff_arbiter.json
@@ -417,7 +417,7 @@ After plan approval, present the plan interactively before proceeding to build.
    f. Return to Step 3, item 1:
       - Planner will be invoked with user_feedback.md referenced (per Step 3, item 2 -- Planner invocation above)
       - plan_iteration increments as normal
-      - Full review cycle (Claude slot A + Codex slot B + Arbiter) runs
+      - Full review cycle (Reviewer A + Reviewer B + Arbiter) runs
       - After approval, Step 3.5 presentation starts fresh from step 1
 
 ### Step 4: Build Phase
@@ -475,8 +475,8 @@ After plan approval, present the plan interactively before proceeding to build.
 4. **Invoke BOTH Code Reviewers IN PARALLEL** (same message, two dispatch calls):
 
    Two different models review independently for model diversity. Resolve each slot from `model_routing[runtime]`:
-   - **Slot A**: dispatch via `model_routing[runtime].code_reviewer_a` → `.quest/<id>/phase_03_review/review_claude.md`
-   - **Slot B**: dispatch via `model_routing[runtime].code_reviewer_b` → `.quest/<id>/phase_03_review/review_codex.md`
+   - **Slot A**: dispatch via `model_routing[runtime].code_reviewer_a` → `.quest/<id>/phase_03_review/review_reviewer_a.md`
+   - **Slot B**: dispatch via `model_routing[runtime].code_reviewer_b` → `.quest/<id>/phase_03_review/review_reviewer_b.md`
 
    For each slot, read the routing config and invoke accordingly:
    - If `tool == "task"`: `Task(subagent_type: <subagent>, ...)`
@@ -501,8 +501,8 @@ After plan approval, present the plan interactively before proceeding to build.
      Diff summary: <git diff --stat>
 
      Review ONLY the files listed above. Use git diff for details.
-     Write review to: .quest/<id>/phase_03_review/review_claude.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_claude.json
+     Write review to: .quest/<id>/phase_03_review/review_reviewer_a.md
+     Write handoff file to: .quest/<id>/phase_03_review/handoff_reviewer_a.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -521,8 +521,8 @@ After plan approval, present the plan interactively before proceeding to build.
 
      Review ONLY the files listed above.
      List up to 5 issues, highest severity first.
-     Write review to: .quest/<id>/phase_03_review/review_claude.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_claude.json
+     Write review to: .quest/<id>/phase_03_review/review_reviewer_a.md
+     Write handoff file to: .quest/<id>/phase_03_review/handoff_reviewer_a.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -546,8 +546,8 @@ After plan approval, present the plan interactively before proceeding to build.
      Diff summary: <git diff --stat>
 
      Review ONLY the files listed above. Use git diff for details.
-     Write review to: .quest/<id>/phase_03_review/review_codex.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_codex.json
+     Write review to: .quest/<id>/phase_03_review/review_reviewer_b.md
+     Write handoff file to: .quest/<id>/phase_03_review/handoff_reviewer_b.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -566,8 +566,8 @@ After plan approval, present the plan interactively before proceeding to build.
 
      Review ONLY the files listed above.
      List up to 5 issues, highest severity first.
-     Write review to: .quest/<id>/phase_03_review/review_codex.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_codex.json
+     Write review to: .quest/<id>/phase_03_review/review_reviewer_b.md
+     Write handoff file to: .quest/<id>/phase_03_review/handoff_reviewer_b.json
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -577,7 +577,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Issue BOTH calls in the SAME message for parallel execution
    - Wait for BOTH to complete
    - Record the current wall-clock time as `dispatch_end`
-   - Read `.quest/<id>/phase_03_review/handoff_claude.json` and `handoff_codex.json`
+   - Read `.quest/<id>/phase_03_review/handoff_reviewer_a.json` and `handoff_reviewer_b.json`
    - Verify both review files exist (from handoff.artifacts)
    - Fallback: if either handoff.json missing or unparsable, parse text handoff from that response
 
@@ -600,7 +600,7 @@ After plan approval, present the plan interactively before proceeding to build.
      Review complete:
        Claude: "<summary from handoff or text fallback>"
        Codex: "<summary from handoff or text fallback>"
-     Full reviews at: .quest/<id>/phase_03_review/review_claude.md, .quest/<id>/phase_03_review/review_codex.md
+     Full reviews at: .quest/<id>/phase_03_review/review_reviewer_a.md, .quest/<id>/phase_03_review/review_reviewer_b.md
      ```
    - Do NOT read the full review files for routing or status display
 
@@ -618,8 +618,8 @@ After plan approval, present the plan interactively before proceeding to build.
 
 2. **Invoke Fixer** (dispatch via `model_routing[runtime].fixer`):
    - Prompt: Reference file paths only, do not embed content:
-     - Code review A: `.quest/<id>/phase_03_review/review_claude.md`
-     - Code review B: `.quest/<id>/phase_03_review/review_codex.md`
+     - Code review A: `.quest/<id>/phase_03_review/review_reviewer_a.md`
+     - Code review B: `.quest/<id>/phase_03_review/review_reviewer_b.md`
      - Changed files: <file list from git diff>
      - Quest brief: `.quest/<id>/quest_brief.md`
      - Plan: `.quest/<id>/phase_01_plan/plan.md`
@@ -632,7 +632,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - Read `.quest/<id>/phase_03_review/handoff_fixer.json` for status/routing
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
-3. **Clear stale handoff files:** Delete any existing `handoff_claude.json` and `handoff_codex.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
+3. **Clear stale handoff files:** Delete any existing `handoff_reviewer_a.json` and `handoff_reviewer_b.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
 
 4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
@@ -685,12 +685,12 @@ After plan approval, present the plan interactively before proceeding to build.
    - Runtime counts must come from logged runtime values only; do not infer runtime from role names.
    - Also split by role instance using `(phase, agent)` pairs (do NOT key by `agent` alone):
      - Planner = `(phase=plan, agent=planner)`
-     - Plan Review Slot A = `(phase=plan_review, agent=slot_a_claude)`
-     - Plan Review Slot B = `(phase=plan_review, agent=slot_b_codex)`
+     - Plan Review Slot A = `(phase=plan_review, agent=reviewer_a)`
+     - Plan Review Slot B = `(phase=plan_review, agent=reviewer_b)`
      - Arbiter = `(phase=plan_review, agent=arbiter)`
      - Builder = `(phase=build, agent=builder)`
-     - Code Review Slot A = `(phase=code_review, agent=slot_a_claude)`
-     - Code Review Slot B = `(phase=code_review, agent=slot_b_codex)`
+     - Code Review Slot A = `(phase=code_review, agent=reviewer_a)`
+     - Code Review Slot B = `(phase=code_review, agent=reviewer_b)`
      - Fixer = `(phase=fix, agent=fixer)`
    - For each role instance, report `X/Y` where:
      - `Y` = total observed invocations for that exact `(phase, agent)` pair in the log
@@ -917,9 +917,9 @@ mcp__codex__codex(
   model: "gpt-5.3-codex",
   prompt: "Review .quest/<id>/phase_01_plan/plan.md
 
-  List any issues (max 5 bullets). Write to .quest/<id>/phase_01_plan/review_codex.md
+  List any issues (max 5 bullets). Write to .quest/<id>/phase_01_plan/review_reviewer_b.md
 
-  End with: ---HANDOFF--- STATUS: complete ARTIFACTS: .quest/<id>/phase_01_plan/review_codex.md NEXT: arbiter SUMMARY: <one line>"
+  End with: ---HANDOFF--- STATUS: complete ARTIFACTS: .quest/<id>/phase_01_plan/review_reviewer_b.md NEXT: arbiter SUMMARY: <one line>"
 )
 ```
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -21,6 +21,25 @@ Before Step 4 (Build Phase), the orchestrator and all agents MUST NOT edit sourc
 - Any implementation request received before Build must be captured as plan feedback (`.quest/<id>/phase_01_plan/user_feedback.md`) and deferred to Step 4.
 - If any pre-Build action would modify non-`.quest/**` files, STOP and ask the user whether to proceed to Build first.
 
+### Runtime Detection
+
+The orchestrator detects the current runtime at startup and reads dispatch config from `.ai/allowlist.json`:
+
+1. **Detection order:**
+   - If `.opencode/` directory exists and the orchestrator is running inside OpenCode: runtime = `opencode`
+   - If the environment is Codex (e.g., `spawn_agent`/`worker` tools available): runtime = `codex`
+   - Otherwise: runtime = `claude` (default)
+
+2. **Dispatch lookup:**
+   - Read `model_routing[<runtime>]` from `.ai/allowlist.json` for each slot
+   - For each slot, use the `tool`, `subagent`, `tier`, and/or `model` fields to determine how to invoke
+   - If `tool == "task"`: invoke `Task(subagent_type=<subagent>)`
+   - If `tool == "mcp"`: invoke `mcp__<server>__<server>(model=<model>)`
+   - If `tier` is set: resolve the concrete model via `model_tiers[<runtime>][<tier>]`
+   - If `model` is set explicitly: use that model directly (overrides tier)
+
+3. **Permissions** always come from `role_permissions` in the allowlist (shared across all runtimes).
+
 ### Context Retention Rule
 
 After every subagent invocation (`Task` or `mcp__codex__codex`), the orchestrator retains ONLY:
@@ -71,11 +90,11 @@ The orchestrator NEVER reads full review files, plan content, or build output fo
 
 **Format:**
 ```
-<timestamp> | phase=<phase> | agent=<agent_name> | runtime=claude|codex | iter=<plan_iteration or fix_iteration> | handoff_json=found|missing|unparsable | source=handoff_json|text_fallback
+<timestamp> | phase=<phase> | agent=<agent_name> | runtime=claude|opencode|codex | iter=<plan_iteration or fix_iteration> | handoff_json=found|missing|unparsable | source=handoff_json|text_fallback
 ```
 
 Use `plan_iteration` for plan/plan_review phases, `fix_iteration` for code_review/fix phases, and `1` for build (single pass).
-Set `runtime` to the runtime actually used for that invocation (`claude` or `codex`).
+Set `runtime` to the runtime actually used for that invocation (as detected via Runtime Detection above: `claude`, `opencode`, or `codex`).
 Never infer runtime from the agent label/name (for example `slot_a_claude`); labels are role identifiers, not backend evidence.
 
 Runtime attribution rule (authoritative):
@@ -155,7 +174,7 @@ gates.max_plan_iterations (default: 4)
 
 1. **Update state:** `plan_iteration += 1`, `status: in_progress`, `last_role: planner_agent`
 
-2. **Invoke Planner** (Claude `Task(subagent_type="planner")`):
+2. **Invoke Planner** (dispatch via `model_routing[runtime].planner`):
    - Prompt: Reference file paths only, do not embed artifact content:
      - Quest brief: `.quest/<id>/quest_brief.md`
      - Arbiter verdict (iteration 2+): `.quest/<id>/phase_01_plan/arbiter_verdict.md`
@@ -176,19 +195,23 @@ gates.max_plan_iterations (default: 4)
    - `codex_context_digest_path` (default: `.ai/context_digest.md`)
    - For plan review: treat `auto` as `full`. Use `fast` only if explicitly set.
 
-4. **Invoke BOTH Plan Reviewers IN PARALLEL** (same message, one Task call + one Codex call):
+4. **Invoke BOTH Plan Reviewers IN PARALLEL** (same message, two dispatch calls):
 
-   Two different models review independently for model diversity:
-   - **Slot A** (Claude): `Task(subagent_type="plan-reviewer")` → `.quest/<id>/phase_01_plan/review_claude.md`
-   - **Slot B** (Codex): `mcp__codex__codex` → `.quest/<id>/phase_01_plan/review_codex.md`
+   Two different models review independently for model diversity. Resolve each slot from `model_routing[runtime]`:
+   - **Slot A**: dispatch via `model_routing[runtime].reviewer_a` → `.quest/<id>/phase_01_plan/review_claude.md`
+   - **Slot B**: dispatch via `model_routing[runtime].reviewer_b` → `.quest/<id>/phase_01_plan/review_codex.md`
 
-   **Slot A — Claude Task agent** (full and fast modes):
+   For each slot, read the routing config and invoke accordingly:
+   - If `tool == "task"`: `Task(subagent_type: <subagent>, ...)`
+   - If `tool == "mcp"`: `mcp__<server>__<server>(model: <model>, ...)`
+   - If `tier` is set: resolve model via `model_tiers[runtime][tier]`
+
+   **Slot A** (full and fast modes):
 
    **Full mode** (default for plan review):
    ```
-   Task(
-     subagent_type: "plan-reviewer",
-     prompt: "You are the Plan Review Agent (Claude).
+   Dispatch via model_routing[runtime].reviewer_a:
+     prompt: "You are the Plan Review Agent (Slot A).
 
      Read your instructions: .skills/quest/agents/plan-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -202,13 +225,11 @@ gates.max_plan_iterations (default: 4)
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
-   )
    ```
    **Fast mode** (only if `review_mode: fast`):
    ```
-   Task(
-     subagent_type: "plan-reviewer",
-     prompt: "You are the Plan Review Agent (Claude).
+   Dispatch via model_routing[runtime].reviewer_a:
+     prompt: "You are the Plan Review Agent (Slot A).
 
      Read context digest: <codex_context_digest_path>
      Quest brief: .quest/<id>/quest_brief.md
@@ -220,16 +241,14 @@ gates.max_plan_iterations (default: 4)
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
-   )
    ```
 
-   **Slot B — Codex MCP** (full and fast modes):
+   **Slot B** (full and fast modes):
 
    **Full mode** (default for plan review):
    ```
-   mcp__codex__codex(
-     model: "gpt-5.3-codex",
-     prompt: "You are the Plan Review Agent (Codex).
+   Dispatch via model_routing[runtime].reviewer_b:
+     prompt: "You are the Plan Review Agent (Slot B).
 
      Read your instructions: .skills/quest/agents/plan-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -243,13 +262,11 @@ gates.max_plan_iterations (default: 4)
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
-   )
    ```
    **Fast mode** (only if `review_mode: fast`):
    ```
-   mcp__codex__codex(
-     model: "gpt-5.3-codex",
-     prompt: "You are the Plan Review Agent (Codex).
+   Dispatch via model_routing[runtime].reviewer_b:
+     prompt: "You are the Plan Review Agent (Slot B).
 
      Read context digest: <codex_context_digest_path>
      Quest brief: .quest/<id>/quest_brief.md
@@ -261,7 +278,6 @@ gates.max_plan_iterations (default: 4)
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
-   )
    ```
    - **Before issuing the calls**, record the current wall-clock time as `dispatch_start`
    - Issue BOTH calls in the SAME message for parallel execution
@@ -279,7 +295,7 @@ gates.max_plan_iterations (default: 4)
       ```
       The wall-clock duration covers both agents. Since both calls are issued in the same message, they run concurrently by construction. Agent self-reported timestamps are unreliable and must NOT be used for parallelism verification.
 
-5. **Invoke Arbiter** (Claude `Task(subagent_type="arbiter")`):
+5. **Invoke Arbiter** (dispatch via `model_routing[runtime].arbiter`):
    - Use a short prompt with path references only:
      ```
      You are the Arbiter Agent.
@@ -415,7 +431,7 @@ After plan approval, present the plan interactively before proceeding to build.
 
 2. **Update state:** `phase: building`, `status: in_progress`, `last_role: builder_agent`
 
-3. **Invoke Builder** (Claude `Task(subagent_type="builder")`):
+3. **Invoke Builder** (dispatch via `model_routing[runtime].builder`):
    - Prompt: Reference file paths only, do not embed content:
      - Approved plan: `.quest/<id>/phase_01_plan/plan.md`
      - Quest brief: `.quest/<id>/quest_brief.md`
@@ -454,19 +470,23 @@ After plan approval, present the plan interactively before proceeding to build.
      - If file_count ≤ max_files AND loc_total ≤ max_loc → **fast**
      - Otherwise → **full**
 
-4. **Invoke BOTH Code Reviewers IN PARALLEL** (same message, one Task call + one Codex call):
+4. **Invoke BOTH Code Reviewers IN PARALLEL** (same message, two dispatch calls):
 
-   Two different models review independently for model diversity:
-   - **Slot A** (Claude): `Task(subagent_type="code-reviewer")` → `.quest/<id>/phase_03_review/review_claude.md`
-   - **Slot B** (Codex): `mcp__codex__codex` → `.quest/<id>/phase_03_review/review_codex.md`
+   Two different models review independently for model diversity. Resolve each slot from `model_routing[runtime]`:
+   - **Slot A**: dispatch via `model_routing[runtime].code_reviewer_a` → `.quest/<id>/phase_03_review/review_claude.md`
+   - **Slot B**: dispatch via `model_routing[runtime].code_reviewer_b` → `.quest/<id>/phase_03_review/review_codex.md`
 
-   **Slot A — Claude Task agent** (full and fast modes):
+   For each slot, read the routing config and invoke accordingly:
+   - If `tool == "task"`: `Task(subagent_type: <subagent>, ...)`
+   - If `tool == "mcp"`: `mcp__<server>__<server>(model: <model>, ...)`
+   - If `tier` is set: resolve model via `model_tiers[runtime][tier]`
+
+   **Slot A** (full and fast modes):
 
    **Full mode**:
    ```
-   Task(
-     subagent_type: "code-reviewer",
-     prompt: "You are the Code Review Agent (Claude).
+   Dispatch via model_routing[runtime].code_reviewer_a:
+     prompt: "You are the Code Review Agent (Slot A).
 
      Read your instructions: .skills/quest/agents/code-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -484,13 +504,11 @@ After plan approval, present the plan interactively before proceeding to build.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
-   )
    ```
    **Fast mode**:
    ```
-   Task(
-     subagent_type: "code-reviewer",
-     prompt: "You are the Code Review Agent (Claude).
+   Dispatch via model_routing[runtime].code_reviewer_a:
+     prompt: "You are the Code Review Agent (Slot A).
 
      Read context digest: <codex_context_digest_path>
      Quest: .quest/<id>/quest_brief.md
@@ -506,16 +524,14 @@ After plan approval, present the plan interactively before proceeding to build.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
-   )
    ```
 
-   **Slot B — Codex MCP** (full and fast modes):
+   **Slot B** (full and fast modes):
 
    **Full mode**:
    ```
-   mcp__codex__codex(
-     model: "gpt-5.3-codex",
-     prompt: "You are the Code Review Agent (Codex).
+   Dispatch via model_routing[runtime].code_reviewer_b:
+     prompt: "You are the Code Review Agent (Slot B).
 
      Read your instructions: .skills/quest/agents/code-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -533,13 +549,11 @@ After plan approval, present the plan interactively before proceeding to build.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
-   )
    ```
    **Fast mode**:
    ```
-   mcp__codex__codex(
-     model: "gpt-5.3-codex",
-     prompt: "You are the Code Review Agent (Codex).
+   Dispatch via model_routing[runtime].code_reviewer_b:
+     prompt: "You are the Code Review Agent (Slot B).
 
      Read context digest: <codex_context_digest_path>
      Quest: .quest/<id>/quest_brief.md
@@ -555,7 +569,6 @@ After plan approval, present the plan interactively before proceeding to build.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
-   )
    ```
    - **Note:** The `<file list>` and `<git diff --stat>` values embedded in these prompts are intentional small metadata (summary statistics and file names, typically a few lines). This is operational data for scoping the review, not subagent artifact content, and does not conflict with the Context Retention Rule.
    - **Before issuing the calls**, record the current wall-clock time as `dispatch_start`
@@ -601,7 +614,7 @@ After plan approval, present the plan interactively before proceeding to build.
 
 1. **Update state:** `phase: fixing`, `fix_iteration += 1`, `last_role: fixer_agent`
 
-2. **Invoke Fixer** (Claude `Task(subagent_type="fixer")`):
+2. **Invoke Fixer** (dispatch via `model_routing[runtime].fixer`):
    - Prompt: Reference file paths only, do not embed content:
      - Code review A: `.quest/<id>/phase_03_review/review_claude.md`
      - Code review B: `.quest/<id>/phase_03_review/review_codex.md`
@@ -824,19 +837,23 @@ If any agent returns `STATUS: needs_human`:
 
 ### Agent-to-Tool Mapping
 
-| Role | Tool | Model |
-|------|------|-------|
-| Planner | `Task(subagent_type="planner")` | Claude |
-| Plan Reviewer Slot A | `Task(subagent_type="plan-reviewer")` | Claude |
-| Plan Reviewer Slot B | `mcp__codex__codex` | Codex (GPT) |
-| Arbiter | `Task(subagent_type="arbiter")` | Claude |
-| Builder | `Task(subagent_type="builder")` | Claude |
-| Code Reviewer Slot A | `Task(subagent_type="code-reviewer")` | Claude |
-| Code Reviewer Slot B | `mcp__codex__codex` | Codex (GPT) |
-| Fixer | `Task(subagent_type="fixer")` | Claude |
+Dispatch for each slot is determined by `model_routing[runtime]` in `.ai/allowlist.json`. The table below shows the slot names and their default routing for the `claude` runtime:
 
-**Model diversity** in review phases gives independent perspectives from different model families. The Arbiter (Claude) synthesizes both reviews.
-This table shows default intent, not guaranteed runtime per environment. If roles are executed through Codex-backed tools, runtime attribution in `context_health.log` must record `codex`.
+| Slot | Default Tool (claude runtime) | Subagent |
+|------|------|-------|
+| `planner` | `Task(subagent_type="planner")` | planner |
+| `reviewer_a` | `Task(subagent_type="plan-reviewer")` | plan-reviewer |
+| `reviewer_b` | `mcp__codex__codex` | plan-reviewer |
+| `arbiter` | `Task(subagent_type="arbiter")` | arbiter |
+| `builder` | `Task(subagent_type="builder")` | builder |
+| `code_reviewer_a` | `Task(subagent_type="code-reviewer")` | code-reviewer |
+| `code_reviewer_b` | `mcp__codex__codex` | code-reviewer |
+| `fixer` | `Task(subagent_type="fixer")` | fixer |
+
+For other runtimes (`opencode`, `codex`), read `model_routing[runtime]` to determine the tool, subagent, tier, and/or model for each slot.
+
+**Model diversity** in review phases gives independent perspectives from different model families. The Arbiter synthesizes both reviews.
+This table shows default intent for the `claude` runtime, not guaranteed runtime per environment. If roles are executed through different tools, runtime attribution in `context_health.log` must record the actual runtime used.
 
 ### Codex MCP Prompt Pattern
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you skip this, Quest will use Claude for all roles (still works, just single-
 
 ## OpenCode
 
-Quest can run from the OpenCode runtime using the `$quest` command. OpenCode uses different models (e.g., big-pickle, minimax) as agents.
+Quest can run from the OpenCode runtime using the `/quest` command. OpenCode uses different models (e.g., big-pickle, minimax) as agents.
 
 ### Prerequisites
 
@@ -167,10 +167,10 @@ opencode
 
 ```bash
 # Run Quest from OpenCode
-$quest "Add a loading skeleton to the user list"
+/quest "Add a loading skeleton to the user list"
 
 # Resume a previous quest
-$quest feature-x_2026-02-27__1200
+/quest feature-x_2026-02-27__1200
 ```
 
 For detailed instructions, see [OpenCode Quickstart Guide](docs/guides/opencode-quickstart.md).

--- a/README.md
+++ b/README.md
@@ -146,6 +146,35 @@ claude mcp add codex-cli -- npx -y codex-mcp-server
 
 If you skip this, Quest will use Claude for all roles (still works, just single-model).
 
+## OpenCode
+
+Quest can run from the OpenCode runtime using the `$quest` command. OpenCode uses different models (e.g., big-pickle, minimax) as agents.
+
+### Prerequisites
+
+- **OpenCode CLI** - Install from [https://opencode.ai/docs](https://opencode.ai/docs)
+
+### Quick Setup
+
+```bash
+# Copy .opencode/ to your repository
+cp -r .opencode/ /path/to/your-repo/
+cd your-repo
+opencode
+```
+
+### Usage
+
+```bash
+# Run Quest from OpenCode
+$quest "Add a loading skeleton to the user list"
+
+# Resume a previous quest
+$quest feature-x_2026-02-27__1200
+```
+
+For detailed instructions, see [OpenCode Quickstart Guide](docs/guides/opencode-quickstart.md).
+
 ## Quick Start
 
 ### Option A: Use the Installer (Recommended)

--- a/docs/guides/opencode-quickstart.md
+++ b/docs/guides/opencode-quickstart.md
@@ -1,0 +1,122 @@
+---
+title: OpenCode Quickstart Guide
+description: How to install and run Quest from OpenCode runtime
+---
+
+# OpenCode Quickstart Guide
+
+This guide explains how to run Quest from the OpenCode runtime. If you're using Claude Code instead, see [Quest Setup Guide](quest_setup.md).
+
+## Prerequisites
+
+### Required: OpenCode CLI
+
+Install OpenCode following the official documentation:
+- Visit [https://opencode.ai/docs](https://opencode.ai/docs) for installation instructions
+- Verify installation:
+  ```bash
+  opencode --version
+  ```
+
+## Installation
+
+### Step 1: Copy OpenCode Configuration
+
+Copy the `.opencode/` directory to your repository root:
+
+```bash
+# From the Quest repository
+cp -r .opencode/ /path/to/your-repo/
+```
+
+### Step 2: Verify Installation
+
+```bash
+# Start OpenCode in your repository
+opencode
+
+# Quest should be available via $quest command
+$quest "your task description"
+```
+
+## Directory Structure
+
+The `.opencode/` directory contains:
+
+```
+.opencode/
+├── opencode.json      # OpenCode configuration (agents, commands, models)
+├── agents/           # Portable role definitions
+│   ├── planner.md
+│   ├── plan-reviewer.md
+│   ├── builder.md
+│   ├── code-reviewer.md
+│   ├── arbiter.md
+│   └── fixer.md
+├── skills/            # Skill procedures
+│   └── quest/
+│       └── SKILL.md  # Quest orchestration skill
+└── commands/          # Command definitions
+    └── quest.md       # $quest command definition
+```
+
+## Running Your First Quest
+
+### Step 1: Start OpenCode
+
+```bash
+cd your-repo
+opencode
+```
+
+### Step 2: Run a Quest
+
+```bash
+# Basic quest
+$quest "Add a loading skeleton to the user list"
+
+# With specific requirements
+$quest "Add dark mode that persists in localStorage"
+
+# Resume a previous quest
+$quest feature-x_2026-02-27__1200
+```
+
+### Step 3: Human Approval Gates
+
+Quest will pause at key points for your approval:
+- **Plan Approval**: Review the implementation plan before building
+- **Code Review Approval**: Review changes before they're finalized
+
+Type `yes` to approve, `no` to request changes, or `abort` to cancel.
+
+## Configuration
+
+### Customize Agent Permissions
+
+Edit `.opencode/opencode.json` to configure agent permissions:
+
+```json
+{
+  "agent": {
+    "quest": {
+      "permission": {
+        "task": {
+          "builder": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+### Allowed Directories
+
+Quest validates file access through `.ai/allowlist.json`. See [Quest Setup Guide](quest_setup.md) for configuration details.
+
+## Next Steps
+
+- **[Quest Setup Guide](quest_setup.md)** - Full setup documentation for both runtimes
+- **[Quest Presentation](quest_presentation.md)** - How Quest works (with diagrams)
+- **[Input Routing Guide](quest_input_routing.md)** - How Quest evaluates your input
+- **[AGENTS.md](../../AGENTS.md)** - Customize coding rules for your project

--- a/docs/guides/opencode-quickstart.md
+++ b/docs/guides/opencode-quickstart.md
@@ -35,8 +35,8 @@ cp -r .opencode/ /path/to/your-repo/
 # Start OpenCode in your repository
 opencode
 
-# Quest should be available via $quest command
-$quest "your task description"
+# Quest should be available via /quest command
+/quest "your task description"
 ```
 
 ## Directory Structure
@@ -57,7 +57,7 @@ The `.opencode/` directory contains:
 │   └── quest/
 │       └── SKILL.md  # Quest orchestration skill
 └── commands/          # Command definitions
-    └── quest.md       # $quest command definition
+    └── quest.md       # /quest command definition
 ```
 
 ## Running Your First Quest
@@ -73,13 +73,13 @@ opencode
 
 ```bash
 # Basic quest
-$quest "Add a loading skeleton to the user list"
+/quest "Add a loading skeleton to the user list"
 
 # With specific requirements
-$quest "Add dark mode that persists in localStorage"
+/quest "Add dark mode that persists in localStorage"
 
 # Resume a previous quest
-$quest feature-x_2026-02-27__1200
+/quest feature-x_2026-02-27__1200
 ```
 
 ### Step 3: Human Approval Gates

--- a/ideas/unified-allowlist-routing.md
+++ b/ideas/unified-allowlist-routing.md
@@ -1,0 +1,321 @@
+# OpenCode Integration via Unified Allowlist Routing
+
+## Status
+idea
+
+## Purpose
+Enable Quest orchestration to run from OpenCode (alongside Claude Code and Codex) using a single unified allowlist with runtime-aware model routing.
+
+## Background
+
+Quest currently works in:
+- **Claude Code:** `/quest` command (stable)
+- **Codex:** `$quest` command (beta)
+
+OpenCode is an open-source AI coding CLI with 75+ provider support, a full agent/subagent system, and MCP server support. Users want to run Quest from OpenCode using its native models or any supported provider.
+
+### What users want
+- Run `/quest` from OpenCode with the same workflow (plan → review → build → fix)
+- Use OpenCode's default models (configurable per-slot)
+- Mix providers freely — e.g., Claude for planning, Trinity for review, Big Pickle for building
+- Keep Claude Code and Codex working unchanged
+
+### Options evaluated
+1. **Separate allowlist copy** (`allowlist-opencode.json`) — duplicates permissions, will drift
+2. **Pointer approach** (main allowlist references separate file) — still two files to maintain
+3. **Unified allowlist with runtime sections** — single source of truth, shared permissions, per-runtime model routing
+
+**Decision:** Option 3. One allowlist to rule them all.
+
+---
+
+## Research Findings (2026-02-27)
+
+### OpenCode's agent system — confirmed and capable
+
+- Subagents defined in `.opencode/agents/*.md` (markdown + YAML frontmatter) or `opencode.json`
+- **`task` tool** is OpenCode's equivalent of Claude Code's `Task(subagent_type=...)`
+- Per-agent `model` field in frontmatter or config (format: `provider/model-id`)
+- `mode: "subagent"` hides agents from primary UI — only AI-invocable
+- `permission` block controls which subagents an orchestrator can spawn
+- Full MCP server support (local + remote + OAuth)
+
+### OpenCode agent config format
+
+**In `opencode.json`:**
+```json
+{
+  "agent": {
+    "planner": {
+      "description": "Creates implementation plans",
+      "mode": "subagent",
+      "model": "anthropic/claude-opus-4-5-20251101",
+      "prompt": "{file:.opencode/agents/planner.md}",
+      "tools": { "write": true, "edit": true, "bash": true }
+    }
+  }
+}
+```
+
+**As markdown files** in `.opencode/agents/`:
+```yaml
+---
+description: Creates implementation plans
+mode: subagent
+model: anthropic/claude-opus-4-5-20251101
+tools:
+  write: true
+  edit: true
+---
+You are a Planner agent...
+```
+
+### OpenCode-native models available
+
+| Model | ID | Context | Notes |
+|-------|----|---------|-------|
+| **Trinity Large Preview** | `arcee-ai/trinity-large-preview` | 131K | 400B MoE, 13B active, free on OpenRouter |
+| **Big Pickle** | `opencode/big-pickle` | 200K | Stealth model via OpenCode Zen, 128K output, free (limited time) |
+
+### Key differences from Claude Code
+
+| Feature | Claude Code | OpenCode |
+|---------|------------|----------|
+| Spawn subagent | `Task(subagent_type="X")` | `task` tool (AI selects by agent description) |
+| Agent config | `.claude/agents/X.md` | `.opencode/agents/X.md` or `opencode.json` |
+| Model format | `sonnet`, `opus`, `haiku` | `provider/model-id` |
+| Cross-provider | Codex via MCP only | Native (any of 75+ providers) |
+| Parallel tasks | Yes (same message, two tool calls) | Unverified — may need sequential fallback |
+| Commands | `.skills/X/SKILL.md` | `.opencode/commands/X.md` or config |
+
+### What the first attempt built (reusable)
+
+The `.opencode/` scaffolding from the stalled quest is solid and should be kept:
+- `opencode.json` — agent definitions, command mappings, permission blocks
+- `.opencode/agents/*.md` — thin wrappers (planner, plan-reviewer, builder, code-reviewer, arbiter, fixer)
+- `.opencode/skills/quest/SKILL.md` — skill structure
+- `.opencode/commands/quest.md` — command definition
+
+What needs to change: agent wrappers should delegate to `.ai/roles/` instead of inlining instructions, and `opencode.json` should stop duplicating model choices.
+
+---
+
+## Proposed Design
+
+### Core principle: shared permissions, runtime-specific routing
+
+The allowlist has two kinds of config:
+1. **Shared across all runtimes:** permissions, gates, approval phases, review thresholds
+2. **Per-runtime:** which tool + model fills each orchestration slot
+
+Today these are tangled (model routing hardcoded in `SKILL.md`, permissions duplicated across files). The fix is to make the allowlist the single control surface for both.
+
+### Allowlist v3 schema
+
+```json
+{
+  "version": 3,
+
+  "auto_approve_phases": {
+    "plan_creation": true,
+    "plan_review": true,
+    "plan_refinement": true,
+    "implementation": false,
+    "code_review": true,
+    "fix_loop": false
+  },
+
+  "gates": {
+    "require_approval_before_commit": true,
+    "require_approval_before_push": true,
+    "require_approval_before_delete": true,
+    "max_plan_iterations": 4,
+    "max_fix_iterations": 3
+  },
+
+  "role_permissions": {
+    "planner": {
+      "file_write": [".quest/**", "docs/implementation/**"],
+      "file_read": ["**"],
+      "bash": ["find", "grep", "wc", "tree", "ls"]
+    },
+    "reviewer_a": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": []
+    },
+    "reviewer_b": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": []
+    },
+    "arbiter": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": []
+    },
+    "builder": {
+      "file_write": [".quest/**", "src/**", "lib/**", "tests/**", "scripts/**"],
+      "file_read": ["**"],
+      "bash": ["pytest", "npm test", "npm run build", "python", "pip", "npx"]
+    },
+    "code_reviewer_a": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["git diff", "git log", "git status"]
+    },
+    "code_reviewer_b": {
+      "file_write": [".quest/**"],
+      "file_read": ["**"],
+      "bash": ["git diff", "git log", "git status"]
+    },
+    "fixer": {
+      "file_write": [".quest/**", "src/**", "lib/**", "tests/**"],
+      "file_read": ["**"],
+      "bash": ["pytest", "npm test", "npm run build", "python"]
+    }
+  },
+
+  "model_routing": {
+    "claude": {
+      "planner":         { "tool": "task", "subagent": "planner" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer" },
+      "reviewer_b":      { "tool": "mcp",  "server": "codex", "model": "gpt-5.2" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter" },
+      "builder":         { "tool": "task", "subagent": "builder" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer" },
+      "code_reviewer_b": { "tool": "mcp",  "server": "codex", "model": "gpt-5.2" },
+      "fixer":           { "tool": "task", "subagent": "fixer" }
+    },
+    "opencode": {
+      "planner":         { "tool": "task", "subagent": "planner",       "tier": "advanced" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer", "tier": "advanced" },
+      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer", "tier": "standard" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter",       "tier": "advanced" },
+      "builder":         { "tool": "task", "subagent": "builder",       "tier": "advanced" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer", "tier": "advanced" },
+      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer", "tier": "standard" },
+      "fixer":           { "tool": "task", "subagent": "fixer",         "tier": "advanced" }
+    },
+    "codex": {
+      "planner":         { "tool": "task", "subagent": "planner" },
+      "reviewer_a":      { "tool": "task", "subagent": "plan-reviewer" },
+      "reviewer_b":      { "tool": "task", "subagent": "plan-reviewer" },
+      "arbiter":         { "tool": "task", "subagent": "arbiter" },
+      "builder":         { "tool": "task", "subagent": "builder" },
+      "code_reviewer_a": { "tool": "task", "subagent": "code-reviewer" },
+      "code_reviewer_b": { "tool": "task", "subagent": "code-reviewer" },
+      "fixer":           { "tool": "task", "subagent": "fixer" }
+    }
+  },
+
+  "model_tiers": {
+    "opencode": {
+      "quick":    "anthropic/claude-haiku-4-5-20250307",
+      "standard": "anthropic/claude-sonnet-4-5-20251101",
+      "advanced": "anthropic/claude-opus-4-5-20251101"
+    }
+  },
+
+  "review_mode": "auto",
+  "fast_review_thresholds": {
+    "max_files": 5,
+    "max_loc": 200
+  }
+}
+```
+
+### How the workflow reads it
+
+```
+1. Detect runtime (claude | opencode | codex)
+2. Read model_routing[runtime] for each slot
+3. For each slot:
+   - If tool == "task": invoke Task(subagent_type=subagent)
+     - If tier set: resolve via model_tiers[runtime][tier]
+   - If tool == "mcp": invoke mcp__<server>__<server>(model=model)
+4. Permissions always come from role_permissions (shared)
+```
+
+The workflow becomes runtime-agnostic. The allowlist drives everything.
+
+### Experimenting with opencode-native models
+
+To try all-opencode-native models, change `model_tiers.opencode`:
+
+```json
+"model_tiers": {
+  "opencode": {
+    "quick":    "anthropic/claude-haiku-4-5-20250307",
+    "standard": "arcee-ai/trinity-large-preview",
+    "advanced": "opencode/big-pickle"
+  }
+}
+```
+
+Every slot mapped to "standard" or "advanced" picks up the new models. No other changes needed.
+
+To mix providers per-slot, override with an explicit model in model_routing:
+
+```json
+"reviewer_b": { "tool": "task", "subagent": "plan-reviewer", "model": "openai/gpt-5.2" }
+```
+
+`model` takes precedence over `tier` when both are present.
+
+---
+
+## File Changes
+
+### Keep from first attempt
+- `.opencode/agents/*.md` — update to delegate to `.ai/roles/` instead of inlining instructions
+- `.opencode/skills/quest/SKILL.md` — rewrite to use runtime-agnostic dispatch
+- `opencode.json` — keep structure, remove per-agent `model` fields (allowlist drives models)
+- `.opencode/commands/quest.md` — keep as-is
+
+### Modify
+- `.ai/allowlist.json` — bump to version 3, add `model_routing` + `model_tiers`
+- `SKILL.md` (both Claude and OpenCode versions) — read routing from allowlist instead of hardcoding `mcp__codex__codex`
+- `.opencode/agents/*.md` — delegate to `.ai/roles/*.md` (portable role definitions)
+
+### Delete
+- `.ai/allowlist-opencode.json` — absorbed into unified allowlist
+
+---
+
+## Open Questions
+
+1. **Parallel task invocation in OpenCode** — does it support two `task` calls in the same turn? The current OpenCode SKILL.md notes "may not support true parallel." If not, reviewer_a and reviewer_b run sequentially. Not a blocker, just slower.
+
+2. **Runtime detection** — how does the workflow know it's running in opencode vs claude? Options:
+   - Check for `.opencode/` directory presence
+   - Explicit `runtime` field in allowlist (user sets it)
+   - Environment variable (`$OPENCODE_HOME` or similar)
+
+3. **OpenCode Zen availability** — Big Pickle is free "for a limited time." Need a fallback tier mapping for when it goes paid.
+
+4. **State management across subagent invocations** — Quest's orchestrator retains only artifact paths + one-line summaries between phases (Context Retention Rule). This works because state lives in `.quest/<id>/` files, not in conversation memory. OpenCode's `task` tool spawns independent sessions (navigable via `<Leader>+Right/Left`), so each subagent starts with a clean context — same as Claude Code's Task tool. The file-based handoff contract (HANDOFF block + artifact files) should transfer cleanly. **Needs verification:** does the parent agent reliably receive the subagent's final output text so it can parse the HANDOFF block? If not, the orchestrator falls back to reading artifact files directly (already works).
+
+---
+
+## Implementation Order
+
+1. Abandon stalled quest `opencode-integration_2026-02-27__1200`
+2. Start new quest with this design as the brief
+3. Steps:
+   a. Update allowlist schema to v3 with `model_routing` + `model_tiers`
+   b. Update `.opencode/agents/*.md` to delegate to `.ai/roles/`
+   c. Rewrite `.opencode/skills/quest/SKILL.md` with runtime-agnostic dispatch
+   d. Slim down `opencode.json` (remove model duplication)
+   e. Delete `.ai/allowlist-opencode.json`
+   f. Test with all-Anthropic tiers first, then swap in opencode-native models
+
+---
+
+## References
+- OpenCode docs: https://opencode.ai/docs/
+- OpenCode agents: https://opencode.ai/docs/agents/
+- OpenCode models: https://opencode.ai/docs/models/
+- OpenCode MCP: https://opencode.ai/docs/mcp-servers/
+- OpenCode config: https://opencode.ai/docs/config/
+- Trinity Large Preview: https://www.arcee.ai/blog/trinity-large

--- a/scripts/validate-quest-config.sh
+++ b/scripts/validate-quest-config.sh
@@ -25,6 +25,10 @@ When run without options, validates:
   - .ai/allowlist.json is valid JSON
   - .ai/allowlist.json matches schema (if ajv installed)
   - .skills/quest/agents/*.md and .ai/roles/quest_agent.md have required sections
+  - .opencode/opencode.json is valid JSON (if present)
+  - .opencode/agents/*.md have required frontmatter and ## Output section
+  - .opencode/skills/*/SKILL.md have valid frontmatter
+  - .opencode/commands/*.md have valid frontmatter
 EOF
   exit 0
 }
@@ -224,6 +228,176 @@ validate_roles() {
   done
 }
 
+# Validate OpenCode opencode.json
+validate_opencode_json() {
+  local opencode_json="$REPO_ROOT/.opencode/opencode.json"
+  if [ ! -f "$opencode_json" ]; then
+    fail ".opencode/opencode.json does not exist"
+    return
+  fi
+
+  if command -v jq &>/dev/null; then
+    if jq empty "$opencode_json" 2>/dev/null; then
+      pass ".opencode/opencode.json is valid JSON"
+    else
+      fail ".opencode/opencode.json is invalid JSON"
+    fi
+  else
+    # Pure bash: check for basic JSON structure
+    if head -c1 "$opencode_json" | grep -q '{' && tail -c2 "$opencode_json" | grep -q '}'; then
+      pass ".opencode/opencode.json appears to be JSON (install jq for full validation)"
+    else
+      fail ".opencode/opencode.json does not appear to be valid JSON"
+    fi
+  fi
+}
+
+# Validate OpenCode agent files have required frontmatter and sections
+validate_opencode_agents() {
+  local agents_dir="$REPO_ROOT/.opencode/agents"
+  if [ ! -d "$agents_dir" ]; then
+    fail ".opencode/agents/ directory does not exist"
+    return
+  fi
+
+  local agent_files=()
+  while IFS= read -r agent_file; do
+    agent_files+=("$agent_file")
+  done < <(find "$agents_dir" -name "*.md" ! -name "README.md" -type f | sort)
+
+  if [ "${#agent_files[@]}" -eq 0 ]; then
+    fail "No agent files found in .opencode/agents/"
+    return
+  fi
+
+  local agent_file
+  for agent_file in "${agent_files[@]}"; do
+    local filename
+    filename=$(basename "$agent_file")
+    local missing=""
+
+    # Check YAML frontmatter exists (--- at start)
+    if ! head -3 "$agent_file" | grep -q "^---"; then
+      missing="$missing YAML frontmatter,"
+    fi
+
+    # Check frontmatter contains name: field
+    if ! grep -q "^name:" "$agent_file"; then
+      missing="$missing name: field,"
+    fi
+
+    # Check frontmatter contains description: field
+    if ! grep -q "^description:" "$agent_file"; then
+      missing="$missing description: field,"
+    fi
+
+    # Check for ## Output section
+    if ! grep -q "^## Output" "$agent_file"; then
+      missing="$missing ## Output section,"
+    fi
+
+    if [ -z "$missing" ]; then
+      pass "$filename has all required frontmatter and sections"
+    else
+      missing="${missing%,}" # Remove trailing comma
+      fail "$filename missing:$missing"
+    fi
+  done
+}
+
+# Validate OpenCode skill files have valid frontmatter
+validate_opencode_skills() {
+  local skills_dir="$REPO_ROOT/.opencode/skills"
+  if [ ! -d "$skills_dir" ]; then
+    fail ".opencode/skills/ directory does not exist"
+    return
+  fi
+
+  local skill_files=()
+  while IFS= read -r skill_file; do
+    skill_files+=("$skill_file")
+  done < <(find "$skills_dir" -name "SKILL.md" -type f | sort)
+
+  if [ "${#skill_files[@]}" -eq 0 ]; then
+    fail "No SKILL.md files found in .opencode/skills/"
+    return
+  fi
+
+  local skill_file
+  for skill_file in "${skill_files[@]}"; do
+    local filename
+    filename=$(basename "$skill_file")
+    local skill_name
+    skill_name=$(dirname "$skill_file" | xargs basename)
+    local missing=""
+
+    # Check YAML frontmatter exists (--- at start)
+    if ! head -3 "$skill_file" | grep -q "^---"; then
+      missing="$missing YAML frontmatter,"
+    fi
+
+    # Check frontmatter contains name: field
+    if ! grep -q "^name:" "$skill_file"; then
+      missing="$missing name: field,"
+    fi
+
+    # Check frontmatter contains description: field
+    if ! grep -q "^description:" "$skill_file"; then
+      missing="$missing description: field,"
+    fi
+
+    if [ -z "$missing" ]; then
+      pass "$skill_name/SKILL.md has valid frontmatter"
+    else
+      missing="${missing%,}" # Remove trailing comma
+      fail "$skill_name/SKILL.md missing:$missing"
+    fi
+  done
+}
+
+# Validate OpenCode command files have valid frontmatter
+validate_opencode_commands() {
+  local commands_dir="$REPO_ROOT/.opencode/commands"
+  if [ ! -d "$commands_dir" ]; then
+    fail ".opencode/commands/ directory does not exist"
+    return
+  fi
+
+  local command_files=()
+  while IFS= read -r command_file; do
+    command_files+=("$command_file")
+  done < <(find "$commands_dir" -name "*.md" ! -name "README.md" -type f | sort)
+
+  if [ "${#command_files[@]}" -eq 0 ]; then
+    fail "No command files found in .opencode/commands/"
+    return
+  fi
+
+  local command_file
+  for command_file in "${command_files[@]}"; do
+    local filename
+    filename=$(basename "$command_file")
+    local missing=""
+
+    # Check YAML frontmatter exists (--- at start)
+    if ! head -3 "$command_file" | grep -q "^---"; then
+      missing="$missing YAML frontmatter,"
+    fi
+
+    # Check frontmatter contains description: field
+    if ! grep -q "^description:" "$command_file"; then
+      missing="$missing description: field,"
+    fi
+
+    if [ -z "$missing" ]; then
+      pass "$filename has valid frontmatter"
+    else
+      missing="${missing%,}" # Remove trailing comma
+      fail "$filename missing:$missing"
+    fi
+  done
+}
+
 echo "=== Quest Configuration Validation ==="
 echo ""
 
@@ -231,6 +405,16 @@ check_gitignore
 validate_json "$REPO_ROOT/.ai/allowlist.json"
 validate_schema
 validate_roles
+
+# OpenCode validation (if .opencode/ directory exists)
+if [ -d "$REPO_ROOT/.opencode" ]; then
+  validate_opencode_json
+  validate_opencode_agents
+  validate_opencode_skills
+  validate_opencode_commands
+else
+  echo -e "${GREEN}[SKIP]${NC} .opencode/ directory not found - skipping OpenCode validation"
+fi
 
 echo ""
 if [ $ERRORS -eq 0 ]; then


### PR DESCRIPTION
## Summary

### Previous commits (PR #46):
- Unify Quest configuration into a single `.ai/allowlist.json` (v3) with per-runtime model routing for Claude Code, OpenCode, and Codex
- Create 6 portable role definitions in `.ai/roles/` shared across all runtimes
- Update OpenCode agents to delegate to portable roles with runtime-specific wiring
- Standardize review file naming to `review_reviewer_a.md` / `review_reviewer_b.md` (runtime-neutral)
- Split reviewer agents into A/B with different models for actual model diversity (big-pickle vs minimax-m2.5-free)
- Add required metadata headers so all agents self-identify with model name in output

### New commit (this PR):
- **Add OpenCode support**: Extend validate-quest-config.sh with OpenCode validation functions
- **Add quickstart guide**: Create docs/guides/opencode-quickstart.md for OpenCode users
- **Update README**: Add OpenCode section with setup instructions
- **Fix agent files**: Add ## Output sections to builder.md and fixer.md (required by validation)
- **Update Quest skill**: Track state and ensure artifact persistence in .quest/ folder

## Test plan

- [x] Run `scripts/validate-quest-config.sh` — all validations pass including OpenCode checks
- [ ] Verify new quickstart guide renders correctly
- [ ] Verify README OpenCode section appears correctly
- [ ] Test OpenCode quest orchestration with new validation functions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Quest/Co-Authored by OpenCode (big-pickle + minimax-m2.5-free) in Collaboration with KjellKod