### PR TITLE
Include root AGENTS.md in installer manifest

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -28,7 +28,7 @@
     "planner": {
       "description": "Creates implementation plans from quest briefs",
       "mode": "subagent",
-      "model": "opencode/trinity-large-preview-free",
+      "model": "opencode/kimi-k2.5",
       "prompt": "{file:agents/planner.md}",
       "permission": {
         "edit": {

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -63,6 +63,7 @@ scripts/validate-handoff-contracts.sh
 
 [user-customized]
 # These files are NEVER overwritten - upstream changes create .quest_updated suffix
+AGENTS.md
 .ai/allowlist.json
 .ai/context_digest.md
 


### PR DESCRIPTION
## WHY
Opencode needs the Agents.md file. It was missing from the install manifest and it's  now added. 
Trinity is replaced for opencode/kimi-k2.5 as the currently under-evaluation default opencode-planner

## Acceptance Criterion
- [ ] validate with this branch's installer that Agents.md is installed both on fresh install. upgrade and force install. 