### PR TITLE
Fix model_overrides key style in quest.md docs

### DIFF
--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -75,7 +75,7 @@ Codex runtime policy for Quest:
 The Creator controls quest permissions via `.ai/allowlist.json`:
 - `auto_approve_phases` — which phases need human approval
 - `arbiter.tool` — Arbiter model (`claude` by default)
-- `model_overrides` — default role model map (`planner`, `plan_reviewer_a`, `plan_reviewer_b`, `builder`, `code_reviewer_a`, `code_reviewer_b`, `arbiter`, `fixer`)
+- `model_overrides` — default role model map (`planner`, `plan-reviewer-a`, `plan-reviewer-b`, `builder`, `code-reviewer-a`, `code-reviewer-b`, `arbiter`, `fixer`)
 - `review_mode` — `auto` (default), `fast`, or `full` for Codex reviews
 - `fast_review_thresholds` — file/LOC thresholds for auto fast mode
 


### PR DESCRIPTION
## Summary
Fix underscore/hyphen mismatch in `model_overrides` documentation that would cause users to set ineffective config overrides.

## Changes
- **Config docs:** Updated `.ai/quest.md` to use hyphenated keys (`plan-reviewer-a`, `code-reviewer-b`, etc.) matching the actual keys in `.ai/allowlist.json`

## Validation
- [x] Compare keys in `.ai/quest.md` line 78 against `.ai/allowlist.json` `model_overrides` block — they should match exactly

---
Quest/Co-Authored by Claude Opus 4.6 in Collaboration with KjellKod