### PR TITLE
Add /gpt skill and clarify model labels in skills

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -34,6 +34,7 @@ This repository uses **layered documentation** for AI agent context management.
 
 ## Quick Navigation
 
+- **Delegate to Codex?** → Use `/gpt` command or `.skills/gpt/` skill
 - **Multi-agent orchestration?** → Use `/quest` command
 - **Celebrate a quest?** → Use `/celebrate` command or `.skills/celebrate/` skill
 - **Building a feature?** → Use `.skills/implementer/` skill
@@ -49,6 +50,7 @@ This repository uses **layered documentation** for AI agent context management.
 
 This repository uses **skills** for specialized workflows. Skills are automatically discovered and used based on task context:
 
+- **gpt:** Delegate tasks to Codex via MCP — reviews, analysis, implementation, second opinions
 - **quest:** Multi-agent orchestration for features (plan → review → build → review → fix)
 - **celebrate:** Play quest completion celebration animation with achievements, metrics, and credits
 - **plan-reviewer:** Review implementation plans and PR specifications for test coverage

--- a/.claude/skills/gpt/SKILL.md
+++ b/.claude/skills/gpt/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: gpt
+description: Delegate a task to OpenAI Codex via MCP. Use when the user invokes /gpt, asks to use codex, or wants a second opinion from a different model.
+user-invocable: true
+---
+
+Read and follow the instructions in `.skills/gpt/SKILL.md`.

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -31,6 +31,7 @@
 .claude/skills/pr-assistant/SKILL.md
 .claude/skills/pr-shepherd/SKILL.md
 .claude/skills/celebrate/SKILL.md
+.claude/skills/gpt/SKILL.md
 .claude/skills/quest/SKILL.md
 .claude/mcp.json
 .claude/AGENTS.md
@@ -59,6 +60,7 @@
 .skills/plan-maker/SKILL.md
 .skills/plan-reviewer/SKILL.md
 .skills/celebrate/SKILL.md
+.skills/gpt/SKILL.md
 .skills/quest/SKILL.md
 .skills/quest/delegation/questioner.md
 .skills/quest/delegation/router.md

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -75,6 +75,13 @@ This directory contains specialized skills for AI agents working in this reposit
 
 **Location:** `.skills/pr-shepherd/SKILL.md`
 
+### gpt
+**Purpose:** Delegate tasks to OpenAI Codex (GPT-5.4) via MCP. Provides structured invocation with sensible defaults for sandbox, model, and reasoning effort.
+
+**Use when:** The user invokes `/gpt`, asks to "use codex" or "ask codex", wants a second opinion from a different model, or Quest routes a role to Codex.
+
+**Location:** `.skills/gpt/SKILL.md`
+
 ### celebrate
 **Purpose:** Play a rich quest completion celebration animation with block letters, achievements, impact metrics, quality score, and end credits. Runs the celebrate script or produces a manual celebration from quest artifacts.
 

--- a/.skills/git-commit-assistant/SKILL.md
+++ b/.skills/git-commit-assistant/SKILL.md
@@ -70,16 +70,18 @@ Generate a single commit message from the current staged diff. Output only the f
 
 ### Trailer (required)
 
-Always append this trailer exactly:
+Always append a trailer in this format:
 
 ```bash
 
-Quest/Co-Authored by Claude Opus 4.6, GPT-5.3 Codex in Collaboration with <github username>
+Quest/Co-Authored by <claude label>, <codex label> in Collaboration with <github username>
 
 ```
 
 Replace:
 
+- **claude label** with the current Claude model label when it is known from the active session or quest artifacts; otherwise use `Claude`.
+- **codex label** with the current Codex model label when it is known from the active session, CLI invocation, or quest artifacts; otherwise use `Codex`.
 - **github username** with the repository author's GitHub username (infer from git config, remote URL, or ask if unknown).
 
 Never omit the trailer.

--- a/.skills/gpt/SKILL.md
+++ b/.skills/gpt/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: gpt
+description: Delegate a task to OpenAI Codex via MCP. Use when the user invokes /gpt, asks to "use codex", "ask codex", "have codex do X", or when a second opinion or parallel implementation from a different model would be valuable.
+---
+
+# Skill: GPT (Codex)
+
+Delegate tasks to OpenAI Codex via the `mcp__codex-cli__codex` MCP tool.
+
+## When to Use
+
+- User types `/gpt` or `/gpt <task>`
+- User asks to "use codex", "ask codex", "have codex review/write/analyze..."
+- User wants a second opinion from a different model
+- Quest workflow routes a role to Codex (builder, fixer, code-reviewer-b, plan-reviewer-b)
+
+## Prerequisites
+
+Codex MCP server must be configured in `.claude/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "codex-cli": {
+      "command": "codex",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+If the tool `mcp__codex-cli__codex` is not available, tell the user to add the config above and restart Claude Code.
+
+## Step 1: Confirm Before Calling
+
+Before invoking Codex, **always tell the user what you're about to do** and wait for confirmation:
+
+```
+I'll delegate this to Codex with:
+- **Model:** gpt-5.4
+- **Reasoning:** high
+- **Sandbox:** workspace-write
+
+Continue? (y/n)
+```
+
+Adjust the defaults based on task complexity:
+- Simple question/hello world → `low` reasoning, `read-only` sandbox
+- Code review/analysis → `high` reasoning, `workspace-write` sandbox
+- Complex architecture/refactor → `xhigh` reasoning, `workspace-write` sandbox
+- Needs network/system access → `danger-full-access` sandbox (**always call this out explicitly**)
+
+If the user specifies reasoning or model in their request, use what they asked for.
+
+## Step 2: Call via MCP
+
+Always use the MCP tool. **Never shell out to `codex exec`.**
+
+```
+mcp__codex-cli__codex({
+  prompt: "<task description>",
+  model: "gpt-5.4",
+  reasoningEffort: "high",
+  sandbox: "workspace-write",
+  fullAuto: true
+})
+```
+
+## Available Models
+
+Use `gpt-5.4` unless the user requests otherwise. The MCP tool schema may lag behind — `gpt-5.4` works even if not listed in the schema's enum.
+
+Known working models:
+`gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`
+
+## Parameters
+
+| Parameter | Default | When to change |
+|-----------|---------|----------------|
+| `model` | `gpt-5.4` | Only if user requests a specific model |
+| `reasoningEffort` | `high` | `low`/`medium` for simple tasks, `xhigh` for complex architecture |
+| `sandbox` | `workspace-write` | `read-only` for pure Q&A with no file output. `danger-full-access` **only with explicit user permission** — needed for network access, system commands, or out-of-workspace writes |
+| `fullAuto` | `true` | Leave true unless user wants approval prompts |
+| `sessionId` | (none) | Set to continue a previous Codex conversation within the same task |
+
+## Sandbox Discipline
+
+- **`workspace-write`** (default) — Codex can read everything, write within the project. Covers reviews, implementation, refactoring, test writing.
+- **`read-only`** — Pure analysis, explanation, Q&A. No file writes at all.
+- **`danger-full-access`** — Full system access. **Always ask the user before using this.** Needed when: installing dependencies, network calls, accessing files outside the workspace.
+
+When called from Quest orchestration, match the sandbox to the role:
+- Builder/Fixer: `workspace-write`
+- Reviewers: `workspace-write` (may write review artifacts)
+- Analysis-only: `read-only`
+
+## Crafting the Prompt
+
+Be specific. Codex runs non-interactively — it can't ask clarifying questions.
+
+Include:
+- What to do (clear task description)
+- Where to look (file paths, directories)
+- What constraints apply (don't modify X, follow pattern Y)
+- What output to produce (write to file, return analysis, make changes)
+
+Bad: `"Review this code"`
+Good: `"Review src/auth/middleware.ts for security issues. Focus on session handling and input validation. Write findings to .quest/<id>/reviews/codex-review.md"`
+
+## Session Continuity
+
+Use `sessionId` to maintain conversation context across multiple calls:
+
+```
+// First call
+mcp__codex-cli__codex({ prompt: "Analyze the auth module...", sessionId: "auth-review-1" })
+
+// Follow-up
+mcp__codex-cli__codex({ prompt: "Now refactor the issues you found", sessionId: "auth-review-1" })
+```
+
+## Interpreting Results
+
+- Summarize findings for the user — don't dump raw output
+- If Codex's response seems incomplete, retry with higher `reasoningEffort` or a more specific prompt
+- If Codex returns an error, report it clearly — MCP gives structured errors, no guessing needed
+
+## What This Skill Does NOT Cover
+
+- **Arbitration between Claude and Codex** — handled by Quest's arbiter role
+- **Critical evaluation of Codex output** — handled by Quest's review pipeline
+- **Model routing for Quest phases** — handled by `allowlist.json` and `workflow.md`
+
+This skill is the transport and invocation layer. Quest orchestration handles the judgment layer.

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -163,13 +163,15 @@ Append this block at the end of the PR body:
      ▐▛███▜▌
     ▝▜█████▛▘
       ▘▘ ▝▝
-Quest/Co-Authored by <agent name and model> in Collaboration with <github username>
+Quest/Co-Authored by <claude label>, <codex label> in Collaboration with <github username>
 </pre>
 ```
 
 Replace:
 
-- **agent name and model** and **github username** with the actual values.
+- **claude label** with the current Claude model label when it is known from the active session or quest artifacts; otherwise use `Claude`.
+- **codex label** with the current Codex model label when it is known from the active session, CLI invocation, or quest artifacts; otherwise use `Codex`.
+- **github username** with the actual GitHub username.
 
 Never omit the trailer.
 


### PR DESCRIPTION
## Summary
Add a `/gpt` skill for delegating tasks to OpenAI Codex via MCP tool call, and update co-author trailer labels in commit/PR skills to use actual model names.

## Changes
- **Skills**:
  - New `.skills/gpt/SKILL.md` — structured Codex invocation via `mcp__codex-cli__codex` with confirmation step, sandbox discipline, model defaults (`gpt-5.4`), and session continuity
  - New `.claude/skills/gpt/SKILL.md` — thin proxy with `user-invocable: true` for `/gpt` slash command discovery
  - Updated `git-commit-assistant` and `pr-assistant` trailer format to use specific model labels instead of generic names
- **Manifest**:
  - Added `.skills/gpt/SKILL.md` and `.claude/skills/gpt/SKILL.md` to `.quest-manifest` for installer distribution
- **Documentation**:
  - Registered `/gpt` skill in `.claude/AGENTS.md` quick navigation and skills list
  - Added `gpt` entry to `.skills/SKILLS.md` catalog

## Validation
- [x] Restart Claude Code in a Quest project and confirm `/gpt` appears in slash command autocomplete
- [x] Run `/gpt say hello` and verify it shows model/reasoning/sandbox confirmation before calling Codex
- [x] Run `scripts/validate-manifest.sh` and confirm no missing or stale entries

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by Claude Opus 4.6, Codex in Collaboration with KjellKod
</pre>