### PR TITLE
Stage Quest artifacts before runtime fallback retries

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -18,10 +18,6 @@
     "code_review": true,
     "fix_loop": false
   },
-  "arbiter": {
-    "tool": "claude",
-    "notes": "Set to 'codex' to use gpt-5.4 as Arbiter instead of Claude. Default: claude."
-  },
   "models": {
     "planner": "claude",
     "plan-reviewer-a": "claude",

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -18,7 +18,10 @@
     "code_review": true,
     "fix_loop": false
   },
-  "review_mode": "full",
+  "arbiter": {
+    "tool": "claude",
+    "notes": "Set to 'codex' to use gpt-5.4 as Arbiter instead of Claude. Default: claude."
+  },
   "models": {
     "planner": "claude",
     "plan-reviewer-a": "claude",
@@ -29,6 +32,7 @@
     "code-reviewer-b": "gpt-5.4",
     "fixer": "gpt-5.4"
   },
+  "review_mode": "full",
   "fast_review_thresholds": {
     "max_files": 5,
     "max_loc": 300

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -117,7 +117,6 @@ When a role invocation fails (missing/unparsable handoff), Quest uses a three-ti
 
 The Creator controls quest permissions via `.ai/allowlist.json`:
 - `auto_approve_phases` — which phases need human approval
-- `arbiter.tool` — Arbiter model (`claude` by default)
 - `models` — default role model map (`planner`, `plan-reviewer-a`, `plan-reviewer-b`, `builder`, `code-reviewer-a`, `code-reviewer-b`, `arbiter`, `fixer`)
 - `review_mode` — `auto` (default), `fast`, or `full` for Codex reviews
 - `fast_review_thresholds` — file/LOC thresholds for auto fast mode

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -77,11 +77,48 @@ Codex-led Quest note:
 - The workflow now probes bridge availability once per session, routes Claude-designated slots by selected model/runtime, and logs bridge-invoked Claude roles as `runtime=claude`.
 - Bridge failures are explicit: timeout retries once, CLI/auth failures block immediately, and malformed output/missing handoff retries once before text fallback or blocking.
 
+## Artifact Preparation and Runtime Fallbacks
+
+### Workspace-Local Quest Paths
+
+All Quest-owned artifacts default to `<repo>/.quest/<quest_id>/...`. This keeps artifacts within the workspace root for all runtimes, avoiding sandbox write-boundary issues.
+
+Use `default_quest_dir(workspace_root, quest_id)` from `quest_runtime.artifacts` to resolve the canonical path.
+
+### Artifact Preparation Invariant
+
+Before each role invocation, the orchestrator prepares that role's expected artifact files:
+1. Resolve paths via `expected_artifacts_for_role(quest_dir, phase, agent)`
+2. Create directories and truncate files via `prepare_artifact_files(paths)`
+3. Instruct the agent to overwrite the prepared files directly (no shell redirection or heredocs)
+
+This is runtime-neutral — the same preparation runs whether the orchestrator is Claude or Codex.
+
+### Fallback Ladder
+
+When a role invocation fails (missing/unparsable handoff), Quest uses a three-tier retry strategy:
+
+- **Tier A — Normal run:** Configured runtime/model, normal permissions, with artifact preparation.
+- **Tier B — Permission/transport retry (same runtime, same model):** Triggered only for `write_boundary` or `permission` failures. Codex: escalate from `workspace-write` to `danger-full-access` only when the user has explicitly approved that broader access or an equivalent persisted approval exists. Claude bridge: add out-of-workspace dirs via `--add-dir`. Native Claude: widen tool permissions.
+- **Tier C — Cross-runtime fallback:** Triggered when Tier B is exhausted or the failure is non-write-boundary (timeout, model failure, invocation error). Codex slots fall back to Claude; Claude bridge slots fall back to Codex.
+
+`danger-full-access` is never set automatically. Escalation is explicit and exceptional.
+
+### Failure Classification
+
+`classify_failure_kind` in `quest_runtime.claude_runner` routes failures:
+- `timeout` — process timed out
+- `invocation` — CLI/auth/environment error
+- `write_boundary` — artifacts missing/empty AND paths are out-of-workspace
+- `permission` — stderr contains permission-denied signals
+- `model` — reasoning/compliance failure (default)
+
 ## Allowlist
 
 The Creator controls quest permissions via `.ai/allowlist.json`:
 - `auto_approve_phases` — which phases need human approval
-- `models` — role-to-model map (`planner`, `plan-reviewer-a`, `plan-reviewer-b`, `builder`, `code-reviewer-a`, `code-reviewer-b`, `arbiter`, `fixer`)
+- `arbiter.tool` — Arbiter model (`claude` by default)
+- `models` — default role model map (`planner`, `plan-reviewer-a`, `plan-reviewer-b`, `builder`, `code-reviewer-a`, `code-reviewer-b`, `arbiter`, `fixer`)
 - `review_mode` — `auto` (default), `fast`, or `full` for Codex reviews
 - `fast_review_thresholds` — file/LOC thresholds for auto fast mode
 

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -71,6 +71,8 @@ scripts/validate-handoff-contracts.sh
 scripts/claude_cli_bridge.py
 scripts/quest_claude_probe.py
 scripts/quest_claude_runner.py
+scripts/quest_checks/__init__.py
+scripts/quest_checks/cli.py
 scripts/quest_runtime/__init__.py
 scripts/quest_runtime/artifacts.py
 scripts/quest_runtime/claude_runner.py

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -71,6 +71,10 @@ scripts/validate-handoff-contracts.sh
 scripts/claude_cli_bridge.py
 scripts/quest_claude_probe.py
 scripts/quest_claude_runner.py
+scripts/quest_runtime/__init__.py
+scripts/quest_runtime/artifacts.py
+scripts/quest_runtime/claude_runner.py
+scripts/quest_runtime/state.py
 scripts/quest_celebrate/__init__.py
 scripts/quest_celebrate/animations.py
 scripts/quest_celebrate/ascii_art.py

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -116,16 +116,51 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 2. Read the expected `handoff.json` file (tiny JSON, ~200 bytes)
 3. Use its `status`, `next`, `summary`, and `artifacts` fields for routing and user display
 4. Discard the full agent response -- do not retain, summarize, or process it
-5. **Deterministic precedence for missing/unparsable handoff.json:**
-   - **Claude runtime invocation:**
-     - **Native Claude `Task(...)`:** If `handoff.json` is missing/unparsable, parse text `---HANDOFF---` as fallback.
-     - **Bridge-invoked Claude (`python3 scripts/quest_claude_runner.py`):**
-       - **Timeout:** Retry the same Claude role once with a reduced artifact-first prompt: no questions, no `needs_human`, read only the listed files, and write the required artifacts plus `handoff.json` before any optional commentary. If the second attempt also times out, treat the step as `blocked`.
-       - **Auth/CLI/environment failure** (for example Claude CLI missing from `PATH`, not authenticated, or bridge script missing): Do NOT retry. Treat the step as `blocked` and surface the stderr summary to the user.
-       - **Other failures** (missing/unparsable handoff, malformed output, `blocked`): Re-run the same Claude role once with a reduced artifact-first prompt and a strict reminder to write the expected artifact files and `handoff.json`. If the second attempt still fails, parse text `---HANDOFF---` as last-resort compatibility fallback; if no parseable text handoff exists, treat the step as `blocked`.
-   - **Codex invocation (`mcp__codex__codex`):**
-     - **Timeout (`McpError` / request timed out):** Do NOT retry. Fall back to the equivalent Claude `Task` immediately. Retrying a timed-out Codex call almost never succeeds and wastes time.
-     - **Other failures** (missing/unparsable handoff, non-compliant output, `blocked`): Re-run the same Codex role once with a strict reminder. If the second attempt still fails, invoke the equivalent Claude `Task` fallback for that step.
+5. **Artifact preparation (before every role invocation):**
+   Before invoking any role, the orchestrator MUST:
+   1. Resolve artifact paths: `expected_artifacts_for_role(quest_dir, phase, agent)`
+   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates files
+   3. Include in the role prompt:
+      ```
+      Artifact files have been prepared for you. Overwrite these files directly:
+      - <path1>
+      - <path2>
+      Do not create Quest artifacts via shell redirection, heredocs, or echo.
+      ```
+   This applies to ALL orchestrators (Claude-led and Codex-led) and ALL runtimes (native Claude, bridge Claude, Codex). The preparation logic does not branch on orchestrator identity.
+
+   **Codex sandbox permissions:** The orchestrator passes `sandbox_permissions: "workspace-write"` by default for Codex invocations. Tier B may escalate to `"danger-full-access"` ONLY when the user has explicitly approved that broader access or an equivalent persisted approval exists (see below). It is never automatic.
+
+6. **Three-tier fallback ladder for missing/unparsable handoff.json:**
+
+   Use `classify_failure_kind(result, artifact_paths, workspace_root)` to determine which tier applies. Classification order: timeout → invocation → write-boundary (out-of-workspace + missing artifacts) → permission → model.
+
+   **Tier A — Normal run (already completed, failed):**
+   The initial invocation with standard permissions and artifact preparation.
+
+   **Tier B — Permission/transport retry (same runtime, same model):**
+   Triggered ONLY when failure is classified as `write_boundary` or `permission`.
+   - **Codex:** Retry with `sandbox_permissions: "danger-full-access"` only when the user has explicitly approved that broader access or an equivalent persisted approval exists. Otherwise stop and request that approval instead of silently changing the sandbox.
+   - **Bridge-invoked Claude:** Add the out-of-workspace artifact directory to `--add-dir`.
+   - **Native Claude `Task(...)`:** Widen tool permissions for the specific directory.
+   - Prompt is unchanged (same task, same contract). Only the permission posture changes.
+   - If Tier B also fails, proceed to Tier C.
+
+   **Tier C — Cross-runtime fallback or block:**
+   Triggered when:
+   - Tier B was attempted and still failed, OR
+   - Failure is NOT write-boundary/permission (timeout, model failure, invocation error)
+
+   **Claude runtime invocation (Tier C):**
+   - **Native Claude `Task(...)`:** If `handoff.json` is missing/unparsable, parse text `---HANDOFF---` as fallback.
+   - **Bridge-invoked Claude (`python3 scripts/quest_claude_runner.py`):**
+     - **Timeout:** Retry the same Claude role once with a reduced artifact-first prompt: no questions, no `needs_human`, read only the listed files, and write the required artifacts plus `handoff.json` before any optional commentary. If the second attempt also times out, treat the step as `blocked`.
+     - **Auth/CLI/environment failure** (for example Claude CLI missing from `PATH`, not authenticated, or bridge script missing): Do NOT retry. Treat the step as `blocked` and surface the stderr summary to the user.
+     - **Other failures** (missing/unparsable handoff, malformed output, `blocked`): Re-run the same Claude role once with a reduced artifact-first prompt and a strict reminder to write the expected artifact files and `handoff.json`. If the second attempt still fails, parse text `---HANDOFF---` as last-resort compatibility fallback; if no parseable text handoff exists, treat the step as `blocked`.
+
+   **Codex invocation — Tier C (`mcp__codex__codex`):**
+   - **Timeout (`McpError` / request timed out):** Do NOT retry. Fall back to the equivalent Claude `Task` immediately.
+   - **Other failures** (missing/unparsable handoff, non-compliant output, `blocked`): Re-run the same Codex role once with a strict reminder. If the second attempt still fails, invoke the equivalent Claude `Task` fallback for that step.
    - Only after this fallback chain, if the final attempt still has no parseable `handoff.json`, parse text `---HANDOFF---` as last-resort compatibility fallback.
 
 **Expected handoff.json locations:**
@@ -151,13 +186,15 @@ The orchestrator NEVER reads full review files, plan content, or build output fo
 - Codex must not ask the user questions and must not return `STATUS: needs_human`.
 - If context is incomplete, Codex makes explicit assumptions in the artifact and continues.
 - If it cannot proceed safely, Codex returns `STATUS: blocked` with a concrete reason.
-- Orchestrator handling for Codex failures:
-  - **Timeout (`McpError` / request timed out):** Skip retry entirely. Fall back to the equivalent Claude `Task` role immediately.
-  - **Other failures** (`needs_human`, non-compliant output, missing/unparsable handoff, `blocked`):
-    1. Re-invoke the same Codex role once with a strict reminder: "no questions, no `needs_human`, make explicit assumptions."
-    2. If the second attempt still fails, fall back to the equivalent Claude `Task` role for that step.
+- Orchestrator handling for Codex failures follows the **three-tier fallback ladder** (see Handoff File Polling):
+  - **Tier B** (write-boundary/permission): Same Codex runtime, `sandbox_permissions: "danger-full-access"` only with explicit user approval or an equivalent persisted approval.
+  - **Tier C** (timeout, model, or Tier B exhausted):
+    - **Timeout (`McpError`):** Skip retry. Fall back to the equivalent Claude `Task` role immediately.
+    - **Other failures** (`needs_human`, non-compliant output, missing/unparsable handoff, `blocked`):
+      1. Re-invoke the same Codex role once with a strict reminder: "no questions, no `needs_human`, make explicit assumptions."
+      2. If the second attempt still fails, fall back to the equivalent Claude `Task` role for that step.
   - Only after the fallback chain may text `---HANDOFF---` parsing be used as a last-resort compatibility path.
-  4. Only enter human Q&A if the Claude runtime fallback returns `STATUS: needs_human`.
+  - Only enter human Q&A if the Claude runtime fallback returns `STATUS: needs_human`.
 
 **MANDATORY — Context health logging:** Every single time you read a handoff.json file (or fall back to text parsing), you MUST append one line to `.quest/<id>/logs/context_health.log` BEFORE making any routing decision. This is not optional. Do this for every agent, every phase, no exceptions. Create the `.quest/<id>/logs/` directory first if it does not exist. `scripts/quest_claude_runner.py` already does this for bridge-invoked Claude roles.
 
@@ -251,16 +288,20 @@ gates.max_plan_iterations (default: 4)
    - Read `models.planner` from allowlist.
    - If planner model is Claude, invoke through Claude runtime (native `Task(...)` when available, bridge in Codex-led sessions).
    - If planner model is Codex, invoke via `mcp__codex__codex`.
+   - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `plan.md` and `handoff.json` in `.quest/<id>/phase_01_plan/`.
    - Prompt: Reference file paths only, do not embed artifact content:
      - Quest brief: `.quest/<id>/quest_brief.md`
      - Arbiter verdict (iteration 2+): `.quest/<id>/phase_01_plan/arbiter_verdict.md`
      - User feedback (if present): `.quest/<id>/phase_01_plan/user_feedback.md`
    - Require the prompt to include:
-     - Write plan to: `.quest/<id>/phase_01_plan/plan.md`
-     - Write handoff file to: `.quest/<id>/phase_01_plan/handoff.json` with schema: `{"status", "artifacts", "next", "summary"}`
+     - Artifact files have been prepared. Overwrite them directly:
+       - `.quest/<id>/phase_01_plan/plan.md`
+       - `.quest/<id>/phase_01_plan/handoff.json`
+     - Do not create Quest artifacts via shell redirection, heredocs, or echo.
+     - handoff.json schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: plan_review`
-   - Wait for the selected Claude runtime to complete
+   - Wait for the selected runtime to complete
    - Read `.quest/<id>/phase_01_plan/handoff.json` for status/routing
    - Verify `.quest/<id>/phase_01_plan/plan.md` exists (from handoff.artifacts)
    - Apply deterministic precedence from **Handoff File Polling** for native Claude task vs bridge execution
@@ -283,8 +324,9 @@ gates.max_plan_iterations (default: 4)
    - **Reviewer A**: dispatched by orchestrator → `.quest/<id>/phase_01_plan/review_plan-reviewer-a.md`
    - **Reviewer B** (workflow only): dispatched by orchestrator → `.quest/<id>/phase_01_plan/review_plan-reviewer-b.md`
 
-   **Slot A** (runtime per `models.plan-reviewer-a`; full and fast modes):
+   **Artifact preparation** (per Handoff File Polling §5): Before issuing reviewer calls, resolve and prepare artifacts for both Reviewer A (`review_plan-reviewer-a.md`, `handoff_plan-reviewer-a.json`) and Reviewer B (`review_plan-reviewer-b.md`, `handoff_plan-reviewer-b.json`) in `.quest/<id>/phase_01_plan/`.
 
+   **Slot A** (runtime per `models.plan-reviewer-a`; full and fast modes):
    **Full mode** (default for plan review):
    ```
    Task(
@@ -298,8 +340,10 @@ gates.max_plan_iterations (default: 4)
      Quest brief: .quest/<id>/quest_brief.md
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
-     Write your review to: .quest/<id>/phase_01_plan/review_plan-reviewer-a.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_01_plan/review_plan-reviewer-a.md
+     - .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -316,8 +360,11 @@ gates.max_plan_iterations (default: 4)
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
      List up to 5 issues, highest severity first.
-     Write your review to: .quest/<id>/phase_01_plan/review_plan-reviewer-a.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_01_plan/review_plan-reviewer-a.md
+     - .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -329,7 +376,7 @@ gates.max_plan_iterations (default: 4)
    **Full mode** (default for plan review):
    ```
    mcp__codex__codex(
-     model: <models.* from allowlist>,
+     model: <models.plan-reviewer-b from allowlist>,
      prompt: "You are Plan Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -340,8 +387,10 @@ gates.max_plan_iterations (default: 4)
      Quest brief: .quest/<id>/quest_brief.md
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
-     Write your review to: .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
+     - .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -350,7 +399,7 @@ gates.max_plan_iterations (default: 4)
    **Fast mode** (only if `review_mode: fast`):
    ```
    mcp__codex__codex(
-     model: <models.* from allowlist>,
+     model: <models.plan-reviewer-b from allowlist>,
      prompt: "You are Plan Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -359,8 +408,11 @@ gates.max_plan_iterations (default: 4)
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
      List up to 5 issues, highest severity first.
-     Write your review to: .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
+     - .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: arbiter"
@@ -372,9 +424,9 @@ gates.max_plan_iterations (default: 4)
    - Record the current wall-clock time as `dispatch_end`
    - Read `.quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json` and `handoff_plan-reviewer-b.json`
    - Verify both review files exist (from handoff.artifacts)
-   - Apply deterministic precedence from **Handoff File Polling**:
-     - Claude slot follows the Claude-runtime precedence above: native task may use direct text fallback; bridge path retries once for timeout/malformed output and blocks immediately on auth/CLI failures.
-     - Codex slot: on timeout, fall back to Claude runtime immediately (no retry); on other failures, retry once then Claude runtime fallback.
+   - Apply the **three-tier fallback ladder** from **Handoff File Polling** §6:
+     - Claude slot follows the Claude-runtime precedence: native task may use direct text fallback; bridge path applies Tier B (permission escalation via `--add-dir`) for write-boundary/permission failures, then Tier C (retry once for timeout/malformed output, block immediately on auth/CLI failures).
+     - Codex slot: classify failure via `classify_failure_kind` logic. Tier B (write-boundary/permission): retry with `sandbox_permissions: "danger-full-access"` only with explicit user approval or an equivalent persisted approval; otherwise stop and surface the approval need. Tier C (timeout, model, or Tier B exhausted): timeout → Claude runtime fallback immediately; other failures → retry once with strict non-interactive reminder, then Claude runtime fallback.
 
    **Parallelism check (orchestrator-timed):**
    1. Create `.quest/<id>/logs/` directory if it doesn't exist
@@ -393,6 +445,7 @@ gates.max_plan_iterations (default: 4)
    - Log: `Plan review: arbiter=skipped (solo mode, using reviewer-a verdict)` to `.quest/<id>/logs/parallelism.log`
 
    **If `quest_mode == "workflow"` (default):** Read `models.arbiter` from allowlist. Invoke Arbiter through the corresponding runtime:
+   - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `arbiter_verdict.md` and `handoff_arbiter.json` in `.quest/<id>/phase_01_plan/`.
    - Use a short prompt with path references only:
      ```
      You are the Arbiter Agent.
@@ -404,12 +457,14 @@ gates.max_plan_iterations (default: 4)
      Review A: .quest/<id>/phase_01_plan/review_plan-reviewer-a.md
      Review B: .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
 
-     Write verdict to: .quest/<id>/phase_01_plan/arbiter_verdict.md
-     Write handoff file to: .quest/<id>/phase_01_plan/handoff_arbiter.json
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_01_plan/arbiter_verdict.md
+     - .quest/<id>/phase_01_plan/handoff_arbiter.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: builder (approve) or planner (iterate)
      ```
-   - Wait for the selected Claude runtime to complete
+   - Wait for the selected runtime to complete
    - Read `.quest/<id>/phase_01_plan/handoff_arbiter.json`
    - Route based on `next` field ("builder" = approved, "planner" = iterate)
    - Apply deterministic precedence from **Handoff File Polling** for native Claude task vs bridge execution
@@ -534,25 +589,33 @@ After plan approval, present the plan interactively before proceeding to build.
 
 3. **Invoke Builder** (default Codex `mcp__codex__codex`, Claude runtime fallback):
    - Read `models.builder` from allowlist.
-   - If builder model is Codex, invoke via `mcp__codex__codex`.
+   - If builder model is Codex, invoke via `mcp__codex__codex` with `sandbox_permissions: "workspace-write"`.
    - If builder model is Claude, invoke through Claude runtime (native `Task(...)` when available, bridge in Codex-led sessions).
+   - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `pr_description.md`, `builder_feedback_discussion.md`, and `handoff.json` in `.quest/<id>/phase_02_implementation/`.
    - Prompt: Reference file paths only, do not embed content:
      - Approved plan: `.quest/<id>/phase_01_plan/plan.md`
      - Quest brief: `.quest/<id>/quest_brief.md`
    - Require the prompt to include:
      - If using Codex path: `Read your instructions: .skills/quest/agents/builder.md`
-     - Write output artifacts under: `.quest/<id>/phase_02_implementation/`
-     - Write handoff file to: `.quest/<id>/phase_02_implementation/handoff.json` with schema: `{"status", "artifacts", "next", "summary"}`
+     - Artifact files have been prepared. Overwrite them directly:
+       - `.quest/<id>/phase_02_implementation/pr_description.md`
+       - `.quest/<id>/phase_02_implementation/builder_feedback_discussion.md`
+       - `.quest/<id>/phase_02_implementation/handoff.json`
+     - Do not create Quest artifacts via shell redirection, heredocs, or echo.
+     - handoff.json schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: code_review`
    - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_02_implementation/handoff.json` for status/routing
    - Verify artifacts written (from handoff.artifacts)
-   - If Codex path fails:
-     - **Timeout (`McpError`):** Skip retry. Invoke Claude runtime fallback for builder immediately.
-     - **Other failures** (`needs_human`, malformed output, missing/unparsable handoff, `blocked`):
-       1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
-       2. If still non-compliant, invoke Claude runtime fallback for builder with the same artifact-path contract.
+   - Apply the **three-tier fallback ladder** from **Handoff File Polling** §6:
+     - Classify failure via `classify_failure_kind` logic.
+     - **Tier B** (write-boundary/permission): Codex → retry with `sandbox_permissions: "danger-full-access"` only with explicit user approval or an equivalent persisted approval. Bridge Claude → add out-of-workspace dirs via `--add-dir`. Native Claude → widen tool permissions.
+     - **Tier C** (timeout, model, invocation, or Tier B exhausted):
+       - **Timeout (`McpError`):** Skip retry. Invoke Claude runtime fallback for builder immediately.
+       - **Other failures** (`needs_human`, malformed output, missing/unparsable handoff, `blocked`):
+         1. Re-run same runtime once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
+         2. If still non-compliant, invoke Claude runtime fallback for builder with the same artifact-path contract.
      - If the Claude runtime fallback uses the bridge, apply bridge failure handling from **Handoff File Polling**.
      - Only ask the user questions if the Claude runtime fallback returns `needs_human`.
    - If the final selected attempt still has missing/unparsable handoff.json, parse text handoff from response as last-resort compatibility fallback.
@@ -594,8 +657,9 @@ After plan approval, present the plan interactively before proceeding to build.
    - **Reviewer A**: dispatched by orchestrator → `.quest/<id>/phase_03_review/review_code-reviewer-a.md`
    - **Reviewer B** (workflow only): dispatched by orchestrator → `.quest/<id>/phase_03_review/review_code-reviewer-b.md`
 
-   **Slot A** (runtime per `models.code-reviewer-a`; full and fast modes):
+   **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `review_code-reviewer-a.md` and `handoff_code-reviewer-a.json` in `.quest/<id>/phase_03_review/`, and `review_code-reviewer-b.md` and `handoff_code-reviewer-b.json` for Reviewer B (workflow mode only).
 
+   **Slot A** (runtime per `models.code-reviewer-a`; full and fast modes):
    **Full mode**:
    ```
    Task(
@@ -613,8 +677,11 @@ After plan approval, present the plan interactively before proceeding to build.
      Diff summary: <git diff --stat>
 
      Review ONLY the files listed above. Use git diff for details.
-     Write review to: .quest/<id>/phase_03_review/review_code-reviewer-a.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_code-reviewer-a.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_03_review/review_code-reviewer-a.md
+     - .quest/<id>/phase_03_review/handoff_code-reviewer-a.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -635,8 +702,11 @@ After plan approval, present the plan interactively before proceeding to build.
 
      Review ONLY the files listed above.
      List up to 5 issues, highest severity first.
-     Write review to: .quest/<id>/phase_03_review/review_code-reviewer-a.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_code-reviewer-a.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_03_review/review_code-reviewer-a.md
+     - .quest/<id>/phase_03_review/handoff_code-reviewer-a.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -648,7 +718,7 @@ After plan approval, present the plan interactively before proceeding to build.
    **Full mode**:
    ```
    mcp__codex__codex(
-     model: <models.* from allowlist>,
+     model: <models.code-reviewer-b from allowlist>,
      prompt: "You are Code Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -663,8 +733,11 @@ After plan approval, present the plan interactively before proceeding to build.
      Diff summary: <git diff --stat>
 
      Review ONLY the files listed above. Use git diff for details.
-     Write review to: .quest/<id>/phase_03_review/review_code-reviewer-b.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_03_review/review_code-reviewer-b.md
+     - .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -673,7 +746,7 @@ After plan approval, present the plan interactively before proceeding to build.
    **Fast mode**:
    ```
    mcp__codex__codex(
-     model: <models.* from allowlist>,
+     model: <models.code-reviewer-b from allowlist>,
      prompt: "You are Code Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -686,8 +759,11 @@ After plan approval, present the plan interactively before proceeding to build.
 
      Review ONLY the files listed above.
      List up to 5 issues, highest severity first.
-     Write review to: .quest/<id>/phase_03_review/review_code-reviewer-b.md
-     Write handoff file to: .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
+
+     Artifact files have been prepared for you. Overwrite these files directly:
+     - .quest/<id>/phase_03_review/review_code-reviewer-b.md
+     - .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
+     Do not create Quest artifacts via shell redirection, heredocs, or echo.
 
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
      NEXT: fixer (if issues) or null (if clean)"
@@ -700,9 +776,9 @@ After plan approval, present the plan interactively before proceeding to build.
    - Record the current wall-clock time as `dispatch_end`
    - Read `.quest/<id>/phase_03_review/handoff_code-reviewer-a.json` and `handoff_code-reviewer-b.json`
    - Verify both review files exist (from handoff.artifacts)
-   - Apply deterministic precedence from **Handoff File Polling**:
-     - Claude slot follows the Claude-runtime precedence above: native task may use direct text fallback; bridge path retries once for timeout/malformed output and blocks immediately on auth/CLI failures.
-     - Codex slot: on timeout, fall back to Claude runtime immediately (no retry); on other failures, retry once then Claude runtime fallback.
+   - Apply the **three-tier fallback ladder** from **Handoff File Polling** §6:
+     - Claude slot follows the Claude-runtime precedence: native task may use direct text fallback; bridge path applies Tier B (permission escalation via `--add-dir`) for write-boundary/permission failures, then Tier C (retry once for timeout/malformed output, block immediately on auth/CLI failures).
+     - Codex slot: classify failure via `classify_failure_kind` logic. Tier B (write-boundary/permission): retry with `sandbox_permissions: "danger-full-access"` only with explicit user approval or an equivalent persisted approval; otherwise stop and surface the approval need. Tier C (timeout, model, or Tier B exhausted): timeout → Claude runtime fallback immediately; other failures → retry once with strict non-interactive reminder, then Claude runtime fallback.
 
    **Parallelism check (orchestrator-timed):**
    1. Create `.quest/<id>/logs/` directory if it doesn't exist
@@ -765,19 +841,26 @@ After plan approval, present the plan interactively before proceeding to build.
      - Changed files: <file list from git diff>
      - Quest brief: `.quest/<id>/quest_brief.md`
      - Plan: `.quest/<id>/phase_01_plan/plan.md`
+   - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `review_fix_feedback_discussion.md` and `handoff_fixer.json` in `.quest/<id>/phase_03_review/`.
    - Require the prompt to include:
      - If using Codex path: `Read your instructions: .skills/quest/agents/fixer.md`
-     - Write feedback to: `.quest/<id>/phase_03_review/review_fix_feedback_discussion.md`
-     - Write handoff file to: `.quest/<id>/phase_03_review/handoff_fixer.json` with schema: `{"status", "artifacts", "next", "summary"}`
+     - Artifact files have been prepared for you. Overwrite these files directly:
+       - `.quest/<id>/phase_03_review/review_fix_feedback_discussion.md`
+       - `.quest/<id>/phase_03_review/handoff_fixer.json`
+     - Do not create Quest artifacts via shell redirection, heredocs, or echo.
+     - handoff.json schema: `{"status", "artifacts", "next", "summary"}`
      - End with: `---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY`
      - `NEXT: code_review`
    - Wait for selected tool call to complete
    - Read `.quest/<id>/phase_03_review/handoff_fixer.json` for status/routing
-   - If Codex path fails:
-     - **Timeout (`McpError`):** Skip retry. Invoke Claude runtime fallback for fixer immediately.
-     - **Other failures** (`needs_human`, malformed output, missing/unparsable handoff, `blocked`):
-       1. Re-run Codex once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
-       2. If still non-compliant, invoke Claude runtime fallback for fixer with the same artifact-path contract.
+   - Apply the **three-tier fallback ladder** from **Handoff File Polling** §6:
+     - Classify failure via `classify_failure_kind` logic.
+     - **Tier B** (write-boundary/permission): Codex → retry with `sandbox_permissions: "danger-full-access"` only with explicit user approval or an equivalent persisted approval. Bridge Claude → add out-of-workspace dirs via `--add-dir`. Native Claude → widen tool permissions.
+     - **Tier C** (timeout, model, invocation, or Tier B exhausted):
+       - **Timeout (`McpError`):** Skip retry. Invoke Claude runtime fallback for fixer immediately.
+       - **Other failures** (`needs_human`, malformed output, missing/unparsable handoff, `blocked`):
+         1. Re-run same runtime once with strict non-interactive reminder ("no questions, no `needs_human`, explicit assumptions").
+         2. If still non-compliant, invoke Claude runtime fallback for fixer with the same artifact-path contract.
      - If the Claude runtime fallback uses the bridge, apply bridge failure handling from **Handoff File Polling**.
      - Only ask the user questions if the Claude runtime fallback returns `needs_human`.
    - If the final selected attempt still has missing/unparsable handoff.json, parse text handoff from response as last-resort compatibility fallback.
@@ -1112,7 +1195,7 @@ Codex MCP calls can be slower when each run must:
 **Example minimal prompt:**
 ```
 mcp__codex__codex(
-  model: <models.* from allowlist>,
+  model: <models.plan-reviewer-b from allowlist>,
   prompt: "Review .quest/<id>/phase_01_plan/plan.md
 
   List any issues (max 5 bullets). Write to .quest/<id>/phase_01_plan/review_plan-reviewer-b.md

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -26,7 +26,6 @@ architecture docs.
 ### Architecture and Workflow Evolution
 | File | Status | Purpose |
 |---|---|---|
-| `generic-artifact-preparation-and-runtime-fallbacks.md` | proposed | Generic Quest plan for workspace-local artifact paths, precreated per-role artifacts, and same-runtime permission fallback before cross-runtime fallback. |
 | `phase2b-context-leak-closure.md` | in-progress | Concrete closure plan and findings for remaining context leaks. |
 | `quest-file-attribution-line.md` | idea | File-level Quest attribution and license provenance line. |
 | `quest-multi-phase-execution.md` | proposed | Recommended pattern for handling large multi-phase initiatives: umbrella planning quest, then separate phase quests unless the passes still feed one bounded deliverable set. |
@@ -48,6 +47,7 @@ architecture docs.
 ### Done Index
 | Status | Idea | Note |
 |---|---|---|
+| done | ~~generic-artifact-preparation-and-runtime-fallbacks~~ | Implemented on `codex-artifact-staging` / PR #74. Archived at [`ideas/archive/generic-artifact-preparation-and-runtime-fallbacks.md`](archive/generic-artifact-preparation-and-runtime-fallbacks.md). |
 | done | ~~quest_dispatcher~~ | Quest now routes Codex-led Claude roles through the Quest runner/probe path with runtime logging and handoff polling. See [journal](../docs/quest-journal/quest-dispatcher_2026-03-09.md). |
 | done | ~~codex-led-claude-bridge-runtime-hardening~~ | Codex-led Claude bridge runtime path shipped, documented, and exercised in a solo smoke test. See [journal](../docs/quest-journal/codex-led-claude-bridge-runtime-hardening_2026-03-09.md). |
 | done | ~~codex-calls-claude~~ | Claude CLI bridge prototype graduated to supported script/runtime docs. See [journal](../docs/quest-journal/codex-calls-claude_2026-03-09.md). |

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -26,6 +26,7 @@ architecture docs.
 ### Architecture and Workflow Evolution
 | File | Status | Purpose |
 |---|---|---|
+| `generic-artifact-preparation-and-runtime-fallbacks.md` | proposed | Generic Quest plan for workspace-local artifact paths, precreated per-role artifacts, and same-runtime permission fallback before cross-runtime fallback. |
 | `phase2b-context-leak-closure.md` | in-progress | Concrete closure plan and findings for remaining context leaks. |
 | `quest-file-attribution-line.md` | idea | File-level Quest attribution and license provenance line. |
 | `quest-multi-phase-execution.md` | proposed | Recommended pattern for handling large multi-phase initiatives: umbrella planning quest, then separate phase quests unless the passes still feed one bounded deliverable set. |

--- a/ideas/archive/generic-artifact-preparation-and-runtime-fallbacks.md
+++ b/ideas/archive/generic-artifact-preparation-and-runtime-fallbacks.md
@@ -1,6 +1,13 @@
 # Generic Artifact Preparation And Runtime Fallbacks
 
-Status: proposed
+Status: archived
+
+Archived: 2026-03-18
+
+Outcome:
+- Implemented on branch `codex-artifact-staging`
+- Draft PR: `#74`
+- Kept as archive context now that the active proposal has been executed
 
 ## Question
 

--- a/ideas/generic-artifact-preparation-and-runtime-fallbacks.md
+++ b/ideas/generic-artifact-preparation-and-runtime-fallbacks.md
@@ -1,0 +1,280 @@
+# Generic Artifact Preparation And Runtime Fallbacks
+
+Status: proposed
+
+## Question
+
+How should Quest reduce artifact-write permission failures and shell-based artifact creation noise in a way that stays generic across Claude-led and Codex-led runs?
+
+## Position
+
+Treat this as one runtime-neutral orchestration problem with three linked rules:
+
+1. Quest-owned artifacts should be workspace-local by default.
+2. The orchestrator should prepare expected artifact files before each role invocation.
+3. Fallbacks should distinguish permission/transport failures from model/runtime failures.
+
+This should apply whether:
+- Claude orchestrates Claude natively
+- Claude orchestrates Codex
+- Codex orchestrates Claude through the bridge
+- Codex orchestrates Codex
+
+For Codex, assume `gpt-5.4` is the target model.
+
+## What We Learned
+
+The most important insight is:
+
+- missing `handoff.json` was often a **write failure**, not a handoff-contract failure
+
+In the failing case, Codex was asked to write quest artifacts to an absolute `.quest` path outside the active repo workspace. Under sandboxed execution, that caused:
+
+1. artifact write failure
+2. missing `handoff.json`
+3. Quest falling back to text `---HANDOFF---`
+
+So the root cause was primarily:
+- artifact path / writable-workspace mismatch
+
+not:
+- handoff schema quality
+- text parsing
+- Codex reasoning quality
+
+## Problem Statement
+
+Quest currently mixes together several concerns:
+
+- where quest artifacts live
+- who creates/truncates them
+- how agents write them
+- what fallback should happen when a write fails
+
+This creates noisy permission prompts and fragile handoff compliance, especially for Codex roles.
+
+The wrong fix is broadening permissions globally.
+
+The better fix is to define a generic orchestration model that:
+- keeps normal artifact paths workspace-local
+- preps files before invocation
+- escalates permissions only when the failure is specifically a write-boundary issue
+- changes runtime/model only after permission/transport fallback is exhausted
+
+## Scope
+
+In scope:
+- Quest-owned artifacts under `.quest/**`
+- artifact path policy
+- artifact preparation before role invocation
+- fallback policy for artifact-write failures
+- documentation/tests for Claude/Codex parity expectations
+
+Out of scope:
+- product/source file creation policy during build/fix
+- changing handoff schema
+- changing gate sequence
+- changing non-Quest artifact locations outside the quest contract
+
+## Core Design
+
+### 1. Workspace-local artifact root by default
+
+Quest should default to writing artifacts under the active repo root:
+
+- `<repo>/.quest/<id>/...`
+
+This is the default that works best for sandboxed runtimes.
+
+If a quest run wants to place `.quest` outside the active workspace, that should be treated as an explicit exceptional mode with corresponding runtime implications.
+
+### 2. Generic artifact preparation before invocation
+
+Before each role invocation, the orchestrator should:
+
+1. resolve the expected artifact paths for the current role
+2. ensure parent directories exist
+3. create or truncate those files
+4. tell the agent to overwrite those prepared files directly
+5. tell the agent not to use shell redirection/heredocs for Quest artifact creation
+
+This rule should key off:
+- phase
+- agent
+- quest mode
+- iteration when needed
+
+It should not branch on:
+- orchestrator identity
+- Claude vs Codex
+
+### 3. Fallback ladder must separate write failures from runtime failures
+
+Quest currently tends to think in terms of "runtime fallback." That is too coarse.
+
+The fallback ladder should be:
+
+#### A. Normal run
+- configured runtime/model
+- normal sandbox/permission posture
+
+#### B. Permission/transport fallback
+- same runtime
+- same model
+- more permissive filesystem/sandbox posture only if the failure is specifically an artifact-write boundary issue
+
+Examples:
+- Codex `gpt-5.4`: `workspace-write` -> `danger-full-access` only when required because artifact path is outside writable workspace
+- Claude bridge: widen `--add-dir` / transport permissions if the write boundary is the blocker
+
+#### C. Cross-runtime fallback
+- only after the permission/transport retry still fails
+- or when the failure is not a write-boundary problem
+
+This preserves the distinction between:
+- "the model could not write the file"
+- "the model could not do the task"
+
+Those are not the same problem and should not share the same first fallback.
+
+## Expected Artifact Contract
+
+Quest already has stable role artifacts such as:
+
+- planner:
+  - `plan.md`
+  - `handoff.json`
+- plan reviewers:
+  - `review_plan-reviewer-a.md`
+  - `review_plan-reviewer-b.md`
+  - `handoff_plan-reviewer-a.json`
+  - `handoff_plan-reviewer-b.json`
+- arbiter:
+  - `arbiter_verdict.md`
+  - `handoff_arbiter.json`
+- builder:
+  - `pr_description.md`
+  - `builder_feedback_discussion.md`
+  - `handoff.json`
+- code reviewers:
+  - `review_code-reviewer-a.md`
+  - `review_code-reviewer-b.md`
+  - `handoff_code-reviewer-a.json`
+  - `handoff_code-reviewer-b.json`
+- fixer:
+  - `review_fix_feedback_discussion.md`
+  - `handoff_fixer.json`
+
+This means the work is not inventing a new artifact model; it is enforcing a better orchestration invariant around the one Quest already has.
+
+## Proposed Implementation Shape
+
+### Artifact helper
+
+Add a helper such as:
+
+- `scripts/quest_runtime/artifacts.py`
+
+Suggested API:
+
+```python
+expected_artifacts_for_role(phase, agent, quest_mode="workflow") -> list[str]
+prepare_artifact_files(paths: list[str]) -> None
+assert_workspace_local_or_explain(paths: list[str], workspace_root: str) -> result
+```
+
+### Workflow integration
+
+Update Quest orchestration so that before every role invocation it:
+
+1. resolves the current role's artifact paths
+2. checks whether they are workspace-local for the active runtime
+3. prepares the files
+4. records any exceptional path/escalation decision
+
+### Prompt updates
+
+Prompts should consistently say:
+
+- these files already exist
+- overwrite them directly
+- do not create Quest artifacts via shell redirection/heredocs
+
+This wording should be generic and used across Claude/Codex runtime paths.
+
+## Runtime Matrix
+
+### Claude -> Claude native
+
+Still uses the generic artifact preparation rule.
+
+### Claude -> Codex (`gpt-5.4`)
+
+Uses the generic artifact preparation rule plus workspace-local path discipline.
+If artifact paths are outside workspace and the write fails, retry first with Codex permission escalation before switching runtime.
+
+### Codex (`gpt-5.4`) -> Claude bridge
+
+Uses the same artifact preparation rule.
+If the bridge cannot write due to path/access boundary, handle that as a transport/permission problem before treating it as a model/runtime problem.
+
+### Codex (`gpt-5.4`) -> Codex (`gpt-5.4`)
+
+Same rules again. No Codex-specific artifact contract.
+
+## Acceptance Criteria
+
+1. Quest-owned artifacts are repo-local by default for sandboxed runtime paths.
+2. Before each role invocation, Quest prepares only that role's expected artifact files.
+3. Prepared files are created/truncated generically across runtime paths.
+4. Artifact preparation logic does not branch on orchestrator identity.
+5. Prompts consistently instruct agents to overwrite prepared artifact files directly and avoid shell redirection/heredocs for Quest artifact creation.
+6. Fallback logic distinguishes permission/transport failure from cross-runtime failure.
+7. For artifact-write failures, the first retry is same runtime + same model + increased permission posture when appropriate.
+8. Cross-runtime fallback happens only after permission/transport fallback is exhausted or when the failure is not a write-boundary issue.
+9. `handoff.json` compliance improves for Codex roles because file-write failures are addressed at the root cause.
+10. No broad default escalation to `danger-full-access`; it remains explicit and exceptional.
+
+## Validation Strategy
+
+Automated:
+- unit tests for artifact resolution/preparation
+- unit tests for workspace-local path checks
+- tests for fallback classification: write-boundary vs non-write failure
+- runtime tests covering planner/reviewer/builder/fixer artifact prep
+
+Manual:
+1. Run a repo-local quest where Codex writes to `<repo>/.quest/...` and confirm `handoff.json` succeeds.
+2. Run an out-of-workspace artifact-path case and confirm Quest uses same-runtime permission fallback before cross-runtime fallback.
+3. Verify Claude-led and Codex-led runs both follow the same high-level ladder.
+
+## Risks
+
+1. Path-policy enforcement could conflict with existing setups that intentionally use a shared parent `.quest`.
+   Mitigation: support explicit exceptional mode rather than silent failure.
+
+2. Permission escalation could become overused.
+   Mitigation: tie escalation only to declared artifact-write boundary failures.
+
+3. Generic helper drift vs workflow docs.
+   Mitigation: validator/test coverage for role-to-artifact mapping and fallback policy.
+
+## Files Likely To Change
+
+- `.skills/quest/delegation/workflow.md`
+- `.ai/quest.md`
+- `scripts/quest_runtime/artifacts.py` (new)
+- `scripts/quest_runtime/claude_runner.py`
+- runtime/fallback tests
+- validator/docs for the generic invariant
+
+## Recommendation
+
+Do not implement this as a Codex patch.
+
+Implement it as a generic Quest runtime rule set:
+- workspace-local artifact paths by default
+- generic artifact preparation before invocation
+- same-runtime permission fallback before cross-runtime fallback
+
+That solves the real failure mode while preserving parity between Claude-led and Codex-led orchestration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Static HTML dashboard generator for Quest"
 requires-python = ">=3.10"
 
+[project.scripts]
+quest-checks = "quest_checks.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["scripts"]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ Build and utility scripts for the Quest repository.
 |------------------|---------|
 | `quest_dashboard/` | Python package that generates a static HTML Quest Dashboard from journal entries and active quest state. See `quest_dashboard/README.md` for details. |
 | `quest_runtime/` | Python package with Quest orchestration helpers (state updates, Claude bridge runner, handoff polling). |
+| `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running the standard Quest validation and test suite. |
 | `claude_cli_bridge.py` | Thin transport bridge from the current host into Claude CLI for Codex-led Claude-designated Quest roles. |
 | `quest_claude_probe.py` | Probes the Claude bridge by requiring a real artifact write and `handoff.json` under the quest logs directory. |
 | `quest_state.py` | Updates `.quest/<id>/state.json` consistently and refreshes `updated_at`. |
@@ -31,6 +32,9 @@ python3 scripts/quest_claude_runner.py --quest-dir .quest/<id> --phase plan_revi
 
 # Probe the Claude bridge with a real artifact + handoff write
 python3 scripts/quest_claude_probe.py --quest-dir .quest/<id> --model opus
+
+# Run the standard Quest validations and test suite
+quest-checks
 
 # Validate quest configuration
 bash scripts/validate-quest-config.sh

--- a/scripts/quest_celebrate/quest_data.py
+++ b/scripts/quest_celebrate/quest_data.py
@@ -68,7 +68,9 @@ class QuestData:
     pr_number: Optional[int] = None
     achievements: List[Achievement] = field(default_factory=list)
     quality_score: int = 0
-    quality_tier: str = ""  # Diamond/Platinum/Gold/Silver/Bronze/Tin/Cardboard/Abandoned
+    quality_tier: str = (
+        ""  # Diamond/Platinum/Gold/Silver/Bronze/Tin/Cardboard/Abandoned
+    )
     test_count: Optional[int] = None
     tests_added: Optional[int] = None
 
@@ -115,7 +117,10 @@ def _load_allowlist_quality_defaults() -> Tuple[int, int, int]:
         and gates["max_plan_iterations"] >= 1
     ):
         max_plan_iterations = gates["max_plan_iterations"]
-    if type(gates.get("max_fix_iterations")) is int and gates["max_fix_iterations"] >= 1:
+    if (
+        type(gates.get("max_fix_iterations")) is int
+        and gates["max_fix_iterations"] >= 1
+    ):
         max_fix_iterations = gates["max_fix_iterations"]
 
     solo = data.get("solo", {})
@@ -627,9 +632,7 @@ def compute_quality_tier(
 
     effective_max_fix_iterations = max_fix_iterations
     if quest_mode == "solo":
-        effective_max_fix_iterations = min(
-            max_fix_iterations, solo_max_fix_iterations
-        )
+        effective_max_fix_iterations = min(max_fix_iterations, solo_max_fix_iterations)
 
     # Check from worst to best so max-gate check uses strict equality
 
@@ -800,7 +803,9 @@ def load_quest_data_from_journal(journal_path: Path) -> QuestData:
 
         quote = celebration.get("quote", {})
         if isinstance(quote, dict) and quote:
-            data.brief_summary = f'{quote.get("text", "")} — {quote.get("attribution", "")}'
+            data.brief_summary = (
+                f'{quote.get("text", "")} — {quote.get("attribution", "")}'
+            )
 
         victory_narrative = celebration.get("victory_narrative")
         if isinstance(victory_narrative, str):
@@ -832,9 +837,7 @@ def load_quest_data_from_journal(journal_path: Path) -> QuestData:
         data.plan_iterations = int(plan_match.group(1))
         parsed_plan_iterations = True
 
-    fix_match = re.search(
-        r"(?:\*\*)?[Ff]ix\s+iterations:\s*(?:\*\*)?\s*(\d+)", content
-    )
+    fix_match = re.search(r"(?:\*\*)?[Ff]ix\s+iterations:\s*(?:\*\*)?\s*(\d+)", content)
     parsed_fix_iterations = False
     if fix_match:
         data.fix_iterations = int(fix_match.group(1))

--- a/scripts/quest_checks/__init__.py
+++ b/scripts/quest_checks/__init__.py
@@ -1,0 +1,1 @@
+"""Quest validation and test runner package."""

--- a/scripts/quest_checks/cli.py
+++ b/scripts/quest_checks/cli.py
@@ -1,0 +1,30 @@
+"""Run the standard Quest validation and test commands."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+COMMANDS: list[tuple[str, list[str]]] = [
+    ("validate quest config", ["bash", "scripts/validate-quest-config.sh"]),
+    ("validate manifest", ["bash", "scripts/validate-manifest.sh"]),
+    ("python tests", [sys.executable, "-m", "pytest"]),
+    ("quest runtime shell tests", ["bash", "tests/test-quest-runtime.sh"]),
+    (
+        "handoff contract shell tests",
+        ["bash", "tests/test-validate-handoff-contracts.sh"],
+    ),
+    ("quest state shell tests", ["bash", "tests/test-validate-quest-state.sh"]),
+]
+
+
+def main() -> int:
+    for label, command in COMMANDS:
+        print(f"==> {label}: {' '.join(command)}")
+        completed = subprocess.run(command, cwd=REPO_ROOT, check=False)
+        if completed.returncode != 0:
+            return completed.returncode
+    return 0

--- a/scripts/quest_claude_probe.py
+++ b/scripts/quest_claude_probe.py
@@ -11,7 +11,9 @@ from quest_runtime.claude_runner import run_bridge_probe
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Probe Quest Claude bridge via artifact write")
+    parser = argparse.ArgumentParser(
+        description="Probe Quest Claude bridge via artifact write"
+    )
     parser.add_argument("--quest-dir", required=True)
     parser.add_argument("--model", default="opus")
     parser.add_argument("--timeout", type=float, default=30.0)

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -30,11 +30,23 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    artifact_paths = expected_artifacts_for_role(
-        quest_dir=args.quest_dir,
-        phase=args.phase,
-        agent=args.agent,
-    )
+    try:
+        artifact_paths = expected_artifacts_for_role(
+            quest_dir=args.quest_dir,
+            phase=args.phase,
+            agent=args.agent,
+        )
+    except ValueError as exc:
+        payload = {
+            "exit_code": 1,
+            "handoff_state": "missing",
+            "result_kind": "invocation_error",
+            "source": None,
+            "stderr": str(exc),
+            "stdout": "",
+        }
+        print(json.dumps(payload, ensure_ascii=True))
+        return 1
     result = run_claude_role(
         cwd=args.cwd,
         quest_dir=args.quest_dir,

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -7,6 +7,7 @@ import argparse
 import json
 from pathlib import Path
 
+from quest_runtime.artifacts import expected_artifacts_for_role
 from quest_runtime.claude_runner import run_claude_role
 
 
@@ -29,6 +30,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    artifact_paths = expected_artifacts_for_role(
+        quest_dir=args.quest_dir,
+        phase=args.phase,
+        agent=args.agent,
+    )
     result = run_claude_role(
         cwd=args.cwd,
         quest_dir=args.quest_dir,
@@ -41,6 +47,7 @@ def main() -> int:
         model=args.model,
         timeout=args.timeout,
         permission_mode=args.permission_mode,
+        artifact_paths=artifact_paths,
         add_dirs=args.add_dir,
     )
     payload = {

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -48,6 +48,7 @@ def main() -> int:
         timeout=args.timeout,
         permission_mode=args.permission_mode,
         artifact_paths=artifact_paths,
+        allow_text_fallback=True,
         add_dirs=args.add_dir,
     )
     payload = {

--- a/scripts/quest_dashboard/loaders.py
+++ b/scripts/quest_dashboard/loaders.py
@@ -177,7 +177,9 @@ def _parse_journal_entry(journal_path: Path, repo_root: Path) -> JournalEntry:
         quality_info = celebration_data.get("quality", {})
         if isinstance(quality_info, dict):
             tier = quality_info.get("tier")
-            quality_tier = tier if isinstance(tier, str) and tier in QUALITY_TIERS else None
+            quality_tier = (
+                tier if isinstance(tier, str) and tier in QUALITY_TIERS else None
+            )
 
         # Extract unique model names from agents list
         models: list[str] = []

--- a/scripts/quest_dashboard/render.py
+++ b/scripts/quest_dashboard/render.py
@@ -38,14 +38,54 @@ _BADGE_TEXT = {
 
 # Quality tier badge colors and tooltips
 _TIER_STYLE = {
-    "Diamond": ("rgba(56, 189, 248, 0.15)", "#38bdf8", "rgba(56, 189, 248, 0.3)", "Flawless — zero issues, shipped clean"),
-    "Platinum": ("rgba(52, 211, 153, 0.15)", "#34d399", "rgba(52, 211, 153, 0.3)", "Near-perfect — minor issues, one-pass fix"),
-    "Gold": ("rgba(96, 165, 250, 0.15)", "#60a5fa", "rgba(96, 165, 250, 0.3)", "Solid — issues caught, fixed cleanly"),
-    "Silver": ("rgba(96, 165, 250, 0.15)", "#60a5fa", "rgba(96, 165, 250, 0.3)", "Workable — multiple iterations but landed"),
-    "Bronze": ("rgba(245, 158, 11, 0.15)", "#f59e0b", "rgba(245, 158, 11, 0.3)", "Rough ride — got through, bruised"),
-    "Tin": ("rgba(148, 163, 184, 0.15)", "#94a3b8", "rgba(148, 163, 184, 0.3)", "Dented — 3+ iterations, plan revisions"),
-    "Cardboard": ("rgba(148, 163, 184, 0.15)", "#94a3b8", "rgba(148, 163, 184, 0.3)", "Held together with tape. Still shipped."),
-    "Abandoned": ("rgba(248, 113, 113, 0.15)", "#f87171", "rgba(248, 113, 113, 0.3)", "Never shipped — lessons learned"),
+    "Diamond": (
+        "rgba(56, 189, 248, 0.15)",
+        "#38bdf8",
+        "rgba(56, 189, 248, 0.3)",
+        "Flawless — zero issues, shipped clean",
+    ),
+    "Platinum": (
+        "rgba(52, 211, 153, 0.15)",
+        "#34d399",
+        "rgba(52, 211, 153, 0.3)",
+        "Near-perfect — minor issues, one-pass fix",
+    ),
+    "Gold": (
+        "rgba(96, 165, 250, 0.15)",
+        "#60a5fa",
+        "rgba(96, 165, 250, 0.3)",
+        "Solid — issues caught, fixed cleanly",
+    ),
+    "Silver": (
+        "rgba(96, 165, 250, 0.15)",
+        "#60a5fa",
+        "rgba(96, 165, 250, 0.3)",
+        "Workable — multiple iterations but landed",
+    ),
+    "Bronze": (
+        "rgba(245, 158, 11, 0.15)",
+        "#f59e0b",
+        "rgba(245, 158, 11, 0.3)",
+        "Rough ride — got through, bruised",
+    ),
+    "Tin": (
+        "rgba(148, 163, 184, 0.15)",
+        "#94a3b8",
+        "rgba(148, 163, 184, 0.3)",
+        "Dented — 3+ iterations, plan revisions",
+    ),
+    "Cardboard": (
+        "rgba(148, 163, 184, 0.15)",
+        "#94a3b8",
+        "rgba(148, 163, 184, 0.3)",
+        "Held together with tape. Still shipped.",
+    ),
+    "Abandoned": (
+        "rgba(248, 113, 113, 0.15)",
+        "#f87171",
+        "rgba(248, 113, 113, 0.3)",
+        "Never shipped — lessons learned",
+    ),
 }
 
 _TIER_ICON = {
@@ -904,10 +944,7 @@ def _render_portfolio_section(
     if not all_quests:
         cards_html = '      <div class="empty-state">No quests in this category</div>'
     else:
-        cards = [
-            _render_quest_card(quest, github_url)
-            for _, quest in all_quests
-        ]
+        cards = [_render_quest_card(quest, github_url) for _, quest in all_quests]
         cards_html = (
             f'      <div class="quest-grid">\n' + "\n".join(cards) + "\n      </div>"
         )
@@ -952,9 +989,11 @@ def _render_quest_card(
                 f'<span><b>Quest ID:</b> <a href="{journal_url}">{html.escape(quest.quest_id)}</a></span>'
             ]
         else:
-            meta_items = [f'<span><b>Quest ID:</b> {html.escape(quest.quest_id)}</span>']
+            meta_items = [
+                f"<span><b>Quest ID:</b> {html.escape(quest.quest_id)}</span>"
+            ]
     else:
-        meta_items = [f'<span><b>Quest ID:</b> {html.escape(quest.quest_id)}</span>']
+        meta_items = [f"<span><b>Quest ID:</b> {html.escape(quest.quest_id)}</span>"]
 
     if isinstance(quest, JournalEntry):
         meta_items.append(
@@ -969,7 +1008,7 @@ def _render_quest_card(
     if quest.plan_iterations is not None or quest.fix_iterations is not None:
         plan = quest.plan_iterations or 0
         fix = quest.fix_iterations or 0
-        meta_items.append(f'<span><b>Iterations:</b> plan {plan} / fix {fix}</span>')
+        meta_items.append(f"<span><b>Iterations:</b> plan {plan} / fix {fix}</span>")
 
     # Add PR link if available (JournalEntry only)
     if isinstance(quest, JournalEntry) and quest.pr_number:
@@ -981,14 +1020,14 @@ def _render_quest_card(
     # Add agent models if available (JournalEntry with celebration_data)
     if isinstance(quest, JournalEntry) and quest.agent_models:
         models_str = ", ".join(html.escape(m) for m in quest.agent_models)
-        meta_items.append(f'<span><b>Cast:</b> {models_str}</span>')
+        meta_items.append(f"<span><b>Cast:</b> {models_str}</span>")
 
     # Add test count if available (JournalEntry with celebration_data)
     if isinstance(quest, JournalEntry) and quest.test_count is not None:
         test_str = str(quest.test_count)
         if quest.tests_added is not None:
             test_str += f" ({quest.tests_added} new)"
-        meta_items.append(f'<span><b>Tests:</b> {html.escape(test_str)}</span>')
+        meta_items.append(f"<span><b>Tests:</b> {html.escape(test_str)}</span>")
 
     meta_html = "\n            ".join(meta_items)
 
@@ -1003,7 +1042,7 @@ def _render_quest_card(
             tier_badge_html = (
                 f' <span class="badge" style="background:{bg};color:{color};'
                 f'border:1px solid {border}" title="{html.escape(tooltip)}">'
-                f'{icon} {html.escape(tier.upper())}</span>'
+                f"{icon} {html.escape(tier.upper())}</span>"
             )
 
     return f"""        <article class="quest-card">

--- a/scripts/quest_runtime/__init__.py
+++ b/scripts/quest_runtime/__init__.py
@@ -1,2 +1,21 @@
 """Quest runtime helpers for orchestration scripts."""
 
+from .artifacts import (
+    ROLE_ARTIFACTS,
+    any_artifact_missing_or_empty,
+    check_artifact_paths,
+    default_quest_dir,
+    expected_artifacts_for_role,
+    is_workspace_local,
+    prepare_artifact_files,
+)
+
+__all__ = [
+    "ROLE_ARTIFACTS",
+    "any_artifact_missing_or_empty",
+    "check_artifact_paths",
+    "default_quest_dir",
+    "expected_artifacts_for_role",
+    "is_workspace_local",
+    "prepare_artifact_files",
+]

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -1,0 +1,116 @@
+"""Quest artifact path helpers for runtime-neutral orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "planner": ("phase_01_plan", ("plan.md", "handoff.json")),
+    "plan-reviewer-a": (
+        "phase_01_plan",
+        ("review_plan-reviewer-a.md", "handoff_plan-reviewer-a.json"),
+    ),
+    "plan-reviewer-b": (
+        "phase_01_plan",
+        ("review_plan-reviewer-b.md", "handoff_plan-reviewer-b.json"),
+    ),
+    "arbiter": ("phase_01_plan", ("arbiter_verdict.md", "handoff_arbiter.json")),
+    "builder": (
+        "phase_02_implementation",
+        ("pr_description.md", "builder_feedback_discussion.md", "handoff.json"),
+    ),
+    "code-reviewer-a": (
+        "phase_03_review",
+        ("review_code-reviewer-a.md", "handoff_code-reviewer-a.json"),
+    ),
+    "code-reviewer-b": (
+        "phase_03_review",
+        ("review_code-reviewer-b.md", "handoff_code-reviewer-b.json"),
+    ),
+    "fixer": (
+        "phase_03_review",
+        ("review_fix_feedback_discussion.md", "handoff_fixer.json"),
+    ),
+}
+
+SOLO_DISABLED_AGENTS = frozenset({"plan-reviewer-b", "code-reviewer-b", "arbiter"})
+
+
+def default_quest_dir(workspace_root: str | Path, quest_id: str) -> Path:
+    """Return the default repo-local quest directory for a run."""
+
+    return Path(workspace_root).resolve() / ".quest" / quest_id
+
+
+def expected_artifacts_for_role(
+    quest_dir: str | Path,
+    phase: str,
+    agent: str,
+    quest_mode: str = "workflow",
+) -> list[Path]:
+    """Return absolute artifact paths for the requested role invocation."""
+
+    del phase  # Role drives artifact paths; workflow phase naming is caller-facing only.
+
+    normalized_agent = agent.strip()
+    if quest_mode == "solo" and normalized_agent in SOLO_DISABLED_AGENTS:
+        return []
+
+    try:
+        phase_dir, filenames = ROLE_ARTIFACTS[normalized_agent]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported quest role: {agent}") from exc
+
+    base_dir = Path(quest_dir).resolve() / phase_dir
+    return [base_dir / filename for filename in filenames]
+
+
+def prepare_artifact_files(paths: list[Path]) -> list[Path]:
+    """Create or truncate the provided artifact files."""
+
+    prepared: list[Path] = []
+    for path in paths:
+        resolved = Path(path).resolve()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text("", encoding="utf-8")
+        prepared.append(resolved)
+    return prepared
+
+
+def is_workspace_local(path: Path, workspace_root: Path) -> bool:
+    """Return True when the path resolves under the workspace root."""
+
+    try:
+        Path(path).resolve().relative_to(Path(workspace_root).resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def check_artifact_paths(
+    paths: list[Path],
+    workspace_root: Path,
+) -> tuple[list[Path], list[Path]]:
+    """Partition artifact paths into workspace-local and external buckets."""
+
+    local_paths: list[Path] = []
+    external_paths: list[Path] = []
+    for path in paths:
+        resolved = Path(path).resolve()
+        if is_workspace_local(resolved, workspace_root):
+            local_paths.append(resolved)
+        else:
+            external_paths.append(resolved)
+    return local_paths, external_paths
+
+
+def any_artifact_missing_or_empty(paths: list[Path]) -> bool:
+    """Return True when any expected artifact is missing or still empty."""
+
+    for path in paths:
+        resolved = Path(path).resolve()
+        if not resolved.exists():
+            return True
+        if resolved.stat().st_size == 0:
+            return True
+    return False

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -35,6 +35,17 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
 
 SOLO_DISABLED_AGENTS = frozenset({"plan-reviewer-b", "code-reviewer-b", "arbiter"})
 
+ROLE_PHASE_ALIASES: dict[str, frozenset[str]] = {
+    "planner": frozenset({"plan"}),
+    "plan-reviewer-a": frozenset({"plan_review"}),
+    "plan-reviewer-b": frozenset({"plan_review"}),
+    "arbiter": frozenset({"plan_review"}),
+    "builder": frozenset({"build", "building", "implementation"}),
+    "code-reviewer-a": frozenset({"code_review", "review", "reviewing"}),
+    "code-reviewer-b": frozenset({"code_review", "review", "reviewing"}),
+    "fixer": frozenset({"fix", "fixing"}),
+}
+
 
 def default_quest_dir(workspace_root: str | Path, quest_id: str) -> Path:
     """Return the default repo-local quest directory for a run."""
@@ -50,8 +61,6 @@ def expected_artifacts_for_role(
 ) -> list[Path]:
     """Return absolute artifact paths for the requested role invocation."""
 
-    del phase  # Role drives artifact paths; workflow phase naming is caller-facing only.
-
     normalized_agent = agent.strip()
     if quest_mode == "solo" and normalized_agent in SOLO_DISABLED_AGENTS:
         return []
@@ -60,6 +69,14 @@ def expected_artifacts_for_role(
         phase_dir, filenames = ROLE_ARTIFACTS[normalized_agent]
     except KeyError as exc:
         raise ValueError(f"Unsupported quest role: {agent}") from exc
+
+    normalized_phase = phase.strip().lower().replace("-", "_")
+    allowed_phases = ROLE_PHASE_ALIASES[normalized_agent]
+    if normalized_phase not in allowed_phases:
+        allowed = ", ".join(sorted(allowed_phases))
+        raise ValueError(
+            f"Quest role {agent} is not valid for phase {phase!r}. Allowed: {allowed}"
+        )
 
     base_dir = Path(quest_dir).resolve() / phase_dir
     return [base_dir / filename for filename in filenames]

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -264,6 +264,7 @@ def run_claude_role(
     permission_mode: str,
     artifact_paths: Iterable[str | Path] | None = None,
     permission_escalation: bool = False,
+    allow_text_fallback: bool = False,
     add_dirs: Iterable[str | Path] | None = None,
     poll_interval: float = 0.5,
     exit_grace_seconds: float = 2.0,
@@ -350,31 +351,19 @@ def run_claude_role(
 
     handoff_state = classify_handoff_file(resolved_handoff_file)
     text_handoff = extract_text_handoff(stdout)
-    if text_handoff is not None:
-        append_context_health_log(
-            resolved_quest_dir,
-            phase=phase,
-            agent=agent,
-            iteration=iteration,
-            handoff_state=handoff_state,
-            source="text_fallback",
-        )
-        return RunResult(
-            exit_code=0,
-            handoff_state=handoff_state,
-            result_kind="text_fallback",
-            source="text_fallback",
-            stdout=stdout,
-            stderr=stderr,
-        )
 
-    result = RunResult(
-        exit_code=process.returncode or 1,
-        handoff_state=handoff_state,
-        result_kind="timeout"
+    result_kind = (
+        "timeout"
         if timed_out
-        else classify_result_kind(process.returncode or 1, stderr, handoff_state),
-        source=None,
+        else classify_result_kind(process.returncode or 1, stderr, handoff_state)
+    )
+    source = "handoff_json" if handoff_state == "found" else None
+    exit_code = 0 if handoff_state == "found" else process.returncode or 1
+    result = RunResult(
+        exit_code=exit_code,
+        handoff_state=handoff_state,
+        result_kind=result_kind,
+        source=source,
         stdout=stdout,
         stderr=stderr,
     )
@@ -406,6 +395,7 @@ def run_claude_role(
                 permission_mode=permission_mode,
                 artifact_paths=resolved_artifact_paths,
                 permission_escalation=True,
+                allow_text_fallback=allow_text_fallback,
                 add_dirs=retry_add_dirs,
                 poll_interval=poll_interval,
                 exit_grace_seconds=exit_grace_seconds,
@@ -421,6 +411,24 @@ def run_claude_role(
                 stdout=retry_result.stdout,
                 stderr=combined_stderr,
             )
+
+    if allow_text_fallback and text_handoff is not None:
+        append_context_health_log(
+            resolved_quest_dir,
+            phase=phase,
+            agent=agent,
+            iteration=iteration,
+            handoff_state=handoff_state,
+            source="text_fallback",
+        )
+        return RunResult(
+            exit_code=0,
+            handoff_state=handoff_state,
+            result_kind="text_fallback",
+            source="text_fallback",
+            stdout=stdout,
+            stderr=stderr,
+        )
 
     return result
 

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -490,11 +490,15 @@ def run_bridge_probe(
 
     handoff_state = classify_handoff_file(handoff_file)
     source = "handoff_json" if handoff_state == "found" else None
-    exit_code = 0 if cp.returncode == 0 and handoff_state == "found" else cp.returncode or 1
+    exit_code = 0 if handoff_state == "found" else cp.returncode or 1
     return RunResult(
         exit_code=exit_code,
         handoff_state=handoff_state,
-        result_kind="handoff_json" if handoff_state == "found" else classify_result_kind(exit_code, cp.stderr, handoff_state),
+        result_kind=(
+            "handoff_json"
+            if handoff_state == "found"
+            else classify_result_kind(exit_code, cp.stderr, handoff_state)
+        ),
         source=source,
         stdout=cp.stdout,
         stderr=cp.stderr,

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -269,13 +269,71 @@ def run_claude_role(
     poll_interval: float = 0.5,
     exit_grace_seconds: float = 2.0,
 ) -> RunResult:
+    workspace_root = Path(cwd).resolve()
     resolved_quest_dir = resolve_path(cwd, quest_dir)
     resolved_prompt_file = resolve_path(cwd, prompt_file)
     resolved_handoff_file = resolve_path(cwd, handoff_file)
     resolved_artifact_paths = [resolve_path(cwd, path) for path in artifact_paths or []]
-    local_artifact_paths, _ = check_artifact_paths(resolved_artifact_paths, Path(cwd).resolve())
+    local_artifact_paths, external_artifact_paths = check_artifact_paths(
+        resolved_artifact_paths,
+        workspace_root,
+    )
     if resolved_artifact_paths and not permission_escalation:
-        prepare_artifact_files(resolved_artifact_paths)
+        try:
+            prepare_artifact_files(resolved_artifact_paths)
+        except OSError as exc:
+            failure_kind = (
+                "write_boundary"
+                if external_artifact_paths
+                else "permission"
+                if isinstance(exc, PermissionError) or "permission denied" in str(exc).lower()
+                else "invocation"
+            )
+            if failure_kind in {"write_boundary", "permission"}:
+                retry_add_dirs = list(add_dirs or [])
+                retry_add_dirs.extend(path.parent for path in external_artifact_paths)
+                retry_note = (
+                    f"Tier B retry: agent={agent} phase={phase} "
+                    f"failure_kind={failure_kind} permission_escalation=True"
+                )
+                retry_result = run_claude_role(
+                    cwd=cwd,
+                    quest_dir=resolved_quest_dir,
+                    phase=phase,
+                    agent=agent,
+                    iteration=iteration,
+                    prompt_file=resolved_prompt_file,
+                    handoff_file=resolved_handoff_file,
+                    bridge_script=bridge_script,
+                    model=model,
+                    timeout=timeout,
+                    permission_mode=permission_mode,
+                    artifact_paths=resolved_artifact_paths,
+                    permission_escalation=True,
+                    allow_text_fallback=allow_text_fallback,
+                    add_dirs=retry_add_dirs,
+                    poll_interval=poll_interval,
+                    exit_grace_seconds=exit_grace_seconds,
+                )
+                combined_stderr = retry_note
+                if retry_result.stderr:
+                    combined_stderr = f"{retry_note}\n{retry_result.stderr}"
+                return RunResult(
+                    exit_code=retry_result.exit_code,
+                    handoff_state=retry_result.handoff_state,
+                    result_kind=retry_result.result_kind,
+                    source=retry_result.source,
+                    stdout=retry_result.stdout,
+                    stderr=combined_stderr,
+                )
+            return RunResult(
+                exit_code=1,
+                handoff_state="missing",
+                result_kind="invocation_error",
+                source=None,
+                stdout="",
+                stderr=str(exc),
+            )
     default_add_dirs = [
         resolve_path(cwd, "."),
         resolved_quest_dir,
@@ -383,11 +441,11 @@ def run_claude_role(
         failure_kind = classify_failure_kind(
             result,
             resolved_artifact_paths,
-            Path(cwd).resolve(),
+            workspace_root,
         )
         if failure_kind in {"write_boundary", "permission"}:
             retry_add_dirs = list(add_dirs or [])
-            retry_add_dirs.extend(_retry_artifact_dirs(resolved_artifact_paths, Path(cwd).resolve()))
+            retry_add_dirs.extend(_retry_artifact_dirs(resolved_artifact_paths, workspace_root))
             retry_note = (
                 f"Tier B retry: agent={agent} phase={phase} "
                 f"failure_kind={failure_kind} permission_escalation=True"

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -36,7 +36,9 @@ class RunResult:
     stderr: str
 
 
-def _effective_permission_mode(permission_mode: str, permission_escalation: bool) -> str:
+def _effective_permission_mode(
+    permission_mode: str, permission_escalation: bool
+) -> str:
     if not permission_escalation:
         return permission_mode
     if permission_mode in {"default", "auto", "plan"}:
@@ -285,9 +287,12 @@ def run_claude_role(
             failure_kind = (
                 "write_boundary"
                 if external_artifact_paths
-                else "permission"
-                if isinstance(exc, PermissionError) or "permission denied" in str(exc).lower()
-                else "invocation"
+                else (
+                    "permission"
+                    if isinstance(exc, PermissionError)
+                    or "permission denied" in str(exc).lower()
+                    else "invocation"
+                )
             )
             if failure_kind in {"write_boundary", "permission"}:
                 retry_add_dirs = list(add_dirs or [])
@@ -349,7 +354,9 @@ def run_claude_role(
         prompt_file=resolved_prompt_file,
         model=model,
         timeout=timeout,
-        permission_mode=_effective_permission_mode(permission_mode, permission_escalation),
+        permission_mode=_effective_permission_mode(
+            permission_mode, permission_escalation
+        ),
         add_dirs=default_add_dirs,
     )
     process = subprocess.Popen(
@@ -368,8 +375,9 @@ def run_claude_role(
 
     while time.monotonic() < deadline:
         handoff_state = classify_handoff_file(resolved_handoff_file)
-        artifacts_complete = not resolved_artifact_paths or not any_artifact_missing_or_empty(
-            resolved_artifact_paths
+        artifacts_complete = (
+            not resolved_artifact_paths
+            or not any_artifact_missing_or_empty(resolved_artifact_paths)
         )
         if handoff_state == "found" and artifacts_complete:
             try:
@@ -413,21 +421,32 @@ def run_claude_role(
 
     handoff_state = classify_handoff_file(resolved_handoff_file)
     text_handoff = extract_text_handoff(stdout)
-    artifacts_complete = not resolved_artifact_paths or not any_artifact_missing_or_empty(
-        resolved_artifact_paths
+    artifacts_complete = (
+        not resolved_artifact_paths
+        or not any_artifact_missing_or_empty(resolved_artifact_paths)
     )
 
     result_kind = (
         "handoff_json"
         if handoff_state == "found" and artifacts_complete
-        else "timeout"
-        if timed_out
-        else "handoff_missing"
-        if handoff_state == "found" and not artifacts_complete
-        else classify_result_kind(process.returncode or 1, stderr, handoff_state)
+        else (
+            "timeout"
+            if timed_out
+            else (
+                "handoff_missing"
+                if handoff_state == "found" and not artifacts_complete
+                else classify_result_kind(
+                    process.returncode or 1, stderr, handoff_state
+                )
+            )
+        )
     )
     source = "handoff_json" if handoff_state == "found" and artifacts_complete else None
-    exit_code = 0 if handoff_state == "found" and artifacts_complete else process.returncode or 1
+    exit_code = (
+        0
+        if handoff_state == "found" and artifacts_complete
+        else process.returncode or 1
+    )
     result = RunResult(
         exit_code=exit_code,
         handoff_state=handoff_state,
@@ -445,7 +464,9 @@ def run_claude_role(
         )
         if failure_kind in {"write_boundary", "permission"}:
             retry_add_dirs = list(add_dirs or [])
-            retry_add_dirs.extend(_retry_artifact_dirs(resolved_artifact_paths, workspace_root))
+            retry_add_dirs.extend(
+                _retry_artifact_dirs(resolved_artifact_paths, workspace_root)
+            )
             retry_note = (
                 f"Tier B retry: agent={agent} phase={phase} "
                 f"failure_kind={failure_kind} permission_escalation=True"
@@ -539,7 +560,7 @@ def run_bridge_probe(
                     "Write this exact JSON to "
                     f"{handoff_file}: "
                     '{"status":"complete","artifacts":["'
-                    f'{artifact_file}'
+                    f"{artifact_file}"
                     '"],"next":null,"summary":"probe ok"}'
                 ),
                 "Reply with exactly:",

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -353,7 +353,9 @@ def run_claude_role(
     text_handoff = extract_text_handoff(stdout)
 
     result_kind = (
-        "timeout"
+        "handoff_json"
+        if handoff_state == "found"
+        else "timeout"
         if timed_out
         else classify_result_kind(process.returncode or 1, stderr, handoff_state)
     )

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -273,6 +273,7 @@ def run_claude_role(
     resolved_prompt_file = resolve_path(cwd, prompt_file)
     resolved_handoff_file = resolve_path(cwd, handoff_file)
     resolved_artifact_paths = [resolve_path(cwd, path) for path in artifact_paths or []]
+    local_artifact_paths, _ = check_artifact_paths(resolved_artifact_paths, Path(cwd).resolve())
     if resolved_artifact_paths and not permission_escalation:
         prepare_artifact_files(resolved_artifact_paths)
     default_add_dirs = [
@@ -281,7 +282,7 @@ def run_claude_role(
         resolved_prompt_file.parent,
         resolved_handoff_file.parent,
     ]
-    default_add_dirs.extend(path.parent for path in resolved_artifact_paths)
+    default_add_dirs.extend(path.parent for path in local_artifact_paths)
     if add_dirs:
         default_add_dirs.extend(add_dirs)
     cmd = build_bridge_cmd(
@@ -309,7 +310,10 @@ def run_claude_role(
 
     while time.monotonic() < deadline:
         handoff_state = classify_handoff_file(resolved_handoff_file)
-        if handoff_state == "found":
+        artifacts_complete = not resolved_artifact_paths or not any_artifact_missing_or_empty(
+            resolved_artifact_paths
+        )
+        if handoff_state == "found" and artifacts_complete:
             try:
                 stdout, stderr = process.communicate(timeout=exit_grace_seconds)
             except subprocess.TimeoutExpired:
@@ -351,16 +355,21 @@ def run_claude_role(
 
     handoff_state = classify_handoff_file(resolved_handoff_file)
     text_handoff = extract_text_handoff(stdout)
+    artifacts_complete = not resolved_artifact_paths or not any_artifact_missing_or_empty(
+        resolved_artifact_paths
+    )
 
     result_kind = (
         "handoff_json"
-        if handoff_state == "found"
+        if handoff_state == "found" and artifacts_complete
         else "timeout"
         if timed_out
+        else "handoff_missing"
+        if handoff_state == "found" and not artifacts_complete
         else classify_result_kind(process.returncode or 1, stderr, handoff_state)
     )
-    source = "handoff_json" if handoff_state == "found" else None
-    exit_code = 0 if handoff_state == "found" else process.returncode or 1
+    source = "handoff_json" if handoff_state == "found" and artifacts_complete else None
+    exit_code = 0 if handoff_state == "found" and artifacts_complete else process.returncode or 1
     result = RunResult(
         exit_code=exit_code,
         handoff_state=handoff_state,
@@ -430,6 +439,16 @@ def run_claude_role(
             source="text_fallback",
             stdout=stdout,
             stderr=stderr,
+        )
+
+    if result.source == "handoff_json":
+        append_context_health_log(
+            resolved_quest_dir,
+            phase=phase,
+            agent=agent,
+            iteration=iteration,
+            handoff_state=result.handoff_state,
+            source="handoff_json",
         )
 
     return result

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from quest_runtime.artifacts import (
+    any_artifact_missing_or_empty,
+    check_artifact_paths,
+    prepare_artifact_files,
+)
 from quest_runtime.state import utc_now_iso
 
 
@@ -29,6 +34,14 @@ class RunResult:
     source: str | None
     stdout: str
     stderr: str
+
+
+def _effective_permission_mode(permission_mode: str, permission_escalation: bool) -> str:
+    if not permission_escalation:
+        return permission_mode
+    if permission_mode in {"default", "auto", "plan"}:
+        return "acceptEdits"
+    return permission_mode
 
 
 def select_role_runtime(
@@ -183,6 +196,41 @@ def classify_result_kind(exit_code: int, stderr: str, handoff_state: str) -> str
     return "error"
 
 
+def classify_failure_kind(
+    result: RunResult,
+    artifact_paths: list[Path],
+    workspace_root: Path,
+) -> str:
+    """Classify run failures for retry routing."""
+
+    if result.result_kind == "timeout":
+        return "timeout"
+    if result.result_kind == "invocation_error":
+        return "invocation"
+
+    _, external_paths = check_artifact_paths(artifact_paths, workspace_root)
+    if external_paths and any_artifact_missing_or_empty(artifact_paths):
+        return "write_boundary"
+
+    if "permission denied" in result.stderr.lower():
+        return "permission"
+
+    if artifact_paths and not any_artifact_missing_or_empty(artifact_paths):
+        return "model"
+
+    return "model"
+
+
+def _retry_artifact_dirs(
+    artifact_paths: list[Path],
+    workspace_root: Path,
+) -> list[Path]:
+    """Return out-of-workspace artifact directories for escalation retries."""
+
+    _, external_paths = check_artifact_paths(artifact_paths, workspace_root)
+    return [path.parent for path in external_paths]
+
+
 def append_context_health_log(
     quest_dir: str | Path,
     *,
@@ -215,6 +263,8 @@ def run_claude_role(
     model: str,
     timeout: float,
     permission_mode: str,
+    artifact_paths: Iterable[str | Path] | None = None,
+    permission_escalation: bool = False,
     add_dirs: Iterable[str | Path] | None = None,
     poll_interval: float = 0.5,
     exit_grace_seconds: float = 2.0,
@@ -222,12 +272,16 @@ def run_claude_role(
     resolved_quest_dir = resolve_path(cwd, quest_dir)
     resolved_prompt_file = resolve_path(cwd, prompt_file)
     resolved_handoff_file = resolve_path(cwd, handoff_file)
+    resolved_artifact_paths = [resolve_path(cwd, path) for path in artifact_paths or []]
+    if resolved_artifact_paths and not permission_escalation:
+        prepare_artifact_files(resolved_artifact_paths)
     default_add_dirs = [
         resolve_path(cwd, "."),
         resolved_quest_dir,
         resolved_prompt_file.parent,
         resolved_handoff_file.parent,
     ]
+    default_add_dirs.extend(path.parent for path in resolved_artifact_paths)
     if add_dirs:
         default_add_dirs.extend(add_dirs)
     cmd = build_bridge_cmd(
@@ -236,7 +290,7 @@ def run_claude_role(
         prompt_file=resolved_prompt_file,
         model=model,
         timeout=timeout,
-        permission_mode=permission_mode,
+        permission_mode=_effective_permission_mode(permission_mode, permission_escalation),
         add_dirs=default_add_dirs,
     )
     process = subprocess.Popen(
@@ -315,7 +369,7 @@ def run_claude_role(
             stderr=stderr,
         )
 
-    return RunResult(
+    result = RunResult(
         exit_code=process.returncode or 1,
         handoff_state=handoff_state,
         result_kind="timeout"
@@ -325,6 +379,51 @@ def run_claude_role(
         stdout=stdout,
         stderr=stderr,
     )
+
+    if not permission_escalation and resolved_artifact_paths:
+        failure_kind = classify_failure_kind(
+            result,
+            resolved_artifact_paths,
+            Path(cwd).resolve(),
+        )
+        if failure_kind in {"write_boundary", "permission"}:
+            retry_add_dirs = list(add_dirs or [])
+            retry_add_dirs.extend(_retry_artifact_dirs(resolved_artifact_paths, Path(cwd).resolve()))
+            retry_note = (
+                f"Tier B retry: agent={agent} phase={phase} "
+                f"failure_kind={failure_kind} permission_escalation=True"
+            )
+            retry_result = run_claude_role(
+                cwd=cwd,
+                quest_dir=resolved_quest_dir,
+                phase=phase,
+                agent=agent,
+                iteration=iteration,
+                prompt_file=resolved_prompt_file,
+                handoff_file=resolved_handoff_file,
+                bridge_script=bridge_script,
+                model=model,
+                timeout=timeout,
+                permission_mode=permission_mode,
+                artifact_paths=resolved_artifact_paths,
+                permission_escalation=True,
+                add_dirs=retry_add_dirs,
+                poll_interval=poll_interval,
+                exit_grace_seconds=exit_grace_seconds,
+            )
+            combined_stderr = retry_note
+            if retry_result.stderr:
+                combined_stderr = f"{retry_note}\n{retry_result.stderr}"
+            return RunResult(
+                exit_code=retry_result.exit_code,
+                handoff_state=retry_result.handoff_state,
+                result_kind=retry_result.result_kind,
+                source=retry_result.source,
+                stdout=retry_result.stdout,
+                stderr=combined_stderr,
+            )
+
+    return result
 
 
 def run_bridge_probe(
@@ -343,6 +442,7 @@ def run_bridge_probe(
     prompt_file = probe_dir / "probe_prompt.txt"
     artifact_file = probe_dir / "probe_artifact.txt"
     handoff_file = probe_dir / "probe_handoff.json"
+    prepare_artifact_files([artifact_file, handoff_file])
 
     prompt_file.write_text(
         "\n".join(

--- a/scripts/quest_runtime/claude_runner.py
+++ b/scripts/quest_runtime/claude_runner.py
@@ -184,7 +184,6 @@ def classify_result_kind(exit_code: int, stderr: str, handoff_state: str) -> str
             "not found",
             "no such file",
             "not authenticated",
-            "permission denied",
             "claude cli",
         )
     ):

--- a/scripts/quest_runtime/state.py
+++ b/scripts/quest_runtime/state.py
@@ -36,4 +36,3 @@ def update_state(quest_dir: str | Path, **updates: Any) -> dict[str, Any]:
     state["updated_at"] = utc_now_iso()
     write_state(quest_dir, state)
     return state
-

--- a/scripts/quest_state.py
+++ b/scripts/quest_state.py
@@ -41,4 +41,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/security_ci_guard.py
+++ b/scripts/security_ci_guard.py
@@ -5,39 +5,39 @@ from __future__ import annotations
 from pathlib import Path
 
 
-WORKFLOW_DIR = Path('.github/workflows')
+WORKFLOW_DIR = Path(".github/workflows")
 TRUSTED_AUTHOR_SNIPPETS = {
     "github.event.pull_request.user.login == 'KjellKod'",
     'github.event.pull_request.user.login == "KjellKod"',
 }
-SAME_REPO_SNIPPET = 'github.event.pull_request.head.repo.full_name == github.repository'
-BASE_SHA_SNIPPET = 'ref: ${{ github.event.pull_request.base.sha }}'
+SAME_REPO_SNIPPET = "github.event.pull_request.head.repo.full_name == github.repository"
+BASE_SHA_SNIPPET = "ref: ${{ github.event.pull_request.base.sha }}"
 SECRET_BEARING_SNIPPETS = (
-    'OPENAI_API_KEY',
-    'secrets.OPENAI_API_KEY',
-    'pull-requests: write',
-    'issues: write',
+    "OPENAI_API_KEY",
+    "secrets.OPENAI_API_KEY",
+    "pull-requests: write",
+    "issues: write",
 )
 BROAD_WRITE_SNIPPETS = (
-    'contents: write',
-    'actions: write',
-    'packages: write',
-    'deployments: write',
-    'attestations: write',
-    'checks: write',
+    "contents: write",
+    "actions: write",
+    "packages: write",
+    "deployments: write",
+    "attestations: write",
+    "checks: write",
 )
 
 
 def uses_pull_request_event(text: str) -> bool:
-    return 'pull_request:' in text
+    return "pull_request:" in text
 
 
 def uses_pull_request_target(text: str) -> bool:
-    return 'pull_request_target:' in text
+    return "pull_request_target:" in text
 
 
 def uses_checkout(text: str) -> bool:
-    return 'actions/checkout@' in text
+    return "actions/checkout@" in text
 
 
 def is_secret_bearing(text: str) -> bool:
@@ -49,7 +49,7 @@ def has_trusted_author_gate(text: str) -> bool:
 
 
 def scan_workflow(path: Path) -> list[str]:
-    text = path.read_text(encoding='utf-8')
+    text = path.read_text(encoding="utf-8")
     failures: list[str] = []
 
     if not (uses_pull_request_event(text) or uses_pull_request_target(text)):
@@ -57,29 +57,37 @@ def scan_workflow(path: Path) -> list[str]:
 
     if uses_pull_request_target(text) and uses_checkout(text):
         failures.append(
-            f'{path}: pull_request_target must not be combined with actions/checkout on PR code.'
+            f"{path}: pull_request_target must not be combined with actions/checkout on PR code."
         )
 
     if not uses_pull_request_event(text):
         return failures
 
     if any(snippet in text for snippet in BROAD_WRITE_SNIPPETS):
-        failures.append(f'{path}: PR workflow requests overly broad write permissions.')
+        failures.append(f"{path}: PR workflow requests overly broad write permissions.")
 
     if not is_secret_bearing(text):
         return failures
 
-    if 'permissions:' not in text:
-        failures.append(f'{path}: secret-bearing PR workflow must declare explicit permissions.')
-    if 'environment:' not in text:
-        failures.append(f'{path}: secret-bearing PR workflow must use an environment gate.')
+    if "permissions:" not in text:
+        failures.append(
+            f"{path}: secret-bearing PR workflow must declare explicit permissions."
+        )
+    if "environment:" not in text:
+        failures.append(
+            f"{path}: secret-bearing PR workflow must use an environment gate."
+        )
     if not has_trusted_author_gate(text):
-        failures.append(f'{path}: secret-bearing PR workflow must gate execution to KjellKod.')
+        failures.append(
+            f"{path}: secret-bearing PR workflow must gate execution to KjellKod."
+        )
     if SAME_REPO_SNIPPET not in text:
-        failures.append(f'{path}: secret-bearing PR workflow must require same-repo PRs.')
+        failures.append(
+            f"{path}: secret-bearing PR workflow must require same-repo PRs."
+        )
     if uses_checkout(text) and BASE_SHA_SNIPPET not in text:
         failures.append(
-            f'{path}: secret-bearing PR workflow must checkout the trusted base SHA, not PR head code.'
+            f"{path}: secret-bearing PR workflow must checkout the trusted base SHA, not PR head code."
         )
 
     return failures
@@ -87,18 +95,18 @@ def scan_workflow(path: Path) -> list[str]:
 
 def main() -> int:
     failures: list[str] = []
-    for path in sorted(WORKFLOW_DIR.glob('*.y*ml')):
+    for path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
         failures.extend(scan_workflow(path))
 
     if not failures:
-        print('workflow security guard passed')
+        print("workflow security guard passed")
         return 0
 
-    print('workflow security guard failed:')
+    print("workflow security guard failed:")
     for failure in failures:
-        print(f'- {failure}')
+        print(f"- {failure}")
     return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/validate-manifest.sh
+++ b/scripts/validate-manifest.sh
@@ -51,6 +51,7 @@ EXPECTED_PATTERNS=(
   "scripts/claude_cli_bridge.py"
   "scripts/quest_claude_probe.py"
   "scripts/quest_claude_runner.py"
+  "scripts/quest_checks/*.py"
   "scripts/quest_runtime/*.py"
   "scripts/validate-quest-config.sh"
 )

--- a/scripts/validate-manifest.sh
+++ b/scripts/validate-manifest.sh
@@ -51,6 +51,7 @@ EXPECTED_PATTERNS=(
   "scripts/claude_cli_bridge.py"
   "scripts/quest_claude_probe.py"
   "scripts/quest_claude_runner.py"
+  "scripts/quest_runtime/*.py"
   "scripts/validate-quest-config.sh"
 )
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -41,7 +41,11 @@ class TestExpectedArtifactsForRole:
     def test_builder_returns_correct_paths(self, tmp_path: Path):
         paths = expected_artifacts_for_role(tmp_path, "implementation", "builder")
         names = [p.name for p in paths]
-        assert names == ["pr_description.md", "builder_feedback_discussion.md", "handoff.json"]
+        assert names == [
+            "pr_description.md",
+            "builder_feedback_discussion.md",
+            "handoff.json",
+        ]
         assert all("phase_02_implementation" in str(p) for p in paths)
 
     def test_code_reviewer_a_returns_correct_paths(self, tmp_path: Path):
@@ -57,11 +61,15 @@ class TestExpectedArtifactsForRole:
 
     def test_solo_mode_excludes_disabled_agents(self, tmp_path: Path):
         for agent in SOLO_DISABLED_AGENTS:
-            paths = expected_artifacts_for_role(tmp_path, "plan", agent, quest_mode="solo")
+            paths = expected_artifacts_for_role(
+                tmp_path, "plan", agent, quest_mode="solo"
+            )
             assert paths == [], f"Expected empty for solo-disabled agent {agent}"
 
     def test_solo_mode_keeps_enabled_agents(self, tmp_path: Path):
-        paths = expected_artifacts_for_role(tmp_path, "plan", "planner", quest_mode="solo")
+        paths = expected_artifacts_for_role(
+            tmp_path, "plan", "planner", quest_mode="solo"
+        )
         assert len(paths) == 2
 
     def test_unknown_role_raises_value_error(self, tmp_path: Path):
@@ -254,14 +262,21 @@ class TestClassifyFailureKind:
         result = _make_result(result_kind="handoff_missing")
         assert classify_failure_kind(result, [artifact], tmp_path) == "model"
 
-    def test_artifacts_missing_out_of_workspace_returns_write_boundary(self, tmp_path: Path):
+    def test_artifacts_missing_out_of_workspace_returns_write_boundary(
+        self, tmp_path: Path
+    ):
         workspace = tmp_path / "repo"
         workspace.mkdir()
         external_artifact = tmp_path / "external" / "handoff.json"
         result = _make_result(result_kind="handoff_missing")
-        assert classify_failure_kind(result, [external_artifact], workspace) == "write_boundary"
+        assert (
+            classify_failure_kind(result, [external_artifact], workspace)
+            == "write_boundary"
+        )
 
-    def test_partial_write_out_of_workspace_returns_write_boundary(self, tmp_path: Path):
+    def test_partial_write_out_of_workspace_returns_write_boundary(
+        self, tmp_path: Path
+    ):
         """Arbiter-mandated: plan.md written but handoff.json missing, external path."""
         workspace = tmp_path / "repo"
         workspace.mkdir()
@@ -272,7 +287,10 @@ class TestClassifyFailureKind:
         handoff = external_dir / "handoff.json"
         # handoff.json does NOT exist
         result = _make_result(result_kind="handoff_missing")
-        assert classify_failure_kind(result, [plan, handoff], workspace) == "write_boundary"
+        assert (
+            classify_failure_kind(result, [plan, handoff], workspace)
+            == "write_boundary"
+        )
 
     def test_permission_denied_in_stderr(self, tmp_path: Path):
         artifact = tmp_path / "handoff.json"
@@ -319,7 +337,9 @@ class TestRunClaudeRole:
         def fake_prepare(paths: list[Path]) -> list[Path]:
             raise OSError("disk full")
 
-        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
+        monkeypatch.setattr(
+            claude_runner_module, "prepare_artifact_files", fake_prepare
+        )
 
         result = run_claude_role(
             cwd=tmp_path,
@@ -382,7 +402,9 @@ class TestRunClaudeRole:
             def kill(self):
                 return None
 
-        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
+        monkeypatch.setattr(
+            claude_runner_module, "prepare_artifact_files", fake_prepare
+        )
         monkeypatch.setattr(
             claude_runner_module.subprocess,
             "Popen",
@@ -518,7 +540,9 @@ class TestRunClaudeRole:
                 return FakeProcess()
             return FakeProcess(on_communicate=complete_second_attempt)
 
-        monkeypatch.setattr(claude_runner_module, "build_bridge_cmd", fake_build_bridge_cmd)
+        monkeypatch.setattr(
+            claude_runner_module, "build_bridge_cmd", fake_build_bridge_cmd
+        )
         monkeypatch.setattr(
             claude_runner_module.subprocess,
             "Popen",
@@ -581,8 +605,14 @@ class TestRunClaudeRole:
             def kill(self):
                 return None
 
-        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
-        monkeypatch.setattr(claude_runner_module.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+        monkeypatch.setattr(
+            claude_runner_module, "prepare_artifact_files", fake_prepare
+        )
+        monkeypatch.setattr(
+            claude_runner_module.subprocess,
+            "Popen",
+            lambda *args, **kwargs: FakeProcess(),
+        )
 
         result = run_claude_role(
             cwd=tmp_path,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -306,6 +306,143 @@ class TestClassifyFailureKind:
 
 
 class TestRunClaudeRole:
+    def test_handoff_without_required_artifact_content_is_not_success(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("prompt", encoding="utf-8")
+        handoff_file = tmp_path / "handoff.json"
+        artifact = tmp_path / "plan.md"
+
+        class FakeProcess:
+            returncode = 1
+
+            def communicate(self, timeout: float | None = None):
+                handoff_file.write_text(
+                    '{"status":"complete","artifacts":["plan.md"],"next":null,"summary":"ok"}',
+                    encoding="utf-8",
+                )
+                return "", ""
+
+            def poll(self):
+                return 1
+
+            def terminate(self):
+                return None
+
+            def kill(self):
+                return None
+
+        monkeypatch.setattr(
+            claude_runner_module.subprocess,
+            "Popen",
+            lambda *args, **kwargs: FakeProcess(),
+        )
+
+        result = run_claude_role(
+            cwd=tmp_path,
+            quest_dir=tmp_path,
+            phase="plan",
+            agent="planner",
+            iteration=1,
+            prompt_file=prompt_file,
+            handoff_file=handoff_file,
+            bridge_script=tmp_path / "bridge.py",
+            model="opus",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=[artifact],
+            poll_interval=0.01,
+            exit_grace_seconds=0.01,
+        )
+
+        assert result.exit_code != 0
+        assert result.handoff_state == "found"
+        assert result.result_kind != "handoff_json"
+        assert result.source is None
+
+    def test_external_artifact_dir_only_added_on_permission_retry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        prompt_file = workspace / "prompt.txt"
+        prompt_file.write_text("prompt", encoding="utf-8")
+        handoff_file = workspace / "handoff.json"
+        external_artifact = tmp_path / "external" / "plan.md"
+        captured_add_dirs: list[list[str]] = []
+        popen_calls = {"count": 0}
+
+        def fake_build_bridge_cmd(**kwargs):
+            captured_add_dirs.append(list(kwargs["add_dirs"]))
+            return ["bridge"]
+
+        class FakeProcess:
+            def __init__(self, *, on_communicate=None):
+                self.returncode = 1
+                self._on_communicate = on_communicate
+
+            def communicate(self, timeout: float | None = None):
+                if self._on_communicate is not None:
+                    self._on_communicate()
+                return "", "Permission denied writing artifact"
+
+            def poll(self):
+                return 1
+
+            def terminate(self):
+                return None
+
+            def kill(self):
+                return None
+
+        def complete_second_attempt():
+            external_artifact.write_text("ok", encoding="utf-8")
+            handoff_file.write_text(
+                '{"status":"complete","artifacts":["plan.md"],"next":null,"summary":"ok"}',
+                encoding="utf-8",
+            )
+
+        def fake_popen(*args, **kwargs):
+            popen_calls["count"] += 1
+            if popen_calls["count"] == 1:
+                return FakeProcess()
+            return FakeProcess(on_communicate=complete_second_attempt)
+
+        monkeypatch.setattr(claude_runner_module, "build_bridge_cmd", fake_build_bridge_cmd)
+        monkeypatch.setattr(
+            claude_runner_module.subprocess,
+            "Popen",
+            lambda *args, **kwargs: fake_popen(),
+        )
+
+        result = run_claude_role(
+            cwd=workspace,
+            quest_dir=workspace,
+            phase="plan",
+            agent="planner",
+            iteration=1,
+            prompt_file=prompt_file,
+            handoff_file=handoff_file,
+            bridge_script=workspace / "bridge.py",
+            model="opus",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=[external_artifact],
+            poll_interval=0.01,
+            exit_grace_seconds=0.01,
+        )
+
+        assert result.exit_code == 0
+        assert len(captured_add_dirs) == 2
+        assert external_artifact.parent.resolve() not in captured_add_dirs[0]
+        assert external_artifact.parent.resolve() in captured_add_dirs[1]
+        assert "Tier B retry:" in result.stderr
+
     def test_permission_escalation_retry_does_not_reprepare_artifacts(
         self,
         tmp_path: Path,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -306,6 +306,111 @@ class TestClassifyFailureKind:
 
 
 class TestRunClaudeRole:
+    def test_artifact_preparation_error_returns_structured_invocation_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("prompt", encoding="utf-8")
+        handoff_file = tmp_path / "handoff.json"
+        artifact = tmp_path / "plan.md"
+
+        def fake_prepare(paths: list[Path]) -> list[Path]:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
+
+        result = run_claude_role(
+            cwd=tmp_path,
+            quest_dir=tmp_path,
+            phase="plan",
+            agent="planner",
+            iteration=1,
+            prompt_file=prompt_file,
+            handoff_file=handoff_file,
+            bridge_script=tmp_path / "bridge.py",
+            model="opus",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=[artifact],
+            poll_interval=0.01,
+            exit_grace_seconds=0.01,
+        )
+
+        assert result.exit_code == 1
+        assert result.handoff_state == "missing"
+        assert result.result_kind == "invocation_error"
+        assert result.source is None
+        assert "disk full" in result.stderr
+
+    def test_artifact_preparation_permission_error_retries_without_crashing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        prompt_file = workspace / "prompt.txt"
+        prompt_file.write_text("prompt", encoding="utf-8")
+        handoff_file = workspace / "handoff.json"
+        external_artifact = tmp_path / "external" / "plan.md"
+        prepare_calls = {"count": 0}
+
+        def fake_prepare(paths: list[Path]) -> list[Path]:
+            prepare_calls["count"] += 1
+            raise PermissionError("Permission denied")
+
+        class FakeProcess:
+            returncode = 0
+
+            def communicate(self, timeout: float | None = None):
+                external_artifact.parent.mkdir(parents=True, exist_ok=True)
+                external_artifact.write_text("ok", encoding="utf-8")
+                handoff_file.write_text(
+                    '{"status":"complete","artifacts":["plan.md"],"next":null,"summary":"ok"}',
+                    encoding="utf-8",
+                )
+                return "", ""
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                return None
+
+            def kill(self):
+                return None
+
+        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
+        monkeypatch.setattr(
+            claude_runner_module.subprocess,
+            "Popen",
+            lambda *args, **kwargs: FakeProcess(),
+        )
+
+        result = run_claude_role(
+            cwd=workspace,
+            quest_dir=workspace,
+            phase="plan",
+            agent="planner",
+            iteration=1,
+            prompt_file=prompt_file,
+            handoff_file=handoff_file,
+            bridge_script=workspace / "bridge.py",
+            model="opus",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=[external_artifact],
+            poll_interval=0.01,
+            exit_grace_seconds=0.01,
+        )
+
+        assert prepare_calls["count"] == 1
+        assert result.exit_code == 0
+        assert result.result_kind == "handoff_json"
+        assert "Tier B retry:" in result.stderr
+
     def test_handoff_without_required_artifact_content_is_not_success(
         self,
         tmp_path: Path,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -51,7 +51,7 @@ class TestExpectedArtifactsForRole:
         assert all("phase_03_review" in str(p) for p in paths)
 
     def test_fixer_returns_correct_paths(self, tmp_path: Path):
-        paths = expected_artifacts_for_role(tmp_path, "review", "fixer")
+        paths = expected_artifacts_for_role(tmp_path, "fix", "fixer")
         names = [p.name for p in paths]
         assert names == ["review_fix_feedback_discussion.md", "handoff_fixer.json"]
 
@@ -68,9 +68,23 @@ class TestExpectedArtifactsForRole:
         with pytest.raises(ValueError, match="Unsupported quest role"):
             expected_artifacts_for_role(tmp_path, "plan", "nonexistent-role")
 
+    def test_invalid_phase_for_role_raises_value_error(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="not valid for phase"):
+            expected_artifacts_for_role(tmp_path, "build", "planner")
+
     def test_all_roles_in_mapping_resolve(self, tmp_path: Path):
+        valid_phases = {
+            "planner": "plan",
+            "plan-reviewer-a": "plan_review",
+            "plan-reviewer-b": "plan_review",
+            "arbiter": "plan_review",
+            "builder": "implementation",
+            "code-reviewer-a": "code_review",
+            "code-reviewer-b": "code_review",
+            "fixer": "fix",
+        }
         for role in ROLE_ARTIFACTS:
-            paths = expected_artifacts_for_role(tmp_path, "any", role)
+            paths = expected_artifacts_for_role(tmp_path, valid_phases[role], role)
             assert len(paths) > 0, f"Role {role} returned no artifacts"
 
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -17,7 +17,12 @@ from quest_runtime.artifacts import (
     is_workspace_local,
     prepare_artifact_files,
 )
-from quest_runtime.claude_runner import RunResult, classify_failure_kind, run_claude_role
+from quest_runtime.claude_runner import (
+    RunResult,
+    classify_failure_kind,
+    classify_result_kind,
+    run_claude_role,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +264,20 @@ class TestClassifyFailureKind:
         artifact = tmp_path / "handoff.json"
         # artifact missing but path is workspace-local → not write_boundary
         result = _make_result(stderr="Error: Permission denied writing to /foo/bar")
+        assert classify_failure_kind(result, [artifact], tmp_path) == "permission"
+
+    def test_permission_denied_after_result_classification_returns_permission(
+        self, tmp_path: Path
+    ):
+        artifact = tmp_path / "handoff.json"
+        result = _make_result(
+            result_kind=classify_result_kind(
+                1,
+                "Error: Permission denied writing to /foo/bar",
+                "missing",
+            ),
+            stderr="Error: Permission denied writing to /foo/bar",
+        )
         assert classify_failure_kind(result, [artifact], tmp_path) == "permission"
 
     def test_default_is_model(self, tmp_path: Path):

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,0 +1,330 @@
+"""Unit tests for Quest artifact helpers and failure classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import quest_runtime.claude_runner as claude_runner_module
+from quest_runtime.artifacts import (
+    ROLE_ARTIFACTS,
+    SOLO_DISABLED_AGENTS,
+    any_artifact_missing_or_empty,
+    check_artifact_paths,
+    default_quest_dir,
+    expected_artifacts_for_role,
+    is_workspace_local,
+    prepare_artifact_files,
+)
+from quest_runtime.claude_runner import RunResult, classify_failure_kind, run_claude_role
+
+
+# ---------------------------------------------------------------------------
+# Artifact resolution
+# ---------------------------------------------------------------------------
+
+
+class TestExpectedArtifactsForRole:
+    def test_planner_returns_correct_paths(self, tmp_path: Path):
+        paths = expected_artifacts_for_role(tmp_path, "plan", "planner")
+        names = [p.name for p in paths]
+        assert names == ["plan.md", "handoff.json"]
+        assert all(p.is_absolute() for p in paths)
+        assert all("phase_01_plan" in str(p) for p in paths)
+
+    def test_builder_returns_correct_paths(self, tmp_path: Path):
+        paths = expected_artifacts_for_role(tmp_path, "implementation", "builder")
+        names = [p.name for p in paths]
+        assert names == ["pr_description.md", "builder_feedback_discussion.md", "handoff.json"]
+        assert all("phase_02_implementation" in str(p) for p in paths)
+
+    def test_code_reviewer_a_returns_correct_paths(self, tmp_path: Path):
+        paths = expected_artifacts_for_role(tmp_path, "review", "code-reviewer-a")
+        names = [p.name for p in paths]
+        assert names == ["review_code-reviewer-a.md", "handoff_code-reviewer-a.json"]
+        assert all("phase_03_review" in str(p) for p in paths)
+
+    def test_fixer_returns_correct_paths(self, tmp_path: Path):
+        paths = expected_artifacts_for_role(tmp_path, "review", "fixer")
+        names = [p.name for p in paths]
+        assert names == ["review_fix_feedback_discussion.md", "handoff_fixer.json"]
+
+    def test_solo_mode_excludes_disabled_agents(self, tmp_path: Path):
+        for agent in SOLO_DISABLED_AGENTS:
+            paths = expected_artifacts_for_role(tmp_path, "plan", agent, quest_mode="solo")
+            assert paths == [], f"Expected empty for solo-disabled agent {agent}"
+
+    def test_solo_mode_keeps_enabled_agents(self, tmp_path: Path):
+        paths = expected_artifacts_for_role(tmp_path, "plan", "planner", quest_mode="solo")
+        assert len(paths) == 2
+
+    def test_unknown_role_raises_value_error(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Unsupported quest role"):
+            expected_artifacts_for_role(tmp_path, "plan", "nonexistent-role")
+
+    def test_all_roles_in_mapping_resolve(self, tmp_path: Path):
+        for role in ROLE_ARTIFACTS:
+            paths = expected_artifacts_for_role(tmp_path, "any", role)
+            assert len(paths) > 0, f"Role {role} returned no artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Artifact preparation
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareArtifactFiles:
+    def test_creates_directories_and_files(self, tmp_path: Path):
+        paths = [
+            tmp_path / "deep" / "nested" / "file.md",
+            tmp_path / "deep" / "another.json",
+        ]
+        result = prepare_artifact_files(paths)
+        assert len(result) == 2
+        for p in result:
+            assert p.exists()
+            assert p.stat().st_size == 0
+
+    def test_truncates_existing_files(self, tmp_path: Path):
+        target = tmp_path / "existing.md"
+        target.write_text("old content", encoding="utf-8")
+        assert target.stat().st_size > 0
+
+        prepare_artifact_files([target])
+        assert target.stat().st_size == 0
+
+    def test_idempotent(self, tmp_path: Path):
+        paths = [tmp_path / "a.md", tmp_path / "b.json"]
+        prepare_artifact_files(paths)
+        result = prepare_artifact_files(paths)
+        assert len(result) == 2
+        assert all(p.exists() for p in result)
+
+    def test_returns_resolved_paths(self, tmp_path: Path):
+        relative_looking = tmp_path / "sub" / ".." / "file.md"
+        result = prepare_artifact_files([relative_looking])
+        assert len(result) == 1
+        assert ".." not in str(result[0])
+
+
+# ---------------------------------------------------------------------------
+# Workspace-local check
+# ---------------------------------------------------------------------------
+
+
+class TestIsWorkspaceLocal:
+    def test_path_under_workspace(self, tmp_path: Path):
+        child = tmp_path / "sub" / "file.md"
+        child.parent.mkdir(parents=True, exist_ok=True)
+        child.touch()
+        assert is_workspace_local(child, tmp_path) is True
+
+    def test_path_outside_workspace(self, tmp_path: Path):
+        outside = tmp_path.parent / "elsewhere" / "file.md"
+        assert is_workspace_local(outside, tmp_path) is False
+
+    def test_workspace_root_itself(self, tmp_path: Path):
+        assert is_workspace_local(tmp_path, tmp_path) is True
+
+    def test_symlink_under_workspace(self, tmp_path: Path):
+        real_file = tmp_path / "real.md"
+        real_file.touch()
+        link = tmp_path / "link.md"
+        link.symlink_to(real_file)
+        assert is_workspace_local(link, tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# Path partitioning
+# ---------------------------------------------------------------------------
+
+
+class TestCheckArtifactPaths:
+    def test_mixed_paths_split_correctly(self, tmp_path: Path):
+        local = tmp_path / "inside.md"
+        external = tmp_path.parent / "outside.md"
+        local_list, external_list = check_artifact_paths([local, external], tmp_path)
+        assert len(local_list) == 1
+        assert len(external_list) == 1
+
+    def test_all_local(self, tmp_path: Path):
+        paths = [tmp_path / "a.md", tmp_path / "b.md"]
+        local_list, external_list = check_artifact_paths(paths, tmp_path)
+        assert len(local_list) == 2
+        assert len(external_list) == 0
+
+    def test_all_external(self, tmp_path: Path):
+        paths = [tmp_path.parent / "x.md"]
+        local_list, external_list = check_artifact_paths(paths, tmp_path)
+        assert len(local_list) == 0
+        assert len(external_list) == 1
+
+
+# ---------------------------------------------------------------------------
+# any_artifact_missing_or_empty
+# ---------------------------------------------------------------------------
+
+
+class TestAnyArtifactMissingOrEmpty:
+    def test_missing_file(self, tmp_path: Path):
+        assert any_artifact_missing_or_empty([tmp_path / "nope.md"]) is True
+
+    def test_empty_file(self, tmp_path: Path):
+        f = tmp_path / "empty.md"
+        f.write_text("", encoding="utf-8")
+        assert any_artifact_missing_or_empty([f]) is True
+
+    def test_non_empty_file(self, tmp_path: Path):
+        f = tmp_path / "ok.md"
+        f.write_text("content", encoding="utf-8")
+        assert any_artifact_missing_or_empty([f]) is False
+
+    def test_mixed_present_and_missing(self, tmp_path: Path):
+        present = tmp_path / "present.md"
+        present.write_text("content", encoding="utf-8")
+        missing = tmp_path / "missing.md"
+        assert any_artifact_missing_or_empty([present, missing]) is True
+
+
+# ---------------------------------------------------------------------------
+# default_quest_dir
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultQuestDir:
+    def test_returns_repo_local_path(self, tmp_path: Path):
+        result = default_quest_dir(tmp_path, "my-quest_2026-01-01__0000")
+        assert result == tmp_path / ".quest" / "my-quest_2026-01-01__0000"
+        assert result.is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Failure classification
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    *,
+    exit_code: int = 1,
+    result_kind: str = "error",
+    stderr: str = "",
+) -> RunResult:
+    return RunResult(
+        exit_code=exit_code,
+        handoff_state="missing",
+        result_kind=result_kind,
+        source=None,
+        stdout="",
+        stderr=stderr,
+    )
+
+
+class TestClassifyFailureKind:
+    def test_timeout(self, tmp_path: Path):
+        result = _make_result(result_kind="timeout")
+        assert classify_failure_kind(result, [], tmp_path) == "timeout"
+
+    def test_invocation_error(self, tmp_path: Path):
+        result = _make_result(result_kind="invocation_error")
+        assert classify_failure_kind(result, [], tmp_path) == "invocation"
+
+    def test_artifacts_exist_and_nonempty_returns_model(self, tmp_path: Path):
+        artifact = tmp_path / "handoff.json"
+        artifact.write_text('{"status":"complete"}', encoding="utf-8")
+        result = _make_result(result_kind="handoff_missing")
+        assert classify_failure_kind(result, [artifact], tmp_path) == "model"
+
+    def test_artifacts_missing_out_of_workspace_returns_write_boundary(self, tmp_path: Path):
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        external_artifact = tmp_path / "external" / "handoff.json"
+        result = _make_result(result_kind="handoff_missing")
+        assert classify_failure_kind(result, [external_artifact], workspace) == "write_boundary"
+
+    def test_partial_write_out_of_workspace_returns_write_boundary(self, tmp_path: Path):
+        """Arbiter-mandated: plan.md written but handoff.json missing, external path."""
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        external_dir = tmp_path / "external" / "phase_01_plan"
+        external_dir.mkdir(parents=True)
+        plan = external_dir / "plan.md"
+        plan.write_text("# Plan\ncontent", encoding="utf-8")
+        handoff = external_dir / "handoff.json"
+        # handoff.json does NOT exist
+        result = _make_result(result_kind="handoff_missing")
+        assert classify_failure_kind(result, [plan, handoff], workspace) == "write_boundary"
+
+    def test_permission_denied_in_stderr(self, tmp_path: Path):
+        artifact = tmp_path / "handoff.json"
+        # artifact missing but path is workspace-local → not write_boundary
+        result = _make_result(stderr="Error: Permission denied writing to /foo/bar")
+        assert classify_failure_kind(result, [artifact], tmp_path) == "permission"
+
+    def test_default_is_model(self, tmp_path: Path):
+        artifact = tmp_path / "handoff.json"
+        # missing, workspace-local, no permission error → model
+        result = _make_result(result_kind="handoff_missing")
+        assert classify_failure_kind(result, [artifact], tmp_path) == "model"
+
+    def test_empty_artifact_list_returns_model(self, tmp_path: Path):
+        result = _make_result(result_kind="handoff_missing")
+        assert classify_failure_kind(result, [], tmp_path) == "model"
+
+
+class TestRunClaudeRole:
+    def test_permission_escalation_retry_does_not_reprepare_artifacts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("prompt", encoding="utf-8")
+        handoff_file = tmp_path / "handoff.json"
+        handoff_file.write_text('{"status":"complete"}', encoding="utf-8")
+        artifact = tmp_path / "plan.md"
+        artifact.write_text("keep me", encoding="utf-8")
+
+        prepare_calls: list[list[Path]] = []
+
+        def fake_prepare(paths: list[Path]) -> list[Path]:
+            prepare_calls.append([Path(path) for path in paths])
+            return [Path(path) for path in paths]
+
+        class FakeProcess:
+            returncode = 0
+
+            def communicate(self, timeout: float | None = None):
+                return "", ""
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                return None
+
+            def kill(self):
+                return None
+
+        monkeypatch.setattr(claude_runner_module, "prepare_artifact_files", fake_prepare)
+        monkeypatch.setattr(claude_runner_module.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+
+        result = run_claude_role(
+            cwd=tmp_path,
+            quest_dir=tmp_path,
+            phase="plan",
+            agent="planner",
+            iteration=1,
+            prompt_file=prompt_file,
+            handoff_file=handoff_file,
+            bridge_script=tmp_path / "bridge.py",
+            model="opus",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=[artifact],
+            permission_escalation=True,
+        )
+
+        assert result.result_kind == "handoff_json"
+        assert prepare_calls == []
+        assert artifact.read_text(encoding="utf-8") == "keep me"

--- a/tests/unit/test_quest_celebrate.py
+++ b/tests/unit/test_quest_celebrate.py
@@ -1076,63 +1076,82 @@ class TestQualityTier:
 
     def test_diamond_zero_issues_zero_fix(self):
         tier = compute_quality_tier(
-            plan_iterations=1, fix_iterations=0,
-            review_findings_count=0, status="complete",
+            plan_iterations=1,
+            fix_iterations=0,
+            review_findings_count=0,
+            status="complete",
         )
         assert tier == "Diamond"
 
     def test_platinum_minor_issues_one_fix(self):
         tier = compute_quality_tier(
-            plan_iterations=1, fix_iterations=1,
-            review_findings_count=2, status="complete",
+            plan_iterations=1,
+            fix_iterations=1,
+            review_findings_count=2,
+            status="complete",
         )
         assert tier == "Platinum"
 
     def test_gold_two_plan_one_fix(self):
         tier = compute_quality_tier(
-            plan_iterations=2, fix_iterations=1,
-            review_findings_count=3, status="complete",
+            plan_iterations=2,
+            fix_iterations=1,
+            review_findings_count=3,
+            status="complete",
         )
         assert tier == "Gold"
 
     def test_silver_two_fix_iterations(self):
         tier = compute_quality_tier(
-            plan_iterations=2, fix_iterations=2,
-            review_findings_count=5, status="complete",
+            plan_iterations=2,
+            fix_iterations=2,
+            review_findings_count=5,
+            status="complete",
         )
         assert tier == "Silver"
 
     def test_bronze_three_fix_iterations(self):
         """3 fix iterations (below max gate of 3) → Bronze."""
         tier = compute_quality_tier(
-            plan_iterations=1, fix_iterations=3,
-            review_findings_count=5, status="complete",
-            max_plan_iterations=5, max_fix_iterations=4,
+            plan_iterations=1,
+            fix_iterations=3,
+            review_findings_count=5,
+            status="complete",
+            max_plan_iterations=5,
+            max_fix_iterations=4,
         )
         assert tier == "Bronze"
 
     def test_tin_approaching_max_gate(self):
         """Hit one max gate but not both → Tin."""
         tier = compute_quality_tier(
-            plan_iterations=4, fix_iterations=2,
-            review_findings_count=5, status="complete",
-            max_plan_iterations=4, max_fix_iterations=4,
+            plan_iterations=4,
+            fix_iterations=2,
+            review_findings_count=5,
+            status="complete",
+            max_plan_iterations=4,
+            max_fix_iterations=4,
         )
         assert tier == "Tin"
 
     def test_cardboard_hit_both_max_gates(self):
         """Hit both max gates → Cardboard."""
         tier = compute_quality_tier(
-            plan_iterations=4, fix_iterations=3,
-            review_findings_count=5, status="complete",
-            max_plan_iterations=4, max_fix_iterations=3,
+            plan_iterations=4,
+            fix_iterations=3,
+            review_findings_count=5,
+            status="complete",
+            max_plan_iterations=4,
+            max_fix_iterations=3,
         )
         assert tier == "Cardboard"
 
     def test_abandoned_status(self):
         tier = compute_quality_tier(
-            plan_iterations=1, fix_iterations=0,
-            review_findings_count=0, status="abandoned",
+            plan_iterations=1,
+            fix_iterations=0,
+            review_findings_count=0,
+            status="abandoned",
         )
         assert tier == "Abandoned"
 
@@ -1170,7 +1189,8 @@ class TestQualityTier:
     def test_journal_replay_does_not_read_live_allowlist(self, tmp_path):
         journal_path = tmp_path / "journal.md"
         journal_path.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
                 # Quest Journal: test-quest
 
                 - Quest ID: `test-quest_2026-03-05__0643`
@@ -1180,17 +1200,32 @@ class TestQualityTier:
 
                 - Plan iterations: 1
                 - Fix iterations: 0
-            """),
+            """
+            ),
             encoding="utf-8",
         )
 
-        with patch("quest_celebrate.quest_data._load_allowlist_quality_defaults", side_effect=AssertionError("should not read live allowlist during journal replay")):
+        with patch(
+            "quest_celebrate.quest_data._load_allowlist_quality_defaults",
+            side_effect=AssertionError(
+                "should not read live allowlist during journal replay"
+            ),
+        ):
             data = load_quest_data_from_journal(journal_path)
         assert data.quality_tier == "Diamond"
+
     def test_all_tiers_in_quality_tiers_dict(self):
         """Every tier the function can return has an entry in QUALITY_TIERS."""
-        for tier_name in ["Diamond", "Platinum", "Gold", "Silver", "Bronze",
-                          "Tin", "Cardboard", "Abandoned"]:
+        for tier_name in [
+            "Diamond",
+            "Platinum",
+            "Gold",
+            "Silver",
+            "Bronze",
+            "Tin",
+            "Cardboard",
+            "Abandoned",
+        ]:
             assert tier_name in QUALITY_TIERS
             icon, grade, tooltip = QUALITY_TIERS[tier_name]
             assert icon
@@ -1201,7 +1236,8 @@ class TestQualityTier:
 class TestJournalCelebrationData:
     """Tests for celebration_data extraction from journal markdown."""
 
-    SAMPLE_JOURNAL = textwrap.dedent("""\
+    SAMPLE_JOURNAL = textwrap.dedent(
+        """\
         # Quest Journal: test-quest
 
         - Quest ID: `test-quest_2026-03-05__0643`
@@ -1243,7 +1279,8 @@ class TestJournalCelebrationData:
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
 
     def test_extract_celebration_data_finds_json(self):
         data = extract_celebration_data_from_journal(self.SAMPLE_JOURNAL)
@@ -1286,7 +1323,8 @@ class TestJournalCelebrationData:
         assert data.fix_iterations == 1
 
     def test_load_quest_data_from_journal_legacy_no_celebration_data(self, tmp_path):
-        legacy = textwrap.dedent("""\
+        legacy = textwrap.dedent(
+            """\
             # Quest Journal: old-quest
 
             - Quest ID: `old-quest_2026-01-01__0000`
@@ -1296,7 +1334,8 @@ class TestJournalCelebrationData:
 
             - Plan iterations: 2
             - Fix iterations: 2
-        """)
+        """
+        )
         journal_path = tmp_path / "old-quest_2026-01-01.md"
         journal_path.write_text(legacy)
 
@@ -1309,8 +1348,11 @@ class TestJournalCelebrationData:
         # No agents or achievements from legacy
         assert len(data.agents) == 0
 
-    def test_load_quest_data_from_journal_supports_existing_journal_formats(self, tmp_path):
-        legacy = textwrap.dedent("""\
+    def test_load_quest_data_from_journal_supports_existing_journal_formats(
+        self, tmp_path
+    ):
+        legacy = textwrap.dedent(
+            """\
             # Quest: Dashboard Final Implementation
 
             **Quest ID:** dashboard-final-implementation_2026-02-12__0913
@@ -1320,7 +1362,8 @@ class TestJournalCelebrationData:
 
             - Plan iterations: 1
             - Fix iterations: 0
-        """)
+        """
+        )
         journal_path = tmp_path / "dashboard-final-implementation_2026-02-12.md"
         journal_path.write_text(legacy)
 
@@ -1331,7 +1374,8 @@ class TestJournalCelebrationData:
         assert data.status == "abandoned"
 
     def test_load_quest_data_from_journal_skips_invalid_json_entries(self, tmp_path):
-        journal = textwrap.dedent("""\
+        journal = textwrap.dedent(
+            """\
             # Quest Journal: malformed-json
 
             - Quest ID: `malformed-json_2026-03-06__1200`
@@ -1346,7 +1390,8 @@ class TestJournalCelebrationData:
             }
             ```
             <!-- celebration-data-end -->
-        """)
+        """
+        )
         journal_path = tmp_path / "malformed-json_2026-03-06.md"
         journal_path.write_text(journal)
 
@@ -1356,8 +1401,11 @@ class TestJournalCelebrationData:
         assert [achievement.title for achievement in data.achievements] == ["Shipped"]
         assert data.brief_summary == ""
 
-    def test_load_quest_data_from_journal_ignores_invalid_quality_tier_type(self, tmp_path):
-        journal = textwrap.dedent("""\
+    def test_load_quest_data_from_journal_ignores_invalid_quality_tier_type(
+        self, tmp_path
+    ):
+        journal = textwrap.dedent(
+            """\
             # Quest Journal: malformed-quality
 
             - Quest ID: `malformed-quality_2026-03-06__1200`
@@ -1369,7 +1417,8 @@ class TestJournalCelebrationData:
             }
             ```
             <!-- celebration-data-end -->
-        """)
+        """
+        )
         journal_path = tmp_path / "malformed-quality_2026-03-06.md"
         journal_path.write_text(journal)
 
@@ -1377,12 +1426,16 @@ class TestJournalCelebrationData:
 
         assert data.quality_tier == ""
 
-    def test_load_quest_data_from_journal_leaves_tier_unset_without_iterations(self, tmp_path):
-        journal = textwrap.dedent("""\
+    def test_load_quest_data_from_journal_leaves_tier_unset_without_iterations(
+        self, tmp_path
+    ):
+        journal = textwrap.dedent(
+            """\
             # Quest Journal: legacy-no-iterations
 
             - Quest ID: `legacy-no-iterations_2026-03-06__1200`
-        """)
+        """
+        )
         journal_path = tmp_path / "legacy-no-iterations_2026-03-06.md"
         journal_path.write_text(journal)
 

--- a/tests/unit/test_quest_dashboard_loaders.py
+++ b/tests/unit/test_quest_dashboard_loaders.py
@@ -496,7 +496,8 @@ def test_load_dashboard_data_normalizes_none_github_url(tmp_path):
 
 
 def test_extract_celebration_data_parses_json():
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: test
 
         <!-- celebration-data-start -->
@@ -509,7 +510,8 @@ def test_extract_celebration_data_parses_json():
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
     data = _extract_celebration_data(content)
     assert data is not None
     assert data["quality"]["tier"] == "Gold"
@@ -532,7 +534,8 @@ def test_journal_entry_skips_invalid_agent_entries_in_celebration_json(tmp_path)
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: Rich Quest
 
         **Quest ID:** rich-quest-001
@@ -547,7 +550,8 @@ def test_journal_entry_skips_invalid_agent_entries_in_celebration_json(tmp_path)
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
     (journal_dir / "rich-quest.md").write_text(content)
 
     entry = _parse_journal_entry(journal_dir / "rich-quest.md", tmp_path)
@@ -563,7 +567,8 @@ def test_journal_entry_ignores_invalid_quality_tier_type(tmp_path):
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: Rich Quest
 
         **Quest ID:** rich-quest-001
@@ -575,7 +580,8 @@ def test_journal_entry_ignores_invalid_quality_tier_type(tmp_path):
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
     (journal_dir / "rich-quest.md").write_text(content)
 
     entry = _parse_journal_entry(journal_dir / "rich-quest.md", tmp_path)
@@ -588,7 +594,8 @@ def test_journal_entry_deduplicates_agent_models_by_normalized_label(tmp_path):
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: Rich Quest
 
         **Quest ID:** rich-quest-001
@@ -603,7 +610,8 @@ def test_journal_entry_deduplicates_agent_models_by_normalized_label(tmp_path):
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
     (journal_dir / "rich-quest.md").write_text(content)
 
     entry = _parse_journal_entry(journal_dir / "rich-quest.md", tmp_path)
@@ -625,7 +633,8 @@ def test_journal_entry_with_celebration_data(tmp_path):
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: Rich Quest
 
         **Quest ID:** rich-quest-001
@@ -653,7 +662,8 @@ def test_journal_entry_with_celebration_data(tmp_path):
         }
         ```
         <!-- celebration-data-end -->
-    """)
+    """
+    )
     (journal_dir / "rich-quest_2026-03-05.md").write_text(content)
 
     entry = _parse_journal_entry(journal_dir / "rich-quest_2026-03-05.md", tmp_path)
@@ -669,7 +679,8 @@ def test_journal_entry_without_celebration_data_has_none_fields(tmp_path):
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(
+        """\
         # Quest Journal: Old Quest
 
         **Quest ID:** old-quest-001
@@ -678,7 +689,8 @@ def test_journal_entry_without_celebration_data_has_none_fields(tmp_path):
         ## Summary
 
         An old quest without celebration data.
-    """)
+    """
+    )
     (journal_dir / "old-quest_2026-01-15.md").write_text(content)
 
     entry = _parse_journal_entry(journal_dir / "old-quest_2026-01-15.md", tmp_path)

--- a/tests/unit/test_quest_dashboard_render.py
+++ b/tests/unit/test_quest_dashboard_render.py
@@ -877,39 +877,43 @@ def test_hero_has_timestamp(tmp_path):
 
 def test_kpi_row_blocked_count(tmp_path):
     """Blocked KPI shows correct count; unknown-status quests excluded from In Progress."""
-    active_quests = [
-        ActiveQuest(
-            quest_id=f"active-{i}",
-            slug=f"active-{i}",
-            title=f"Active {i}",
-            elevator_pitch="Test.",
-            status="In Progress",
-            phase="Building",
-            updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
-        )
-        for i in range(3)
-    ] + [
-        ActiveQuest(
-            quest_id=f"blocked-{i}",
-            slug=f"blocked-{i}",
-            title=f"Blocked {i}",
-            elevator_pitch="Test.",
-            status="Blocked",
-            phase="Building",
-            updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
-        )
-        for i in range(2)
-    ] + [
-        ActiveQuest(
-            quest_id="mystery-001",
-            slug="mystery",
-            title="Mystery Quest",
-            elevator_pitch="Unknown status.",
-            status="SomethingWeird",
-            phase="Unknown",
-            updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
-        ),
-    ]
+    active_quests = (
+        [
+            ActiveQuest(
+                quest_id=f"active-{i}",
+                slug=f"active-{i}",
+                title=f"Active {i}",
+                elevator_pitch="Test.",
+                status="In Progress",
+                phase="Building",
+                updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
+            )
+            for i in range(3)
+        ]
+        + [
+            ActiveQuest(
+                quest_id=f"blocked-{i}",
+                slug=f"blocked-{i}",
+                title=f"Blocked {i}",
+                elevator_pitch="Test.",
+                status="Blocked",
+                phase="Building",
+                updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
+            )
+            for i in range(2)
+        ]
+        + [
+            ActiveQuest(
+                quest_id="mystery-001",
+                slug="mystery",
+                title="Mystery Quest",
+                elevator_pitch="Unknown status.",
+                status="SomethingWeird",
+                phase="Unknown",
+                updated_at=datetime(2026, 2, 12, 10, 0, 0, tzinfo=UTC),
+            ),
+        ]
+    )
 
     data = DashboardData(
         finished_quests=[],

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -160,6 +160,57 @@ def test_run_bridge_probe_treats_found_handoff_as_success_even_on_nonzero_exit(
     assert result.stderr == "Timed out after 30.0s"
 
 
+def test_run_claude_role_treats_found_handoff_as_success_even_after_timeout(
+    tmp_path, monkeypatch
+):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("timeout handoff test\n", encoding="utf-8")
+    handoff_file = tmp_path / "handoff.json"
+
+    class FakeProcess:
+        def __init__(self):
+            self.returncode = 1
+
+        def communicate(self, timeout: float | None = None):
+            handoff_file.write_text(
+                '{"status":"complete","artifacts":[],"next":null,"summary":"ok"}',
+                encoding="utf-8",
+            )
+            return "", "Timed out after 30.0s"
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(claude_runner_module.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+
+    result = run_claude_role(
+        cwd=tmp_path,
+        quest_dir=tmp_path,
+        phase="plan",
+        agent="planner",
+        iteration=1,
+        prompt_file=prompt_file,
+        handoff_file=handoff_file,
+        bridge_script=tmp_path / "bridge.py",
+        model="opus",
+        timeout=0.01,
+        permission_mode="bypassPermissions",
+        poll_interval=0.01,
+        exit_grace_seconds=0.01,
+    )
+
+    assert result.exit_code == 0
+    assert result.handoff_state == "found"
+    assert result.result_kind == "handoff_json"
+    assert result.source == "handoff_json"
+
+
 def test_run_claude_role_does_not_short_circuit_to_text_fallback_before_retry(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -156,3 +156,74 @@ def test_run_bridge_probe_treats_found_handoff_as_success_even_on_nonzero_exit(
     assert result.result_kind == "handoff_json"
     assert result.source == "handoff_json"
     assert result.stderr == "Timed out after 30.0s"
+
+
+def test_run_claude_role_does_not_short_circuit_to_text_fallback_before_retry(
+    tmp_path, monkeypatch
+):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("prompt", encoding="utf-8")
+    handoff_file = tmp_path / "handoff.json"
+    artifact = tmp_path / "artifact.md"
+
+    class FakeProcess:
+        def __init__(self, *, stdout: str, stderr: str, on_communicate=None):
+            self.returncode = 1
+            self._stdout = stdout
+            self._stderr = stderr
+            self._on_communicate = on_communicate
+
+        def communicate(self, timeout: float | None = None):
+            if self._on_communicate is not None:
+                self._on_communicate()
+            return self._stdout, self._stderr
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    popen_calls = {"count": 0}
+
+    def make_handoff():
+        handoff_file.write_text(
+            '{"status":"complete","artifacts":["artifact.md"],"next":null,"summary":"ok"}',
+            encoding="utf-8",
+        )
+
+    def fake_popen(*args, **kwargs):
+        popen_calls["count"] += 1
+        if popen_calls["count"] == 1:
+            return FakeProcess(
+                stdout="---HANDOFF---\nSTATUS: complete\nARTIFACTS: artifact.md\nNEXT: null\nSUMMARY: text fallback\n",
+                stderr="Error: Permission denied writing artifact",
+            )
+        return FakeProcess(stdout="", stderr="", on_communicate=make_handoff)
+
+    monkeypatch.setattr(claude_runner_module.subprocess, "Popen", fake_popen)
+
+    result = run_claude_role(
+        cwd=tmp_path,
+        quest_dir=tmp_path,
+        phase="plan",
+        agent="planner",
+        iteration=1,
+        prompt_file=prompt_file,
+        handoff_file=handoff_file,
+        bridge_script=tmp_path / "bridge.py",
+        model="opus",
+        timeout=1.0,
+        permission_mode="bypassPermissions",
+        artifact_paths=[artifact],
+        poll_interval=0.01,
+        exit_grace_seconds=0.01,
+    )
+
+    assert popen_calls["count"] == 2
+    assert result.result_kind == "handoff_json"
+    assert result.source == "handoff_json"
+    assert "Tier B retry:" in result.stderr

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import quest_claude_runner
 import quest_runtime.claude_runner as claude_runner_module
-from quest_runtime.claude_runner import run_bridge_probe, run_claude_role, select_role_runtime
+from quest_runtime.claude_runner import (
+    run_bridge_probe,
+    run_claude_role,
+    select_role_runtime,
+)
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -187,7 +191,9 @@ def test_run_claude_role_treats_found_handoff_as_success_even_after_timeout(
         def kill(self):
             return None
 
-    monkeypatch.setattr(claude_runner_module.subprocess, "Popen", lambda *args, **kwargs: FakeProcess())
+    monkeypatch.setattr(
+        claude_runner_module.subprocess, "Popen", lambda *args, **kwargs: FakeProcess()
+    )
 
     result = run_claude_role(
         cwd=tmp_path,

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -441,3 +441,32 @@ def test_quest_claude_runner_enables_text_fallback(monkeypatch, tmp_path, capsys
     assert exit_code == 0
     assert captured["allow_text_fallback"] is True
     assert '"result_kind": "text_fallback"' in payload
+
+
+def test_quest_claude_runner_returns_structured_invocation_error_on_bad_phase(
+    monkeypatch, tmp_path, capsys
+):
+    args = Namespace(
+        quest_dir=str(tmp_path / ".quest" / "qid"),
+        phase="bad_phase",
+        agent="planner",
+        iter=1,
+        prompt_file=str(tmp_path / "prompt.txt"),
+        handoff_file=str(tmp_path / "handoff.json"),
+        model="opus",
+        timeout=90.0,
+        permission_mode="bypassPermissions",
+        bridge_script="scripts/claude_cli_bridge.py",
+        cwd=str(tmp_path),
+        add_dir=[],
+    )
+
+    monkeypatch.setattr(quest_claude_runner, "parse_args", lambda: args)
+
+    exit_code = quest_claude_runner.main()
+    payload = capsys.readouterr().out.strip()
+
+    assert exit_code == 1
+    assert '"result_kind": "invocation_error"' in payload
+    assert '"handoff_state": "missing"' in payload
+    assert "not valid for phase" in payload

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import stat
 import subprocess
+from argparse import Namespace
 from pathlib import Path
 
+import quest_claude_runner
 import quest_runtime.claude_runner as claude_runner_module
 from quest_runtime.claude_runner import run_bridge_probe, run_claude_role, select_role_runtime
 
@@ -227,3 +229,50 @@ def test_run_claude_role_does_not_short_circuit_to_text_fallback_before_retry(
     assert result.result_kind == "handoff_json"
     assert result.source == "handoff_json"
     assert "Tier B retry:" in result.stderr
+
+
+def test_quest_claude_runner_enables_text_fallback(monkeypatch, tmp_path, capsys):
+    args = Namespace(
+        quest_dir=str(tmp_path / ".quest" / "qid"),
+        phase="plan",
+        agent="planner",
+        iter=1,
+        prompt_file=str(tmp_path / "prompt.txt"),
+        handoff_file=str(tmp_path / "handoff.json"),
+        model="opus",
+        timeout=90.0,
+        permission_mode="bypassPermissions",
+        bridge_script="scripts/claude_cli_bridge.py",
+        cwd=str(tmp_path),
+        add_dir=[],
+    )
+    captured: dict[str, object] = {}
+
+    def fake_expected_artifacts_for_role(*, quest_dir, phase, agent):
+        return [Path(quest_dir) / "phase_01_plan" / "plan.md"]
+
+    def fake_run_claude_role(**kwargs):
+        captured.update(kwargs)
+        return claude_runner_module.RunResult(
+            exit_code=0,
+            handoff_state="missing",
+            result_kind="text_fallback",
+            source="text_fallback",
+            stdout="ok",
+            stderr="",
+        )
+
+    monkeypatch.setattr(quest_claude_runner, "parse_args", lambda: args)
+    monkeypatch.setattr(
+        quest_claude_runner,
+        "expected_artifacts_for_role",
+        fake_expected_artifacts_for_role,
+    )
+    monkeypatch.setattr(quest_claude_runner, "run_claude_role", fake_run_claude_role)
+
+    exit_code = quest_claude_runner.main()
+    payload = capsys.readouterr().out.strip()
+
+    assert exit_code == 0
+    assert captured["allow_text_fallback"] is True
+    assert '"result_kind": "text_fallback"' in payload

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import stat
+import subprocess
 from pathlib import Path
 
-from quest_runtime.claude_runner import run_claude_role, select_role_runtime
+import quest_runtime.claude_runner as claude_runner_module
+from quest_runtime.claude_runner import run_bridge_probe, run_claude_role, select_role_runtime
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -115,3 +117,42 @@ def test_run_claude_role_reports_invocation_error_result_kind(tmp_path):
     assert result.handoff_state == "missing"
     assert result.result_kind == "invocation_error"
     assert result.source is None
+
+
+def test_run_bridge_probe_treats_found_handoff_as_success_even_on_nonzero_exit(
+    tmp_path, monkeypatch
+):
+    completed = subprocess.CompletedProcess(
+        args=["bridge"],
+        returncode=1,
+        stdout="",
+        stderr="Timed out after 30.0s",
+    )
+
+    def fake_run(*args, **kwargs):
+        probe_dir = tmp_path / "logs" / "bridge_probe"
+        artifact_file = probe_dir / "probe_artifact.txt"
+        handoff_file = probe_dir / "probe_handoff.json"
+        artifact_file.write_text("ok", encoding="utf-8")
+        handoff_file.write_text(
+            '{"status":"complete","artifacts":["probe_artifact.txt"],"next":null,"summary":"probe ok"}',
+            encoding="utf-8",
+        )
+        return completed
+
+    monkeypatch.setattr(claude_runner_module.subprocess, "run", fake_run)
+
+    result = run_bridge_probe(
+        cwd=tmp_path,
+        quest_dir=tmp_path,
+        bridge_script=tmp_path / "bridge.py",
+        model="opus",
+        timeout=30.0,
+        permission_mode="bypassPermissions",
+    )
+
+    assert result.exit_code == 0
+    assert result.handoff_state == "found"
+    assert result.result_kind == "handoff_json"
+    assert result.source == "handoff_json"
+    assert result.stderr == "Timed out after 30.0s"

--- a/tests/unit/test_quest_runtime.py
+++ b/tests/unit/test_quest_runtime.py
@@ -211,6 +211,119 @@ def test_run_claude_role_treats_found_handoff_as_success_even_after_timeout(
     assert result.source == "handoff_json"
 
 
+def test_run_claude_role_does_not_treat_found_handoff_as_success_when_artifact_empty(
+    tmp_path, monkeypatch
+):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("timeout handoff test\n", encoding="utf-8")
+    handoff_file = tmp_path / "handoff.json"
+    artifact = tmp_path / "plan.md"
+
+    class FakeProcess:
+        def __init__(self):
+            self.returncode = 1
+
+        def communicate(self, timeout: float | None = None):
+            handoff_file.write_text(
+                '{"status":"complete","artifacts":["plan.md"],"next":null,"summary":"ok"}',
+                encoding="utf-8",
+            )
+            return "", "Timed out after 30.0s"
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(
+        claude_runner_module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: FakeProcess(),
+    )
+
+    result = run_claude_role(
+        cwd=tmp_path,
+        quest_dir=tmp_path,
+        phase="plan",
+        agent="planner",
+        iteration=1,
+        prompt_file=prompt_file,
+        handoff_file=handoff_file,
+        bridge_script=tmp_path / "bridge.py",
+        model="opus",
+        timeout=0.01,
+        permission_mode="bypassPermissions",
+        artifact_paths=[artifact],
+        poll_interval=0.01,
+        exit_grace_seconds=0.01,
+    )
+
+    assert result.exit_code != 0
+    assert result.handoff_state == "found"
+    assert result.result_kind != "handoff_json"
+    assert result.source is None
+
+
+def test_run_claude_role_logs_context_health_for_late_handoff_success(
+    tmp_path, monkeypatch
+):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("timeout handoff test\n", encoding="utf-8")
+    handoff_file = tmp_path / "handoff.json"
+
+    class FakeProcess:
+        def __init__(self):
+            self.returncode = 1
+
+        def communicate(self, timeout: float | None = None):
+            handoff_file.write_text(
+                '{"status":"complete","artifacts":[],"next":null,"summary":"ok"}',
+                encoding="utf-8",
+            )
+            return "", "Timed out after 30.0s"
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(
+        claude_runner_module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: FakeProcess(),
+    )
+
+    result = run_claude_role(
+        cwd=tmp_path,
+        quest_dir=tmp_path,
+        phase="plan",
+        agent="planner",
+        iteration=1,
+        prompt_file=prompt_file,
+        handoff_file=handoff_file,
+        bridge_script=tmp_path / "bridge.py",
+        model="opus",
+        timeout=0.01,
+        permission_mode="bypassPermissions",
+        poll_interval=0.01,
+        exit_grace_seconds=0.01,
+    )
+
+    log_file = tmp_path / "logs" / "context_health.log"
+
+    assert result.exit_code == 0
+    assert log_file.exists()
+    assert "source=handoff_json" in log_file.read_text(encoding="utf-8")
+
+
 def test_run_claude_role_does_not_short_circuit_to_text_fallback_before_retry(
     tmp_path, monkeypatch
 ):
@@ -243,6 +356,7 @@ def test_run_claude_role_does_not_short_circuit_to_text_fallback_before_retry(
     popen_calls = {"count": 0}
 
     def make_handoff():
+        artifact.write_text("ok", encoding="utf-8")
         handoff_file.write_text(
             '{"status":"complete","artifacts":["artifact.md"],"next":null,"summary":"ok"}',
             encoding="utf-8",


### PR DESCRIPTION
## Summary
Make Quest artifact preparation explicit before role execution and tighten runtime fallback behavior so write-boundary failures retry on the same runtime before cross-runtime fallback.
- Keep Quest artifacts workspace-local by default for sandboxed runs.
- Align Codex role defaults on `gpt-5.4`.

## Changes
- **Runtime helpers**:
  - Add `scripts/quest_runtime/artifacts.py` for role-to-artifact resolution, artifact preparation, and workspace-local path checks.
  - Export the new helpers from `scripts/quest_runtime/__init__.py`.
- **Claude bridge path**:
  - Pass resolved artifact paths through `scripts/quest_claude_runner.py`.
  - Update `scripts/quest_runtime/claude_runner.py` to prepare role artifacts, classify failures, and perform Tier B same-runtime retries without re-truncating artifacts.
- **Quest workflow/docs**:
  - Update `.skills/quest/delegation/workflow.md` and `.ai/quest.md` to document artifact preparation, workspace-local `.quest` paths, and the Tier A/B/C fallback ladder.
  - Update `.ai/allowlist.json` to use `models.*` and `gpt-5.4` for Codex slots.
- **Planning/tests**:
  - Add the implementation idea doc in `ideas/generic-artifact-preparation-and-runtime-fallbacks.md`.
  - Add `tests/unit/test_artifacts.py` for artifact helpers and retry behavior.

## Validation
- [x] Run `bash scripts/validate-manifest.sh` and confirm Quest files are fully covered.
- [x] Run `bash scripts/validate-quest-config.sh` and confirm config/docs validation passes.
- [x] Run `pytest -q tests/unit/test_artifacts.py tests/unit/test_quest_runtime.py` and confirm runtime helper coverage passes.
Watch for: permission/write-boundary classification should trigger same-runtime escalation before any cross-runtime fallback.

## Notes
- This draft is focused on Quest runtime behavior and workflow contracts; end-to-end verification of external shared `.quest` paths is still best validated manually.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by Claude, GPT-5.4 in Collaboration with KjellKod
</pre>
