### PR TITLE
Set OpenCode planner default to Claude Opus 4.6

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -35,7 +35,7 @@
     "planner": {
       "description": "Creates implementation plans from quest briefs",
       "mode": "subagent",
-      "model": "opencode/kimi-k2.5",
+      "model": "opencode/claude-opus-4-6",
       "prompt": "{file:agents/planner.md}",
       "permission": {
         "edit": {


### PR DESCRIPTION
## Summary
Set the default OpenCode planner model to Claude Opus 4.6 so planning runs on Opus by default.

## Changes
- Updated .opencode/opencode.json planner agent model from opencode/kimi-k2.5 to opencode/claude-opus-4-6
- Left all other agent model assignments unchanged

## Validation
- Confirmed diff contains only the planner model line change in .opencode/opencode.json

## Notes
- Config-only change; no runtime code paths modified