### PR TITLE
Default Quest build/fix to Codex and codify fallback behavior

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,9 @@
+# Skills Bootstrap Note
+
+More repository skills are defined under `.skills/`.
+
+To expose a repo skill to Codex session discovery, mirror it into `.agents/skills/`:
+
+```bash
+mkdir -p .agents/skills/<skill-name> && cp .skills/<skill-name>/SKILL.md .agents/skills/<skill-name>/SKILL.md
+```

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,5 +1,5 @@
-# Skills Bootstrap Note
-
-More repository skills are defined under `.skills/`.
-Review the `.skills/` directory for improved skill usage
+---
+name: README.md
+description: This directory has information about the `quest` skill. For more available skills, see this repository's root directory in `.skills`
+---
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,9 +1,5 @@
 # Skills Bootstrap Note
 
 More repository skills are defined under `.skills/`.
+Review the `.skills/` directory for improved skill usage
 
-To expose a repo skill to Codex session discovery, mirror it into `.agents/skills/`:
-
-```bash
-mkdir -p .agents/skills/<skill-name> && cp .skills/<skill-name>/SKILL.md .agents/skills/<skill-name>/SKILL.md
-```

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -17,10 +17,11 @@
     "planner": "opus",
     "plan_reviewer_a": "opus",
     "plan_reviewer_b": "gpt-5.3-codex",
-    "builder": "opus",
+    "builder": "gpt-5.3-codex",
     "code_reviewer_a": "opus",
     "code_reviewer_b": "gpt-5.3-codex",
-    "arbiter": "opus"
+    "arbiter": "opus",
+    "fixer": "gpt-5.3-codex"
   },
   "review_mode": "auto",
   "fast_review_thresholds": {

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -65,6 +65,11 @@ Max iterations controlled by `gates.max_plan_iterations` in allowlist.
 Intake -> Plan -> [Dual Review + Arbiter Loop] -> [Gate] -> Implement -> Code Review -> [Fix Loop] -> [Gate] -> Done
 ```
 
+Codex runtime policy for Quest:
+- Codex roles run non-interactive (`no questions`, `no needs_human`).
+- If a Codex role cannot comply, Quest retries once with explicit-assumption guidance, then falls back to the equivalent Claude role.
+- Human Q&A is used only when the Claude path returns `needs_human`.
+
 ## Allowlist
 
 The Creator controls quest permissions via `.ai/allowlist.json`:

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -38,15 +38,15 @@ The Quest Agent interprets your intent, matches brief references, and routes to 
 
 | Role | File | Tool | Purpose |
 |------|------|------|---------|
-| Quest Agent | (Claude Code itself) | Claude | Orchestration, gating |
-| Planner | `.skills/quest/agents/planner.md` | Claude | Write and refine plan artifacts |
-| Plan Reviewer (Claude) | `.skills/quest/agents/plan-reviewer.md` | Claude | Review plans (read-only) |
+| Quest Agent | (Claude Code itself) | Claude Opus (`opus`) | Orchestration, gating |
+| Planner | `.skills/quest/agents/planner.md` | Claude Opus (`opus`) | Write and refine plan artifacts |
+| Plan Reviewer (Claude) | `.skills/quest/agents/plan-reviewer.md` | Claude Opus (`opus`) | Review plans (read-only) |
 | Plan Reviewer (Codex) | `.skills/quest/agents/plan-reviewer.md` | Codex (`gpt-5.3-codex`) | Review plans (read-only) |
-| Arbiter | `.skills/quest/agents/arbiter.md` | Claude | Synthesize reviews, approve or iterate |
-| Builder | `.skills/quest/agents/builder.md` | Claude | Implement changes |
-| Code Reviewer (Claude) | `.skills/quest/agents/code-reviewer.md` | Claude | Review code (read-only) |
+| Arbiter | `.skills/quest/agents/arbiter.md` | Claude Opus (`opus`) | Synthesize reviews, approve or iterate |
+| Builder | `.skills/quest/agents/builder.md` | Codex (`gpt-5.3-codex`) by default; Claude fallback | Implement changes |
+| Code Reviewer (Claude) | `.skills/quest/agents/code-reviewer.md` | Claude Opus (`opus`) | Review code (read-only) |
 | Code Reviewer (Codex) | `.skills/quest/agents/code-reviewer.md` | Codex (`gpt-5.3-codex`) | Review code (read-only) |
-| Fixer | `.skills/quest/agents/fixer.md` | Claude | Fix review issues |
+| Fixer | `.skills/quest/agents/fixer.md` | Codex (`gpt-5.3-codex`) by default; Claude fallback | Fix review issues |
 
 ## Plan Phase Flow
 
@@ -70,6 +70,7 @@ Intake -> Plan -> [Dual Review + Arbiter Loop] -> [Gate] -> Implement -> Code Re
 The Creator controls quest permissions via `.ai/allowlist.json`:
 - `auto_approve_phases` — which phases need human approval
 - `arbiter.tool` — Arbiter model (`claude` by default)
+- `model_overrides` — default role model map (`planner`, `plan_reviewer_a`, `plan_reviewer_b`, `builder`, `code_reviewer_a`, `code_reviewer_b`, `arbiter`, `fixer`)
 - `review_mode` — `auto` (default), `fast`, or `full` for Codex reviews
 - `fast_review_thresholds` — file/LOC thresholds for auto fast mode
 - `codex_context_digest_path` — short context file used by Codex

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -32,6 +32,7 @@
 .claude/skills/quest/SKILL.md
 .claude/AGENTS.md
 .codex/AGENTS.md
+.agents/skills/README.md
 .agents/skills/quest/SKILL.md
 .skills/BOOTSTRAP.md
 .skills/README.md

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -51,10 +51,14 @@ Use this format:
 - **<Category>**:
   - Description of change
 
-## Test Plan
+## Validation
 - [ ] Concrete verification step describing what to do and what to expect
 - [ ] Another verification step
 Watch for: <known risk or edge case, if any>
+
+## Notes
+- Important implementation/deployment/reviewer context that is not obvious from the diff.
+- Do not repeat the Summary; only include unique, high-signal details reviewers should know.
 ```
 
 ### Summary section
@@ -101,7 +105,7 @@ Rules:
 - Omit categories with no changes. Only include what is relevant.
 - If the PR is very small (1-2 files), a flat bullet list is fine — do not force categories.
 
-### Test Plan section
+### Validation section
 
 Each checkbox should be a concrete verification step — what to do and what result to expect. A reviewer reading the list should be able to pull the branch and verify without guessing.
 
@@ -111,6 +115,15 @@ Rules:
 - Only include steps that a human needs to perform. Skip anything CI already covers (linting, syntax checks, type checks).
 - If there is a known risk or edge case worth watching, add a `Watch for:` line at the end — no checkbox, just a heads-up.
 - Keep it short. 2-5 steps is typical. If you need more, the PR may be too large.
+
+### Notes section
+
+Use `## Notes` for important context reviewers should know before merge or rollout.
+
+Rules:
+- Include only non-obvious, high-value context (e.g., follow-up work, rollout caveats, compatibility constraints, temporary limitations).
+- Do not duplicate the Summary section.
+- Keep it concise; omit the section content if there is nothing important to add.
 
 ### Bot-generated content
 

--- a/.skills/quest/agents/builder.md
+++ b/.skills/quest/agents/builder.md
@@ -4,7 +4,7 @@
 Implements the approved plan. Writes code, runs tests, produces a PR description.
 
 ## Tool
-Claude (`Task(subagent_type="builder")`)
+Codex (`mcp__codex__codex`) by default, with Claude (`Task(subagent_type="builder")`) as fallback.
 
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)

--- a/.skills/quest/agents/builder.md
+++ b/.skills/quest/agents/builder.md
@@ -6,6 +6,12 @@ Implements the approved plan. Writes code, runs tests, produces a PR description
 ## Tool
 Codex (`mcp__codex__codex`) by default, with Claude (`Task(subagent_type="builder")`) as fallback.
 
+When running on Codex, this role is non-interactive:
+- Do not ask questions.
+- Do not return `STATUS: needs_human`.
+- If context is incomplete, make explicit assumptions and continue.
+- If unsafe to proceed, return `STATUS: blocked`.
+
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
 - `AGENTS.md` (coding conventions and architecture boundaries)
@@ -49,6 +55,7 @@ SUMMARY: <one line>
 Both steps are required. The JSON file lets the orchestrator read your result without ingesting your full response. The text block is the backward-compatible fallback.
 
 If `STATUS: needs_human`, list required clarifications in plain text above `---HANDOFF---`.
+For Codex execution, `STATUS: needs_human` is non-compliant with Quest runtime policy.
 
 ## Allowed Actions
 - Read any file in the repo

--- a/.skills/quest/agents/code-reviewer.md
+++ b/.skills/quest/agents/code-reviewer.md
@@ -14,6 +14,7 @@ There are **two** Code Review Agent invocations on each review pass. They run **
 - **Tool:** Codex (`mcp__codex__codex`, model: `gpt-5.3-codex`)
 - **Artifact path:** `.quest/<id>/phase_03_review/review_codex.md`
 - **Perspective:** Independent second pass on the same implementation diff (GPT model family).
+- **Non-interactive rule:** Do not ask questions and do not return `needs_human`. Use explicit assumptions; if unsafe, return `blocked`.
 
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
@@ -67,6 +68,7 @@ SUMMARY: <one line>
 Both steps are required. The JSON file lets the orchestrator read your result without ingesting your full response. The text block is the backward-compatible fallback.
 
 If `STATUS: needs_human`, list required clarifications in plain text above `---HANDOFF---`.
+For Slot B (Codex), `STATUS: needs_human` is non-compliant with Quest runtime policy.
 
 If `NEXT: null`, the review passed with no blocking issues.
 If `NEXT: fixer`, there are issues to fix.

--- a/.skills/quest/agents/fixer.md
+++ b/.skills/quest/agents/fixer.md
@@ -6,6 +6,12 @@ Fixes issues identified by the Code Review Agent. Applies targeted fixes and re-
 ## Tool
 Codex (`mcp__codex__codex`) by default, with Claude (`Task(subagent_type="fixer")`) as fallback.
 
+When running on Codex, this role is non-interactive:
+- Do not ask questions.
+- Do not return `STATUS: needs_human`.
+- If context is incomplete, make explicit assumptions and continue.
+- If unsafe to proceed, return `STATUS: blocked`.
+
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
 - `AGENTS.md` (coding conventions and architecture boundaries)
@@ -52,6 +58,7 @@ SUMMARY: <one line>
 Both steps are required. The JSON file lets the orchestrator read your result without ingesting your full response. The text block is the backward-compatible fallback.
 
 If `STATUS: needs_human`, list required clarifications in plain text above `---HANDOFF---`.
+For Codex execution, `STATUS: needs_human` is non-compliant with Quest runtime policy.
 
 The fixer always hands back to `code_review` for re-review. The orchestrator enforces `max_fix_iterations`.
 

--- a/.skills/quest/agents/fixer.md
+++ b/.skills/quest/agents/fixer.md
@@ -4,7 +4,7 @@
 Fixes issues identified by the Code Review Agent. Applies targeted fixes and re-runs tests.
 
 ## Tool
-Claude (`Task(subagent_type="fixer")`)
+Codex (`mcp__codex__codex`) by default, with Claude (`Task(subagent_type="fixer")`) as fallback.
 
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)

--- a/.skills/quest/agents/plan-reviewer.md
+++ b/.skills/quest/agents/plan-reviewer.md
@@ -14,6 +14,7 @@ There are **two** Plan Review Agent invocations on every plan iteration. They ru
 - **Tool:** Codex (`mcp__codex__codex`, model: `gpt-5.3-codex`)
 - **Artifact path:** `.quest/<id>/phase_01_plan/review_codex.md`
 - **Perspective:** Independent second pass on the same plan (GPT model family).
+- **Non-interactive rule:** Do not ask questions and do not return `needs_human`. Use explicit assumptions; if unsafe, return `blocked`.
 
 ## Context Required (both instances)
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
@@ -73,6 +74,7 @@ SUMMARY: <one line>
 Both steps are required. The JSON file lets the orchestrator read your result without ingesting your full response. The text block is the backward-compatible fallback.
 
 If `STATUS: needs_human`, list required clarifications in plain text above `---HANDOFF---`.
+For Slot B (Codex), `STATUS: needs_human` is non-compliant with Quest runtime policy.
 
 ## Allowed Actions
 - Read any file in the repo

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -67,6 +67,15 @@ The orchestrator NEVER reads full review files, plan content, or build output fo
 
 **Codex MCP response handling:** After a `mcp__codex__codex` call returns, the orchestrator reads the corresponding `handoff.json` file and does NOT retain the Codex response body in working context. The response may still appear in the conversation history (platform limitation), but the orchestrator treats it as consumed and does not reference it for any subsequent decision.
 
+**Codex non-interactive contract (all `mcp__codex__codex` calls):**
+- Codex must not ask the user questions and must not return `STATUS: needs_human`.
+- If context is incomplete, Codex makes explicit assumptions in the artifact and continues.
+- If it cannot proceed safely, Codex returns `STATUS: blocked` with a concrete reason.
+- Orchestrator handling for Codex `needs_human`/non-compliant output:
+  1. Re-invoke the same Codex role once with a strict reminder: "no questions, no `needs_human`, make explicit assumptions."
+  2. If the second attempt is still non-compliant, missing handoff, or blocked, fall back to the equivalent Claude `Task` role for that step.
+  3. Only enter human Q&A if the Claude fallback returns `STATUS: needs_human`.
+
 **MANDATORY — Context health logging:** Every single time you read a handoff.json file (or fall back to text parsing), you MUST append one line to `.quest/<id>/logs/context_health.log` BEFORE making any routing decision. This is not optional. Do this for every agent, every phase, no exceptions. Create the `.quest/<id>/logs/` directory first if it does not exist.
 
 **Format:**
@@ -230,6 +239,7 @@ gates.max_plan_iterations (default: 4)
    mcp__codex__codex(
      model: "gpt-5.3-codex",
      prompt: "You are the Plan Review Agent (Codex).
+     Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
      Read your instructions: .skills/quest/agents/plan-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -250,6 +260,7 @@ gates.max_plan_iterations (default: 4)
    mcp__codex__codex(
      model: "gpt-5.3-codex",
      prompt: "You are the Plan Review Agent (Codex).
+     Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
      Read context digest: <codex_context_digest_path>
      Quest brief: .quest/<id>/quest_brief.md
@@ -431,6 +442,10 @@ After plan approval, present the plan interactively before proceeding to build.
    - Read `.quest/<id>/phase_02_implementation/handoff.json` for status/routing
    - Verify artifacts written (from handoff.artifacts)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
+   - If Codex path returns `needs_human`, malformed handoff, or `blocked`:
+     1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
+     2. If still non-compliant, invoke Claude fallback (`Task(subagent_type="builder")`) with the same artifact-path contract.
+     3. Only ask the user questions if the Claude fallback returns `needs_human`.
 
 4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
@@ -519,6 +534,7 @@ After plan approval, present the plan interactively before proceeding to build.
    mcp__codex__codex(
      model: "gpt-5.3-codex",
      prompt: "You are the Code Review Agent (Codex).
+     Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
      Read your instructions: .skills/quest/agents/code-reviewer.md
      Read context digest: <codex_context_digest_path>
@@ -543,6 +559,7 @@ After plan approval, present the plan interactively before proceeding to build.
    mcp__codex__codex(
      model: "gpt-5.3-codex",
      prompt: "You are the Code Review Agent (Codex).
+     Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
      Read context digest: <codex_context_digest_path>
      Quest: .quest/<id>/quest_brief.md
@@ -622,6 +639,10 @@ After plan approval, present the plan interactively before proceeding to build.
    - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_03_review/handoff_fixer.json` for status/routing
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
+   - If Codex path returns `needs_human`, malformed handoff, or `blocked`:
+     1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
+     2. If still non-compliant, invoke Claude fallback (`Task(subagent_type="fixer")`) with the same artifact-path contract.
+     3. Only ask the user questions if the Claude fallback returns `needs_human`.
 
 3. **Clear stale handoff files:** Delete any existing `handoff_claude.json` and `handoff_codex.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
 
@@ -793,9 +814,13 @@ After plan approval, present the plan interactively before proceeding to build.
 
 ---
 
-## Q&A Loop Pattern
+## Q&A Loop Pattern (Claude-only in normal operation)
 
-If any agent returns `STATUS: needs_human`:
+Normal rule:
+- Codex paths do not enter direct human Q&A. They retry once and then fall back to Claude.
+- Human Q&A is used when a Claude role returns `STATUS: needs_human`.
+
+If a Claude role returns `STATUS: needs_human`:
 
 1. Extract questions from the response (text before `---HANDOFF---`) -- this is an intentional, bounded content read for human interaction, similar to Step 3.5
 2. Present questions to user
@@ -917,7 +942,7 @@ mcp__codex__codex(
 ## Error Handling
 
 - If an agent fails to produce a handoff: Extract any artifacts from the response, log the error, ask user how to proceed
-- If Codex MCP fails: mark the step `blocked`, surface the failure, and ask user whether to retry
+- If Codex MCP fails: retry once with strict non-interactive reminder; if failure persists, fall back to equivalent Claude role; ask user only if fallback also cannot proceed
 - If max iterations reached: Stop, show current state, ask user for guidance
 - If artifact file missing after agent run: Try to extract from response text and write it
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -48,7 +48,11 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 2. Read the expected `handoff.json` file (tiny JSON, ~200 bytes)
 3. Use its `status`, `next`, `summary`, and `artifacts` fields for routing and user display
 4. Discard the full agent response -- do not retain, summarize, or process it
-5. **Fallback:** If handoff.json does not exist or cannot be parsed as valid JSON, parse the text `---HANDOFF---` block from the response (backward compatibility)
+5. **Deterministic precedence for missing/unparsable handoff.json:**
+   - **Claude invocation (Task):** If `handoff.json` is missing/unparsable, parse text `---HANDOFF---` as fallback.
+   - **Codex invocation (`mcp__codex__codex`):** Missing/unparsable `handoff.json` is non-compliant. Re-run the same Codex role once with a strict reminder.
+   - If the second Codex attempt is still non-compliant, missing/unparsable handoff, or `blocked`, invoke the equivalent Claude `Task` fallback for that step.
+   - Only after this retry/fallback chain, if the final attempt still has no parseable `handoff.json`, parse text `---HANDOFF---` as last-resort compatibility fallback.
 
 **Expected handoff.json locations:**
 
@@ -71,10 +75,11 @@ The orchestrator NEVER reads full review files, plan content, or build output fo
 - Codex must not ask the user questions and must not return `STATUS: needs_human`.
 - If context is incomplete, Codex makes explicit assumptions in the artifact and continues.
 - If it cannot proceed safely, Codex returns `STATUS: blocked` with a concrete reason.
-- Orchestrator handling for Codex `needs_human`/non-compliant output:
+- Orchestrator handling for Codex `needs_human`/non-compliant output and missing/unparsable handoff:
   1. Re-invoke the same Codex role once with a strict reminder: "no questions, no `needs_human`, make explicit assumptions."
-  2. If the second attempt is still non-compliant, missing handoff, or blocked, fall back to the equivalent Claude `Task` role for that step.
-  3. Only enter human Q&A if the Claude fallback returns `STATUS: needs_human`.
+  2. If the second attempt is still non-compliant, missing/unparsable handoff, or `blocked`, fall back to the equivalent Claude `Task` role for that step.
+  3. Only after retry + Claude fallback may text `---HANDOFF---` parsing be used as a last-resort compatibility path.
+  4. Only enter human Q&A if the Claude fallback returns `STATUS: needs_human`.
 
 **MANDATORY — Context health logging:** Every single time you read a handoff.json file (or fall back to text parsing), you MUST append one line to `.quest/<id>/logs/context_health.log` BEFORE making any routing decision. This is not optional. Do this for every agent, every phase, no exceptions. Create the `.quest/<id>/logs/` directory first if it does not exist.
 
@@ -280,7 +285,9 @@ gates.max_plan_iterations (default: 4)
    - Record the current wall-clock time as `dispatch_end`
    - Read `.quest/<id>/phase_01_plan/handoff_claude.json` and `handoff_codex.json`
    - Verify both review files exist (from handoff.artifacts)
-   - Fallback: if either handoff.json missing or unparsable, parse text handoff from that response
+   - Apply deterministic precedence from **Handoff File Polling**:
+     - Claude slot may use direct text fallback when handoff.json is missing/unparsable.
+     - Codex slot must retry once, then Claude fallback, before any text fallback routing.
 
    **Parallelism check (orchestrator-timed):**
    1. Create `.quest/<id>/logs/` directory if it doesn't exist
@@ -434,6 +441,7 @@ After plan approval, present the plan interactively before proceeding to build.
      - Approved plan: `.quest/<id>/phase_01_plan/plan.md`
      - Quest brief: `.quest/<id>/quest_brief.md`
    - Require the prompt to include:
+     - If using Codex path: `Read your instructions: .skills/quest/agents/builder.md`
      - Write output artifacts under: `.quest/<id>/phase_02_implementation/`
      - Write handoff file to: `.quest/<id>/phase_02_implementation/handoff.json` with schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
@@ -441,11 +449,11 @@ After plan approval, present the plan interactively before proceeding to build.
    - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_02_implementation/handoff.json` for status/routing
    - Verify artifacts written (from handoff.artifacts)
-   - Fallback: if handoff.json missing or unparsable, parse text handoff from response
-   - If Codex path returns `needs_human`, malformed handoff, or `blocked`:
+   - If Codex path returns `needs_human`, malformed output, missing/unparsable handoff, or `blocked`:
      1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
      2. If still non-compliant, invoke Claude fallback (`Task(subagent_type="builder")`) with the same artifact-path contract.
      3. Only ask the user questions if the Claude fallback returns `needs_human`.
+   - If the final selected attempt still has missing/unparsable handoff.json, parse text handoff from response as last-resort compatibility fallback.
 
 4. **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> reviewing` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
 
@@ -584,7 +592,9 @@ After plan approval, present the plan interactively before proceeding to build.
    - Record the current wall-clock time as `dispatch_end`
    - Read `.quest/<id>/phase_03_review/handoff_claude.json` and `handoff_codex.json`
    - Verify both review files exist (from handoff.artifacts)
-   - Fallback: if either handoff.json missing or unparsable, parse text handoff from that response
+   - Apply deterministic precedence from **Handoff File Polling**:
+     - Claude slot may use direct text fallback when handoff.json is missing/unparsable.
+     - Codex slot must retry once, then Claude fallback, before any text fallback routing.
 
    **Parallelism check (orchestrator-timed):**
    1. Create `.quest/<id>/logs/` directory if it doesn't exist
@@ -597,14 +607,14 @@ After plan approval, present the plan interactively before proceeding to build.
 5. **Check verdicts via handoff.json (with fallback):**
    - For each reviewer slot, use the `next` value obtained in step 4:
      - If handoff.json was successfully read → use its `next` and `summary` fields
-     - If fallback was triggered (handoff.json missing or unparsable) → use the `NEXT` and `SUMMARY` values parsed from the text `---HANDOFF---` block in step 4
+     - If fallback was triggered after applying deterministic precedence (retry/fallback chain) → use `NEXT` and `SUMMARY` from parsed text `---HANDOFF---`
    - If EITHER slot has `next: "fixer"` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> fixing` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Issues found, proceed to Step 6
    - If BOTH have `next: null` → **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json. Review passed! Update state: `phase: complete`, go to Step 7
    - Present summaries to user:
      ```
      Review complete:
-       Claude: "<summary from handoff or text fallback>"
-       Codex: "<summary from handoff or text fallback>"
+       Claude: "<summary from handoff or fallback>"
+       Codex: "<summary from handoff or fallback (after retry/fallback precedence)>"
      Full reviews at: .quest/<id>/phase_03_review/review_claude.md, .quest/<id>/phase_03_review/review_codex.md
      ```
    - Do NOT read the full review files for routing or status display
@@ -632,17 +642,18 @@ After plan approval, present the plan interactively before proceeding to build.
      - Quest brief: `.quest/<id>/quest_brief.md`
      - Plan: `.quest/<id>/phase_01_plan/plan.md`
    - Require the prompt to include:
+     - If using Codex path: `Read your instructions: .skills/quest/agents/fixer.md`
      - Write feedback to: `.quest/<id>/phase_03_review/review_fix_feedback_discussion.md`
      - Write handoff file to: `.quest/<id>/phase_03_review/handoff_fixer.json` with schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: code_review`
    - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_03_review/handoff_fixer.json` for status/routing
-   - Fallback: if handoff.json missing or unparsable, parse text handoff from response
-   - If Codex path returns `needs_human`, malformed handoff, or `blocked`:
+   - If Codex path returns `needs_human`, malformed output, missing/unparsable handoff, or `blocked`:
      1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
      2. If still non-compliant, invoke Claude fallback (`Task(subagent_type="fixer")`) with the same artifact-path contract.
      3. Only ask the user questions if the Claude fallback returns `needs_human`.
+   - If the final selected attempt still has missing/unparsable handoff.json, parse text handoff from response as last-resort compatibility fallback.
 
 3. **Clear stale handoff files:** Delete any existing `handoff_claude.json` and `handoff_codex.json` in `.quest/<id>/phase_03_review/` to prevent stale data from the previous review iteration being read when code reviewers are re-invoked.
 
@@ -651,7 +662,7 @@ After plan approval, present the plan interactively before proceeding to build.
 5. **Re-invoke BOTH Code Reviewers** (same as Step 5)
 
 6. **Check verdict (with fallback):**
-   - For each reviewer slot, use the `next` value obtained in step 5 (from handoff.json if available, or text fallback if not)
+   - For each reviewer slot, use the `next` value obtained in step 5 (handoff.json preferred; text fallback only after deterministic precedence)
    - If BOTH have `next: null` → Fixed!
      - **Validation gate:** Run `scripts/validate-quest-state.sh .quest/<id> complete` -- if non-zero, report output to user and STOP. Do NOT modify state.json.
      - Proceed to Step 7

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -415,7 +415,10 @@ After plan approval, present the plan interactively before proceeding to build.
 
 2. **Update state:** `phase: building`, `status: in_progress`, `last_role: builder_agent`
 
-3. **Invoke Builder** (Claude `Task(subagent_type="builder")`):
+3. **Invoke Builder** (default Codex `mcp__codex__codex`, Claude `Task` fallback):
+   - Read `model_overrides.builder` from allowlist (default: `gpt-5.3-codex`).
+   - If builder model is Codex, invoke via `mcp__codex__codex`.
+   - If builder model is Claude, invoke via `Task(subagent_type="builder")`.
    - Prompt: Reference file paths only, do not embed content:
      - Approved plan: `.quest/<id>/phase_01_plan/plan.md`
      - Quest brief: `.quest/<id>/quest_brief.md`
@@ -424,7 +427,7 @@ After plan approval, present the plan interactively before proceeding to build.
      - Write handoff file to: `.quest/<id>/phase_02_implementation/handoff.json` with schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: code_review`
-   - Wait for Task to complete
+   - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_02_implementation/handoff.json` for status/routing
    - Verify artifacts written (from handoff.artifacts)
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
@@ -601,7 +604,10 @@ After plan approval, present the plan interactively before proceeding to build.
 
 1. **Update state:** `phase: fixing`, `fix_iteration += 1`, `last_role: fixer_agent`
 
-2. **Invoke Fixer** (Claude `Task(subagent_type="fixer")`):
+2. **Invoke Fixer** (default Codex `mcp__codex__codex`, Claude `Task` fallback):
+   - Read `model_overrides.fixer` from allowlist (default: `gpt-5.3-codex`).
+   - If fixer model is Codex, invoke via `mcp__codex__codex`.
+   - If fixer model is Claude, invoke via `Task(subagent_type="fixer")`.
    - Prompt: Reference file paths only, do not embed content:
      - Code review A: `.quest/<id>/phase_03_review/review_claude.md`
      - Code review B: `.quest/<id>/phase_03_review/review_codex.md`
@@ -613,7 +619,7 @@ After plan approval, present the plan interactively before proceeding to build.
      - Write handoff file to: `.quest/<id>/phase_03_review/handoff_fixer.json` with schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: code_review`
-   - Wait for Task to complete
+   - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_03_review/handoff_fixer.json` for status/routing
    - Fallback: if handoff.json missing or unparsable, parse text handoff from response
 
@@ -826,16 +832,16 @@ If any agent returns `STATUS: needs_human`:
 
 | Role | Tool | Model |
 |------|------|-------|
-| Planner | `Task(subagent_type="planner")` | Claude |
-| Plan Reviewer Slot A | `Task(subagent_type="plan-reviewer")` | Claude |
+| Planner | `Task(subagent_type="planner")` | Claude Opus (`opus`) |
+| Plan Reviewer Slot A | `Task(subagent_type="plan-reviewer")` | Claude Opus (`opus`) |
 | Plan Reviewer Slot B | `mcp__codex__codex` | Codex (GPT) |
-| Arbiter | `Task(subagent_type="arbiter")` | Claude |
-| Builder | `Task(subagent_type="builder")` | Claude |
-| Code Reviewer Slot A | `Task(subagent_type="code-reviewer")` | Claude |
+| Arbiter | `Task(subagent_type="arbiter")` | Claude Opus (`opus`) |
+| Builder | `mcp__codex__codex` (default), `Task(subagent_type="builder")` (fallback) | Codex (GPT) default, Claude fallback |
+| Code Reviewer Slot A | `Task(subagent_type="code-reviewer")` | Claude Opus (`opus`) |
 | Code Reviewer Slot B | `mcp__codex__codex` | Codex (GPT) |
-| Fixer | `Task(subagent_type="fixer")` | Claude |
+| Fixer | `mcp__codex__codex` (default), `Task(subagent_type="fixer")` (fallback) | Codex (GPT) default, Claude fallback |
 
-**Model diversity** in review phases gives independent perspectives from different model families. The Arbiter (Claude) synthesizes both reviews.
+**Model diversity** in review phases gives independent perspectives from different model families. The Arbiter (Claude) synthesizes both reviews while implementation/fix defaults stay Codex-first.
 This table shows default intent, not guaranteed runtime per environment. If roles are executed through Codex-backed tools, runtime attribution in `context_health.log` must record `codex`.
 
 ### Codex MCP Prompt Pattern

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,36 +25,9 @@ This document defines the coding conventions and architecture boundaries for thi
 - Don't add "improvements" that weren't requested
 - Test real logic, skip trivial code (getters, imports, types)
 
-## Architecture Boundaries
-
-Customize this section for your project. Define what each directory/module is responsible for:
-
-```
-src/           # Application source code
-  components/  # UI components (if applicable)
-  services/    # Business logic and external integrations
-  utils/       # Shared utility functions
-lib/           # Shared libraries
-tests/         # Test files
-  unit/        # Unit tests
-  integration/ # Integration tests
-scripts/       # Build and utility scripts
-docs/          # Documentation
-  architecture/    # System design docs
-  implementation/  # Active and historical plans
-  guides/          # How-to guides
-```
-
-### Boundary Rules (customize for your project)
-
-1. **Components** only handle UI rendering and local state
-2. **Services** handle business logic and external API calls
-3. **Utils** are pure functions with no side effects
-4. **Tests** mock at service boundaries, not internal logic
-
 ## Testing Expectations
 
-- Bug fixes use TDD when practical (red → green → verify)
+- Bug fixes: add a test that reproduces the bug (fails first), fix the code without changing that test, then re-run it to verify it passes.
 - Unit tests in `tests/unit/`, integration tests in `tests/integration/`
 - Mock at boundaries (APIs, DBs, I/O), not internal logic
 - Test names describe behavior: `test_create_user_when_email_invalid_returns_400()`
@@ -82,6 +55,17 @@ This repository uses the `/quest` command for multi-agent feature development:
 
 See `.ai/quest.md` for full documentation.
 
+### Skills Discovery READ THIS
+Check this location for available skills. 
+1. `.skills` --> see .skills/SKILLS.md
+2. `.agents/skills/`
+
+### Skills Source of Truth & Precedence
+- Before starting any task, inspect `.skills/SKILLS.md` and `.agents/skills/` for available skills
+- Repo-local skill definitions are authoritative
+- Preloaded or session-provided skill lists are hints/fallbacks, not source of truth
+- If sources disagree, report the mismatch explicitly and follow repo-local definitions
+
 ### Allowlist Configuration
 
 Customize `.ai/allowlist.json` for your project's:
@@ -94,7 +78,7 @@ Customize `.ai/allowlist.json` for your project's:
 | Topic | Location |
 |-------|----------|
 | Quest orchestration | `.ai/quest.md` |
-| Available skills | `.skills/SKILLS.md` |
+| SKILLs directory  | `.skills/SKILLS.md` |
 | Quest setup guide | `docs/guides/quest_setup.md` |
 | Architecture | `docs/architecture/` (if present) |
 

--- a/ideas/quest-opencode-integration-from-official-guide.md
+++ b/ideas/quest-opencode-integration-from-official-guide.md
@@ -1,0 +1,281 @@
+# Idea: Quest OpenCode Integration from Official Guide
+
+## Execution Prompt (Read First)
+
+Use this with **Claude Opus 4.6** as the orchestrator (delegating implementation roles to Codex where configured):
+
+```txt
+Implement Quest OpenCode integration using the official OpenCode orchestration model.
+
+Execution mode:
+- You are the orchestrator.
+- Keep orchestration decisions in Claude.
+- Configure and validate Codex-backed subagent roles (implementer/fixer/reviewer-b) through config+markdown wiring.
+
+Constraints:
+- Do not use any v2/v3 branch logic.
+- Do not introduce a custom TypeScript driver.
+- Do not duplicate workflow text into large inline prompt files.
+- Keep changes minimal, explicit, and maintainable.
+
+Follow source docs listed under "Source Documents to Follow".
+Respect repo rules listed under "Repo Execution Constraints (Quest AGENTS.md)".
+
+Tasks:
+1) Implement all items in "Scope (In)" and none from "Scope (Out)".
+2) Enforce "Non-Interactive Subagent Contract":
+   - Codex path: no questions, never `needs_human`; use explicit assumptions or `blocked`.
+   - Claude fallback path: may return `needs_human` only when creator input is truly required.
+3) Implement "Runtime Observability Contract" as specified:
+   - JSONL in `.quest/<id>/logs/subagent_runtime.log`
+   - `event=start` before invoke and `event=finish` after handoff parse/fallback
+   - keep existing `context_health.log` behavior unchanged for handoff compliance
+4) Verify model IDs and report unresolved availability risks.
+5) Satisfy all "Acceptance Criteria".
+
+Deliverables:
+- Exact files changed
+- Why each change is needed
+- Any runtime caveats
+- A short smoke-test checklist
+```
+
+## Goal
+
+Implement Quest OpenCode integration using OpenCode's official model:
+- config + markdown orchestration
+- no custom runtime driver unless needed later
+- no branch archaeology or legacy duplication
+
+## Target Orchestration Model (Cross-Runtime)
+
+This is the **canonical model policy for implementing this idea with Quest now**.
+It is implementation-specific and does **not** change Quest's long-term default model policy in this repository.
+
+Use the same model philosophy across both planning and build/fix loops:
+- strongest reasoning model as orchestrator + reviewer A
+- strongest implementation model as implementer + reviewer B
+
+| Quest role | Model |
+|---|---|
+| Orchestrator | Claude Opus 4.6 |
+| Implementer | Codex 5.3 |
+| Reviewer A | Claude Opus 4.6 |
+| Reviewer B | Codex 5.3 |
+
+Application rule:
+- Planning loop: orchestrator -> planner worker -> review A + review B
+- Build/fix loop: orchestrator -> implementer/fixer worker -> review A + review B
+
+## Why This Exists
+
+We now have a clean orchestration guide in the OpenCode clone:
+- `packages/web/src/content/docs/orchestration.mdx`
+
+This idea document turns that guidance into a practical execution brief for Quest work.
+
+## Guiding Truths
+
+1. Subagents are session-based child runs, not plain function calls.
+2. Wiring and content are separate:
+   - wiring = agent mode, task permissions, command routing
+   - content = orchestration instructions and role prompts
+3. Start with minimal config/markdown orchestration.
+4. Add code-driver logic only if real runtime limits appear.
+5. If your runtime path does not expose OpenCode question reply flow, subagents must run non-interactively.
+
+## Non-Interactive Subagent Contract
+
+For this integration, subagents should not block on human Q&A.
+
+- Primary agent dispatch: `permission.task` must allow all required Quest subagents without approval prompts.
+- Worker behavior: no "ask user" flow inside subagents during plan/build/review/fix loops.
+- Worker fallback: when inputs are incomplete, make explicit assumptions and continue; write assumptions/risk notes into artifacts.
+- Safety valve:
+  - Codex path: return structured `blocked` (not `needs_human`), then retry/fallback policy applies.
+  - Claude fallback path: may return structured `needs_human` when creator input is truly required.
+
+## Runtime Observability Contract
+
+Timeout policy should be data-driven, not guessed.
+
+- Orchestrator writes JSONL to `.quest/<id>/logs/subagent_runtime.log`.
+- Keep `.quest/<id>/logs/context_health.log` as the handoff compliance log (source/handoff integrity).
+- Do not merge timing fields into `context_health.log` by default.
+- Separation rationale:
+  - `context_health.log` remains stable and easy to parse for routing/compliance diagnostics.
+  - `subagent_runtime.log` can evolve for performance analysis without breaking existing compliance tooling.
+  - Failure in one log stream should not corrupt or block the other.
+- Log two events per invocation attempt:
+  - `event=start` immediately before subagent invocation.
+  - `event=finish` immediately after handoff parse/fallback decision.
+- Required fields on every event:
+  - `timestamp` (ISO-8601 UTC)
+  - `event` (`start` or `finish`)
+  - `invocation_id`
+  - `phase`
+  - `agent`
+  - `runtime` (`claude` or `codex`)
+  - `plan_iteration` (integer, `0` when not in plan loop)
+  - `fix_iteration` (integer, `0` when not in fix loop)
+  - `attempt` (integer, per role+phase retry counter)
+- Required fields on `event=finish`:
+  - `started_at` (ISO-8601 UTC)
+  - `finished_at` (ISO-8601 UTC)
+  - `duration_ms`
+  - `outcome` (`complete`, `blocked`, `needs_human`, `error`)
+  - `fallback_used` (boolean)
+  - `fallback_target` (`claude`, `codex`, or `null`)
+- Policy note: `outcome=needs_human` is allowed only for Claude-path invocations.
+- Retries and fallbacks are separate invocation attempts (`invocation_id` per attempt).
+- Logging is observability-only. Routing must not depend on telemetry file availability.
+- Use these logs to compute per-role/runtime p50/p95/p99 before introducing hard timeouts.
+- Optional reporting view: generate a merged report at completion, but keep underlying logs separate.
+
+Minimal permission shape to target:
+
+```json
+{
+  "agent": {
+    "quest": {
+      "mode": "primary",
+      "permission": {
+        "task": "allow"
+      }
+    },
+    "planner": {
+      "mode": "subagent",
+      "permission": {
+        "question": "deny"
+      }
+    },
+    "implementer": {
+      "mode": "subagent",
+      "permission": {
+        "question": "deny"
+      }
+    },
+    "reviewer-a": {
+      "mode": "subagent",
+      "permission": {
+        "question": "deny"
+      }
+    },
+    "reviewer-b": {
+      "mode": "subagent",
+      "permission": {
+        "question": "deny"
+      }
+    }
+  }
+}
+```
+
+If your OpenCode build does not expose `question` in documented permission keys, keep the same non-interactive behavior as a prompt contract and treat any subagent question as a workflow defect.
+
+## Source Documents to Follow
+
+- `/Users/kjell/ws/extra/quest/.ws/opencode/packages/web/src/content/docs/orchestration.mdx`
+- `/Users/kjell/ws/extra/quest/.ws/opencode/packages/web/src/content/docs/agents.mdx`
+- `/Users/kjell/ws/extra/quest/.ws/opencode/packages/web/src/content/docs/commands.mdx`
+- `/Users/kjell/ws/extra/quest/.ws/opencode/packages/web/src/content/docs/permissions.mdx`
+
+## Repo Execution Constraints (Quest AGENTS.md)
+
+- Follow Quest gate sequence exactly:
+  - routing -> plan -> dual plan review -> arbiter -> walkthrough -> explicit approval -> build -> dual code review -> fixes
+- Do not edit project/source files before Build gate approval.
+- Run this work on a feature branch with a draft PR.
+- Before merge, add an explicit review comment to the PR.
+- Keep changes readability-first and simple (KISS/YAGNI/SRP/DRY).
+- Ensure `.ai/allowlist.json` covers:
+  - source directories writable by builder/fixer
+  - test commands needed by builder/fixer
+  - approval gates expected by orchestration
+
+## Model Guidance
+
+Primary implementation runtime pattern:
+- Claude Opus 4.6 as orchestrator
+- Codex 5.3 as implementation/review subagent runtime where configured
+
+Final architecture review:
+- Claude Opus 4.6
+
+OpenCode runtime validation candidates:
+- Big Pickle (orchestrator)
+- KiMi K2.5 or Minimax M2.5 (independent reviewer)
+
+Precedence for this document:
+1. `Target Orchestration Model (Cross-Runtime)` is the canonical policy for this implementation quest.
+2. `Model Guidance` is supporting guidance for execution and validation.
+3. `Quest Default Runtime (Post-Integration)` is future-looking runtime guidance, not the implementation target for this quest.
+
+## Scope (In)
+
+- Add/verify `quest` primary agent wiring
+- Ensure subagents are declared as `mode: subagent`
+- Ensure `quest` primary uses full subagent dispatch permission (`permission.task: allow` or equivalent wildcard allow)
+- Ensure `/quest` command routes to `agent: "quest"`
+- Keep markdown agent files authoritative
+- Enforce non-interactive subagent behavior (no subagent question prompts during orchestration loops)
+- Add orchestrator runtime telemetry (`start`/`finish` events, `started_at`, `finished_at`, `duration_ms`) for every subagent invocation attempt
+- Ensure orchestration prompt includes:
+  - linear flow
+  - fan-out/fan-in hint for dual review
+  - iteration loop guardrails (`max_iterations`)
+
+## Scope (Out)
+
+- No TypeScript orchestration driver
+- No 701-line inline SKILL duplication
+- No `.ai/roles/` reconstruction
+
+## Acceptance Criteria
+
+1. `/quest` command executes through `quest` primary agent.
+2. `quest` can dispatch required subagents without permission prompts (`permission.task` fully allowed for orchestration).
+3. Codex subagents do not ask interactive questions and do not return `needs_human`; they proceed with explicit assumptions or return `blocked`. Only Claude fallback may return `needs_human`.
+4. Orchestration flow supports dual-review pattern (fan-out/fan-in) at prompt level.
+5. Orchestration flow supports refinement/fix loop with max-iteration guard.
+6. Orchestrator emits JSONL runtime telemetry for every invocation attempt with `event=start` and `event=finish`, including `started_at`, `finished_at`, and `duration_ms`.
+7. Config and markdown definitions are minimal and maintainable.
+8. Model IDs are validated with `/models` or `opencode models`.
+9. Execution follows repo gate discipline (no build-before-approval violations).
+10. Allowlist coverage is sufficient to avoid subagent permission deadlocks.
+
+## Review Prompt (Copy/Paste)
+
+Use this with **Claude Opus 4.6**:
+
+```txt
+Review this Quest OpenCode integration change set for architectural correctness.
+
+Review focus:
+1) Does wiring follow official OpenCode orchestration semantics?
+2) Are task permissions correct for reliable orchestration dispatch (no task approval bottlenecks)?
+3) Is command routing to the orchestrator explicit and correct?
+4) Are subagents non-interactive by contract (no subagent question deadlocks)?
+5) Are fan-out/fan-in and iteration loops represented cleanly without framework lock-in?
+6) Did we avoid unnecessary complexity (custom driver, duplication, legacy artifacts)?
+
+Return:
+- Critical issues first
+- Then medium/low risks
+- Final verdict: APPROVE or ITERATE
+```
+
+## Notes
+
+If orchestration later needs strict parallel execution control, external retries, or external state transitions, create a follow-up idea for a small code-based driver.
+If timeout/kill policy is added later, derive defaults from observed p95/p99 runtime telemetry instead of static guesses.
+
+## Quest Default Runtime (Post-Integration)
+
+- Orchestrator: Trinity Large Preview (free, agentic trained, 200K context)
+- Planner: Trinity Large Preview (strong reasoning for planning)
+- Reviewer A: Big Pickle (primary reviewer, needs depth)
+- Reviewer B: KiMi K2.5 (different model family, genuine diversity)
+- Arbiter: Big Pickle or Trinity (decision-making, weighing reviews)
+- Builder: Big Pickle (full tool access, code competence)
+- Fixer: Big Pickle (same as builder)


### PR DESCRIPTION
## Summary
This draft updates Quest’s default runtime split so implementation/fix roles run on Codex first, while orchestration/review control stays on Claude, and documents the non-interactive fallback contract to keep runs deterministic.
- Aligns config, workflow docs, and role prompts around the same builder/fixer model defaults.
- Adds explicit skill discovery precedence in `AGENTS.md` so repo-local skills are treated as source of truth.

## Changes
- **Config**:
  - Updated `.ai/allowlist.json` so `model_overrides.builder` and `model_overrides.fixer` default to `gpt-5.3-codex`.
- **Quest Workflow**:
  - Updated `.ai/quest.md` role table and policy notes to reflect Codex-first builder/fixer with Claude fallback.
  - Updated `.skills/quest/delegation/workflow.md` with a Codex non-interactive contract (`no questions`, `no needs_human`), one retry with stricter guidance, then Claude fallback.
  - Clarified Q&A behavior as Claude-only in normal operation and updated failure handling text accordingly.
- **Skills**:
  - Updated `.skills/quest/agents/builder.md` and `.skills/quest/agents/fixer.md` to document Codex default runtime plus Claude fallback and non-interactive constraints.
  - Updated `.skills/quest/agents/plan-reviewer.md` and `.skills/quest/agents/code-reviewer.md` with explicit Codex Slot B non-interactive rules.
  - Added `.agents/skills/README.md` metadata-only bootstrap text for local skill directory discovery.
- **Documentation**:
  - Updated `AGENTS.md` to add required skill discovery/precedence guidance for `.skills/SKILLS.md` and `.agents/skills/`.
  - Updated bug-fix testing expectation to require a failing reproduction test before fix, then verification pass.
  - Removed generic architecture-template placeholder section from `AGENTS.md`.
- **Ideas**:
  - Added `ideas/quest-opencode-integration-from-official-guide.md` as a future implementation brief (execution prompt, scope, acceptance criteria, observability guidance).

## Validation
- [x] Run `scripts/validate-manifest.sh` and confirm manifest/state checks pass after documentation/workflow updates.
- [x] Inspect `.ai/allowlist.json` and confirm `builder` + `fixer` defaults are `gpt-5.3-codex`.
- [x] Inspect `.ai/quest.md` and `.skills/quest/delegation/workflow.md` and confirm retry-then-Claude-fallback behavior is consistent.
- [x] Inspect `AGENTS.md` and confirm skill discovery/source-of-truth guidance and bug-fix testing expectations are explicit.
Watch for: future drift where allowlist model overrides change without corresponding workflow/agent-doc updates.

## Notes
- This PR changes configuration and documentation contracts; it does not introduce runtime code execution changes outside Quest orchestration docs/prompts.
- The new `ideas/` document is intentionally forward-looking and not part of the currently enforced runtime path.

---
Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with KjellKod
