### PR TITLE
Fix hyphen/underscore mismatch in allowlist model_overrides

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -15,11 +15,11 @@
   },
   "model_overrides": {
     "planner": "opus",
-    "plan_reviewer_a": "opus",
-    "plan_reviewer_b": "gpt-5.3-codex",
+    "plan-reviewer-a": "opus",
+    "plan-reviewer-b": "gpt-5.3-codex",
     "builder": "gpt-5.3-codex",
-    "code_reviewer_a": "opus",
-    "code_reviewer_b": "gpt-5.3-codex",
+    "code-reviewer-a": "opus",
+    "code-reviewer-b": "gpt-5.3-codex",
     "arbiter": "opus",
     "fixer": "gpt-5.3-codex"
   },


### PR DESCRIPTION
## Summary
- Fix naming inconsistency in `.ai/allowlist.json` where `model_overrides` keys used underscores (`plan_reviewer_b`) while agent names in `opencode.json` use hyphens (`plan-reviewer-b`)
- This mismatch could prevent OpenCode's model routing from matching agents to their configured model overrides

## Test plan
- [x] Verify allowlist keys now match agent names in `opencode.json`
- [ ] Run a quest workflow in OpenCode and confirm Codex is routed correctly for `plan-reviewer-b`, `code-reviewer-b` slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)