### PR TITLE
Fix Codex MCP docs: use codex CLI directly

### DIFF
--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "codex": {
+    "codex-cli": {
       "command": "codex",
       "args": ["mcp-server"]
     }

--- a/.skills/celebrate/SKILL.md
+++ b/.skills/celebrate/SKILL.md
@@ -51,26 +51,9 @@ If no argument is provided:
 
 ### Step 3: Generate the Celebration as Rich Markdown
 
-**IMPORTANT: Write the celebration directly as your response text. Do NOT run a script. Do NOT wrap in code blocks. The UI renders agent markdown beautifully — big headers, colorful emojis, proper spacing. Use that.**
+**IMPORTANT: Write the celebration directly as your response text. Do NOT run a script. Do NOT wrap the entire celebration in a code block. The UI renders agent markdown beautifully, but ASCII/block-letter title art must be emitted as plain text lines rather than markdown headers or list items.**
 
 You have all the data from the artifacts. Now **create your own celebration**. Be creative. Make it feel like an achievement, not a status report.
-
-### Default Presentation Style: Epic
-
-Unless the user asks for something smaller, default to an **epic** presentation:
-
-- open with large block-letter title art broken across multiple lines
-- use generous vertical spacing between major sections
-- keep sections visually chunky rather than dense
-- prefer short, high-impact lines over long packed paragraphs
-- create a slower visual cadence so the celebration feels like a procession, not a dump of text
-
-You cannot literally control client scroll speed, so simulate a **half-speed feel** by:
-
-- adding breathing room between headers and sections
-- avoiding overly dense tables or paragraphs
-- presenting achievements and metrics in short bursts
-- using separators and whitespace to pace the reveal
 
 **Required sections** (present them however you like):
 - Quest name and ID
@@ -95,12 +78,17 @@ You cannot literally control client scroll speed, so simulate a **half-speed fee
 - Neutral Emojis to emphesize either celebration or scary (🌪️ 🔥  ⚙️  🔧)
 - `---` horizontal rules for visual separation
 - Tables if they help present the data
-- Extra blank lines between major sections to slow the visual rhythm
+
+**ASCII/block-letter title rules:**
+- Emit block-letter rows as plain text lines only.
+- Do **not** prefix block-letter rows with `#`, `-`, `>`, or any other markdown marker.
+- Keep the title art contiguous with no blank separator inserted inside the rows.
+- After the title art, leave one normal blank line before the rest of the celebration.
 
 **Do NOT:**
 - Put too many characters on one line of block letters — max ~5 letters per line, break long names across multiple lines (one word per block, like the HELLO/WORLD example)
 - Wrap the entire celebration in a code block (kills the rich rendering)
-- Rush the pacing with dense walls of text when the user asked to celebrate
+- Prefix ASCII title art with markdown header markers such as `#`
 - Use generic achievements like "Quest Complete" or "Battle Tested"
 - Use generic metrics like "Files Changed: 22" or "Agents Involved: 0"
 - Use fallback quotes like "Shipping should feel like a celebration"
@@ -127,8 +115,6 @@ You cannot literally control client scroll speed, so simulate a **half-speed fee
 ```
 
 Break the text across **multiple lines** — max ~5 letters per line. Each word gets its own block, like "HELLO" on one line and "WORLD" on the next. For longer words, hyphenate: "RESOL-" on one line and "UTION" on the next. This keeps it readable without horizontal overflow.
-
-Default bigger-than-before opening style is preferred. If in doubt, make the title art grander and give it more air.
 
  🎉 🎉 🎉 🎉  🙌  🎉 🎉 🎉 🎉  
 
@@ -195,7 +181,6 @@ The tier must be candid. Smooth quests get celebrated. Rough quests get acknowle
 - **The quote must come from the quest.** Pull a real line from the arbiter verdict, reviewer summary, or fixer handoff. Not "Shipping should feel like a celebration."
 
 - **Emojis render beautifully in markdown.** Use them generously: ⭐️ 🏆 🎯 💎 📊 🔧 🧪 🔒 📚 ⚡️ 🎊 🎉 🚀 🎮
-- **Pacing matters.** Big wins should feel staged. Use whitespace and section breaks to make the celebration unfold rather than blur together.
 
 ## Examples
 

--- a/.skills/quest/agents/builder.md
+++ b/.skills/quest/agents/builder.md
@@ -4,7 +4,7 @@
 Implements the approved plan. Writes code, runs tests, produces a PR description.
 
 ## Tool
-Codex (`mcp__codex__codex`) by default, with Claude runtime as fallback. Use native `Task(subagent_type="builder")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` for the Claude fallback path. `scripts/claude_cli_bridge.py` remains the transport layer behind that runner.
+Codex (`mcp__codex-cli__codex`) by default, with Claude runtime as fallback. Use native `Task(subagent_type="builder")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` for the Claude fallback path. `scripts/claude_cli_bridge.py` remains the transport layer behind that runner.
 
 When running on Codex, this role is non-interactive:
 - Do not ask questions.

--- a/.skills/quest/agents/fixer.md
+++ b/.skills/quest/agents/fixer.md
@@ -4,7 +4,7 @@
 Fixes issues identified by the Code Review Agent. Applies targeted fixes and re-runs tests.
 
 ## Tool
-Codex (`mcp__codex__codex`) by default, with Claude runtime as fallback. Use native `Task(subagent_type="fixer")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` for the Claude fallback path. `scripts/claude_cli_bridge.py` remains the transport layer behind that runner.
+Codex (`mcp__codex-cli__codex`) by default, with Claude runtime as fallback. Use native `Task(subagent_type="fixer")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` for the Claude fallback path. `scripts/claude_cli_bridge.py` remains the transport layer behind that runner.
 
 When running on Codex, this role is non-interactive:
 - Do not ask questions.

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -17,11 +17,11 @@ Quest is opinionated: default to **thorough**, but be **progressive** and avoid 
 
 ### Codex Availability Probe (Run Once Per Session — Applies to ALL Codex MCP calls)
 
-Tool naming is platform-specific:
-- Claude Code: `mcp__codex__codex`
+Tool naming is platform-specific (depends on the MCP server name in config):
+- Claude Code: `mcp__codex-cli__codex` (server name `codex-cli` in `.claude/mcp.json`)
 - OpenCode: `codex_codex`
 
-In this document, `mcp__codex__codex` means "the platform's Codex session-start MCP tool".
+In this document, `mcp__codex__codex` is used as an **abstract placeholder** meaning "the platform's Codex session-start MCP tool". Substitute the actual tool name for your platform.
 
 Before the first Codex invocation, the orchestrator MUST probe for tool availability:
 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,23 @@ The installer:
 - Supports `--force` for CI/automation
 - Will check after a successful quest completion if a new version is available.  
 
-Use the full [Quest Setup Guide](docs/guides/quest_setup.md) for prerequisites, allowlist customization, Codex MCP, Codex-led Claude bridge setup, and verification.
+**Optional: Dual-model reviews with Codex CLI**
 
-That guide covers:
-- Claude Code install and authentication
-- Codex MCP setup for dual-model reviews
-- Codex-led Claude bridge setup when Codex is the Quest orchestrator
+Quest can use [Codex CLI](https://developers.openai.com/codex/cli/) as a second reviewer — no separate MCP package needed, just the CLI itself:
+
+```bash
+npm i -g @openai/codex
+```
+
+Then add to your `.claude/mcp.json`:
+
+```json
+{ "mcpServers": { "codex-cli": { "command": "codex", "args": ["mcp-server"] } } }
+```
+
+Requires `OPENAI_API_KEY` in your environment. If you skip this, Quest uses Claude for all roles (still works fine).
+
+Use the full [Quest Setup Guide](docs/guides/quest_setup.md) for prerequisites, allowlist customization, Codex MCP details, Codex-led Claude bridge setup, and verification.
 
 ### Option B: Manual Copy
 
@@ -176,7 +187,7 @@ Copy these folders to your repository root:
 - `AGENTS.md` - Coding rules (customize for your project)
 - `DOCUMENTATION_STRUCTURE.md` - Navigation guide
 
-Then follow the full [Quest Setup Guide](docs/guides/quest_setup.md) for allowlist customization, `.gitignore`, Codex MCP setup, Codex-led Claude bridge setup, and verification.
+Then follow the full [Quest Setup Guide](docs/guides/quest_setup.md) for allowlist customization, `.gitignore`, Codex CLI MCP setup, Codex-led Claude bridge setup, and verification.
 
 ### Use It
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Then add to your `.claude/mcp.json`:
 { "mcpServers": { "codex-cli": { "command": "codex", "args": ["mcp-server"] } } }
 ```
 
-Requires `OPENAI_API_KEY` in your environment. If you skip this, Quest uses Claude for all roles (still works fine).
+Requires either `OPENAI_API_KEY` in your environment or a Codex login (`codex` → `/login`). If you skip Codex entirely, Quest uses Claude for all roles (still works fine).
 
 Use the full [Quest Setup Guide](docs/guides/quest_setup.md) for prerequisites, allowlist customization, Codex MCP details, Codex-led Claude bridge setup, and verification.
 

--- a/docs/guides/quest_presentation.md
+++ b/docs/guides/quest_presentation.md
@@ -256,10 +256,10 @@ Task tool with subagent_type: general-purpose
 
 **Codex agents** (plan reviewers, code reviewers):
 ```
-mcp__codex__codex(prompt: "...")
+mcp__codex-cli__codex(prompt: "...")
   → New Codex session
   → Prompt assembled by orchestrator
-  → Completely separate model (GPT 5.2)
+  → Completely separate model (GPT 5.x)
 ```
 
 ### Parallel Review Execution
@@ -459,10 +459,12 @@ logs/
    .quest/
    ```
 
-4. **Optional: Configure Codex MCP** (if using GPT 5.2):
-   ```bash
-   claude mcp add codex -- npx -y @anthropic/codex-mcp-server
+4. **Optional: Configure Codex MCP** (if using GPT 5.x):
+   Add to `.claude/mcp.json`:
+   ```json
+   { "mcpServers": { "codex-cli": { "command": "codex", "args": ["mcp-server"] } } }
    ```
+   Requires: `npm install -g @openai/codex` and `OPENAI_API_KEY` set.
 
 5. **Test**:
    ```

--- a/docs/guides/quest_presentation.md
+++ b/docs/guides/quest_presentation.md
@@ -464,7 +464,7 @@ logs/
    ```json
    { "mcpServers": { "codex-cli": { "command": "codex", "args": ["mcp-server"] } } }
    ```
-   Requires: `npm install -g @openai/codex` and `OPENAI_API_KEY` set.
+   Requires: `npm i -g @openai/codex` and either `OPENAI_API_KEY` or Codex login (`codex` → `/login`).
 
 5. **Test**:
    ```

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -24,12 +24,27 @@ claude auth
 
 Quest can use Codex as a second reviewer. This gives you two different model families reviewing your code (different blind spots).
 
-```bash
-# Add Codex MCP server to Claude Code
-claude mcp add codex -- npx -y @anthropic/codex-mcp-server
+**Requires:**
+- [Codex CLI](https://github.com/openai/codex) installed globally (`npm install -g @openai/codex`)
+- OpenAI API key configured in your environment (`OPENAI_API_KEY`)
+
+Add the Codex MCP server to your project's `.claude/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "codex-cli": {
+      "command": "codex",
+      "args": ["mcp-server"]
+    }
+  }
+}
 ```
 
-**Requires:** OpenAI API key configured in your environment.
+This uses the Codex CLI's built-in `mcp-server` subcommand directly — no npm wrapper package needed.
+
+**Verify it works:** `claude mcp list` should show `codex-cli` as a configured server.
+
 **Documentation:** https://platform.openai.com/docs/quickstart
 
 If you skip this, Quest uses Claude for all roles (still works, just single-model).
@@ -173,14 +188,9 @@ The `.quest/` folder contains ephemeral run state and should not be committed.
 
 ## One-Time MCP Setup (if using Codex)
 
-If you want to use Codex for reviews and arbiter:
+If you want to use Codex for reviews and arbiter, add the config to `.claude/mcp.json` (see [Prerequisites](#optional-codex-mcp-for-dual-model-reviews) above).
 
-```bash
-# Add Codex MCP server
-claude mcp add codex -- npx -y @anthropic/codex-mcp-server
-```
-
-This enables the `mcp__codex__codex` tool for spawning Codex agents.
+This enables the `mcp__codex-cli__codex` tool for spawning Codex agents.
 
 If you don't have Codex or prefer Claude for all roles, set in `allowlist.json`:
 
@@ -267,8 +277,8 @@ Each agent runs in **complete isolation** — no shared conversation history:
 - Start fresh, return handoff when done
 
 **Codex agents** (code-reviewer, arbiter when configured):
-- Called via `mcp__codex__codex` MCP tool
-- Completely separate model (GPT 5.2)
+- Called via `mcp__codex-cli__codex` MCP tool
+- Completely separate model (GPT 5.x)
 - Receive assembled prompt, return handoff
 
 ### Human as Gatekeeper

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -25,8 +25,8 @@ claude auth
 Quest can use Codex as a second reviewer. This gives you two different model families reviewing your code (different blind spots).
 
 **Requires:**
-- [Codex CLI](https://github.com/openai/codex) installed globally (`npm install -g @openai/codex`)
-- OpenAI API key configured in your environment (`OPENAI_API_KEY`)
+- [Codex CLI](https://developers.openai.com/codex/cli/) installed globally (`npm i -g @openai/codex`)
+- Either `OPENAI_API_KEY` in your environment or a Codex login (`codex` → `/login`)
 
 Add the Codex MCP server to your project's `.claude/mcp.json`:
 

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -50,7 +50,7 @@ def select_role_runtime(
     if normalized_target == "codex":
         return RuntimeSelection(
             runtime="codex",
-            entrypoint="mcp__codex__codex",
+            entrypoint="mcp__codex-cli__codex",
             reason="Codex-designated role stays on Codex tooling.",
             requires_probe=False,
         )


### PR DESCRIPTION
## Summary
- Replace all `@anthropic/codex-mcp-server` npm package references with direct `codex mcp-server` CLI config
- Fix MCP tool name references from `mcp__codex__codex` to `mcp__codex-cli__codex` across docs, agent files, workflow, and runtime code
- Add Codex CLI install teaser to README with link to https://developers.openai.com/codex/cli/
- Tighten celebrate skill: remove vague pacing instructions, add concrete ASCII/block-letter rendering rules

## Why
The actual working config uses `codex mcp-server` (the CLI's built-in MCP subcommand). The `@anthropic/codex-mcp-server` npm package was never used. The MCP server self-registers as `codex-cli`, so the tool name is `mcp__codex-cli__codex`, not `mcp__codex__codex`.

## Test plan
- [x] Verify `codex mcp-server` starts correctly via `claude mcp list`
- [x] Verify `mcp__codex-cli__codex` tool is callable from Claude Code
- [x] Review updated setup docs for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)