### PR TITLE
Replace .md probe with quest_preflight.sh script

### DIFF
--- a/.quest-manifest
+++ b/.quest-manifest
@@ -86,6 +86,7 @@ scripts/quest_celebrate/progress.py
 scripts/quest_celebrate/terminal.py
 scripts/quest_celebrate/quest_data.py
 scripts/quest_celebrate/quest-celebrate.sh
+scripts/quest_preflight.sh
 
 [user-customized]
 # These files are NEVER overwritten - upstream changes create .quest_updated suffix

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -36,12 +36,14 @@ If no quest ID is provided:
 
 ### Step 2b: Second Model Availability Probe (New Quest Only)
 
-Before presenting route options, run the preflight check:
+**MANDATORY — run before Step 3.** From the repository root, execute the preflight check:
 
 ```bash
-scripts/quest_preflight.sh --orchestrator claude   # if you are Claude
-scripts/quest_preflight.sh --orchestrator codex    # if you are Codex
+./scripts/quest_preflight.sh --orchestrator claude   # if you are Claude
+./scripts/quest_preflight.sh --orchestrator codex    # if you are Codex
 ```
+
+The script is at the **repository root** (`scripts/quest_preflight.sh`), NOT inside the skill directory.
 
 1. Parse the JSON output. Cache `available` as a boolean for the session.
 2. If `available` is false:

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -47,7 +47,7 @@ The script is at the **repository root** (`scripts/quest_preflight.sh`), NOT ins
 
 1. Parse the JSON output. Cache `available` as a boolean for the session.
 2. If `available` is false:
-   - Display the `warning` field from the JSON output as a blockquote before route options.
+   - Display **every line** of the `warning` array from the JSON output as a blockquote before route options. The array contains the heading, setup commands, and instructions — show them all.
    - Append "(Claude-only)" or "(Codex-only)" to solo/full quest option labels.
 3. If `available` is true, proceed normally.
 

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -36,34 +36,20 @@ If no quest ID is provided:
 
 ### Step 2b: Second Model Availability Probe (New Quest Only)
 
-Before presenting route options, probe for the availability of the second model:
+Before presenting route options, run the preflight check:
 
-**If the orchestrator is Claude** (Claude Code, OpenCode with Claude, etc.):
-1. Call `ToolSearch("codex")` to check if `mcp__codex-cli__codex` (or platform equivalent) is available.
-2. Cache the result as `codex_available` (boolean).
-3. If `codex_available` is false, include a warning in every route presentation (Step 3) before the options:
-   ```
-   ⚠ Codex MCP not available — quest will run Claude-only (all roles).
-     To enable dual-model mode (Claude + Codex), run:
-       npm i -g @openai/codex          # install Codex CLI
-       codex auth                       # login to OpenAI
-       claude mcp add --scope user codex-cli -- codex mcp-server
-     Then restart this Claude Code session.
-   ```
-   Also append "(Claude-only)" to solo/full quest option labels so the user sees the limitation before choosing.
-4. If `codex_available` is true, no warning needed. Proceed normally.
+```bash
+scripts/quest_preflight.sh --orchestrator claude   # if you are Claude
+scripts/quest_preflight.sh --orchestrator codex    # if you are Codex
+```
 
-**If the orchestrator is Codex:**
-1. Probe for Claude bridge availability (see workflow.md Claude Bridge Probe section).
-2. Cache the result as `claude_bridge_available` (boolean).
-3. If `claude_bridge_available` is false, include a warning before route options:
-   ```
-   ⚠ Claude bridge not available — quest will run Codex-only (all roles).
-     Ensure Claude CLI is installed and authenticated: claude auth
-   ```
-4. If `claude_bridge_available` is true, no warning needed. Proceed normally.
+1. Parse the JSON output. Cache `available` as a boolean for the session.
+2. If `available` is false:
+   - Display the `warning` field from the JSON output as a blockquote before route options.
+   - Append "(Claude-only)" or "(Codex-only)" to solo/full quest option labels.
+3. If `available` is true, proceed normally.
 
-This probe result carries into workflow.md — do not re-probe there.
+This result carries into workflow.md — do not re-probe there.
 
 ### Step 3: Route
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -23,13 +23,20 @@ Tool naming is platform-specific (depends on the MCP server name in config):
 
 In this document, `mcp__codex__codex` is used as an **abstract placeholder** meaning "the platform's Codex session-start MCP tool". Substitute the actual tool name for your platform.
 
-If `codex_available` was already cached by the preflight script (SKILL.md Step 2b), use the cached value. Otherwise, probe now:
+If the preflight result was already cached by SKILL.md Step 2b, use the cached values. Otherwise, probe now:
 
-1. Run `scripts/quest_preflight.sh --orchestrator claude` (or `codex` if Codex-led) and parse the JSON output.
+**Claude-led sessions:**
+1. Run `scripts/quest_preflight.sh --orchestrator claude` and parse the JSON output.
 2. Cache the `available` field as `codex_available` (boolean) for the rest of the session.
 3. If `codex_available` is false:
    - Log: `"Codex MCP not available — using Claude runtime fallback for all roles."`
    - **Global rule:** Every `mcp__codex__codex` invocation in this workflow (Reviewer B slots, Builder, Fixer — any role) is replaced with the equivalent Claude runtime fallback for that role. Use the same prompt (minus the non-interactive rule), the same output file paths, and the same handoff contract. Do not retry Codex. Do not treat this as an error.
+
+**Codex-led sessions:**
+1. `codex_available` is always true (Codex is the active runtime — no MCP needed).
+2. Run `scripts/quest_preflight.sh --orchestrator codex` and parse the JSON output.
+3. Cache the `available` field as `claude_bridge_available` (boolean) for the rest of the session.
+4. If `claude_bridge_available` is false: Claude-designated roles block unless that step defines an explicit Codex fallback (see Claude Bridge Probe section below).
 4. If `codex_available` is true:
    - Proceed normally with Codex invocations per the workflow below.
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -23,12 +23,12 @@ Tool naming is platform-specific (depends on the MCP server name in config):
 
 In this document, `mcp__codex__codex` is used as an **abstract placeholder** meaning "the platform's Codex session-start MCP tool". Substitute the actual tool name for your platform.
 
-If `codex_available` was already cached by the quest SKILL.md probe (Step 2b), skip re-probing and use the cached value. Otherwise, before the first Codex invocation, the orchestrator MUST probe for tool availability:
+If `codex_available` was already cached by the preflight script (SKILL.md Step 2b), use the cached value. Otherwise, probe now:
 
-1. Call `ToolSearch("codex")` (or platform equivalent) to discover if `mcp__codex__codex` is available.
-2. Cache the result as `codex_available` (boolean) for the rest of the session.
+1. Run `scripts/quest_preflight.sh --orchestrator claude` (or `codex` if Codex-led) and parse the JSON output.
+2. Cache the `available` field as `codex_available` (boolean) for the rest of the session.
 3. If `codex_available` is false:
-   - The user was already warned during route selection (SKILL.md Step 2b). Do not repeat the full warning — just log: `"Codex MCP not available — using Claude runtime fallback for all roles."`
+   - Log: `"Codex MCP not available — using Claude runtime fallback for all roles."`
    - **Global rule:** Every `mcp__codex__codex` invocation in this workflow (Reviewer B slots, Builder, Fixer — any role) is replaced with the equivalent Claude runtime fallback for that role. Use the same prompt (minus the non-interactive rule), the same output file paths, and the same handoff contract. Do not retry Codex. Do not treat this as an error.
 4. If `codex_available` is true:
    - Proceed normally with Codex invocations per the workflow below.

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -121,6 +121,7 @@ EXECUTABLE_FILES=(
   "scripts/validate-quest-config.sh"
   "scripts/quest_installer.sh"
   "scripts/quest_celebrate/quest-celebrate.sh"
+  "scripts/quest_preflight.sh"
 )
 
 ###############################################################################

--- a/scripts/quest_preflight.sh
+++ b/scripts/quest_preflight.sh
@@ -87,19 +87,21 @@ probe_codex() {
     available="true"
   fi
 
-  # Build warning if not available
+  # Build warning lines if not available
+  local warning_lines=""
   if [ "$available" = "false" ]; then
-    local steps=""
+    warning_lines="    \"Codex MCP not available -- quest will run Claude-only (all roles).\",\n"
+    warning_lines="${warning_lines}    \"To enable dual-model mode (Claude + Codex), run:\",\n"
     if [ "$codex_cli_installed" = "false" ]; then
-      steps="npm i -g @openai/codex          # install Codex CLI\n"
+      warning_lines="${warning_lines}    \"  npm i -g @openai/codex          # install Codex CLI\",\n"
     fi
     if [ "$openai_auth" = "false" ]; then
-      steps="${steps}codex auth                       # login to OpenAI\n"
+      warning_lines="${warning_lines}    \"  codex auth                       # login to OpenAI\",\n"
     fi
     if [ "$codex_mcp_registered" = "false" ]; then
-      steps="${steps}claude mcp add --scope user codex-cli -- codex mcp-server\n"
+      warning_lines="${warning_lines}    \"  claude mcp add --scope user codex-cli -- codex mcp-server\",\n"
     fi
-    warning="Codex MCP not available — quest will run Claude-only (all roles).\nTo enable dual-model mode (Claude + Codex), run:\n  ${steps}Then restart this Claude Code session."
+    warning_lines="${warning_lines}    \"Then restart this Claude Code session.\""
   fi
 
   cat <<EOJSON
@@ -112,7 +114,7 @@ probe_codex() {
     "codex_mcp_registered": ${codex_mcp_registered},
     "openai_auth": ${openai_auth}
   },
-  "warning": $(if [ -n "$warning" ]; then printf '%s' "$warning" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'; else echo 'null'; fi)
+  "warning": $(if [ -n "$warning_lines" ]; then printf '[\n%b\n  ]' "$warning_lines"; else echo 'null'; fi)
 }
 EOJSON
 
@@ -155,14 +157,15 @@ probe_claude_bridge() {
     rm -rf "$probe_dir"
   fi
 
-  # Build warning if not available
+  # Build warning lines if not available
+  local warning_lines=""
   if [ "$available" = "false" ]; then
-    local steps=""
+    warning_lines="    \"Claude bridge not available -- quest will run Codex-only (all roles).\",\n"
+    warning_lines="${warning_lines}    \"Ensure Claude CLI is installed and authenticated:\",\n"
     if [ "$claude_cli_installed" = "false" ]; then
-      steps="Install Claude CLI: npm i -g @anthropic-ai/claude-code\n  "
+      warning_lines="${warning_lines}    \"  npm i -g @anthropic-ai/claude-code  # install Claude CLI\",\n"
     fi
-    steps="${steps}Authenticate: claude auth"
-    warning="Claude bridge not available — quest will run Codex-only (all roles).\nEnsure Claude CLI is installed and authenticated:\n  ${steps}"
+    warning_lines="${warning_lines}    \"  claude auth                          # authenticate\""
   fi
 
   cat <<EOJSON
@@ -175,7 +178,7 @@ probe_claude_bridge() {
     "bridge_script_exists": ${bridge_script_exists},
     "bridge_reachable": ${bridge_reachable}
   },
-  "warning": $(if [ -n "$warning" ]; then printf '%s' "$warning" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'; else echo 'null'; fi)
+  "warning": $(if [ -n "$warning_lines" ]; then printf '[\n%b\n  ]' "$warning_lines"; else echo 'null'; fi)
 }
 EOJSON
 

--- a/scripts/quest_preflight.sh
+++ b/scripts/quest_preflight.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Quest Preflight Check
+# Probes second-model availability before quest routing.
+# Called by SKILL.md Step 2b — output is JSON to stdout.
+#
+# Usage: scripts/quest_preflight.sh [--orchestrator claude|codex]
+#
+# Exit codes:
+#   0 — second model available
+#   1 — second model unavailable (warning in JSON output)
+#   2 — usage error
+
+set -euo pipefail
+
+###############################################################################
+# Defaults
+###############################################################################
+
+ORCHESTRATOR=""
+
+###############################################################################
+# Argument Parsing
+###############################################################################
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --orchestrator)
+      ORCHESTRATOR="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Usage: quest_preflight.sh --orchestrator claude|codex" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$ORCHESTRATOR" ]; then
+  echo "Usage: quest_preflight.sh --orchestrator claude|codex" >&2
+  exit 2
+fi
+
+###############################################################################
+# Auto-detect helpers
+###############################################################################
+
+json_bool() {
+  if "$@" >/dev/null 2>&1; then echo "true"; else echo "false"; fi
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+###############################################################################
+# Claude-led session: probe for Codex
+###############################################################################
+
+probe_codex() {
+  local codex_cli_installed="false"
+  local codex_mcp_registered="false"
+  local openai_auth="false"
+  local available="false"
+  local warning=""
+
+  # Check Codex CLI
+  if has_cmd codex; then
+    codex_cli_installed="true"
+  fi
+
+  # Check MCP registration (requires claude CLI)
+  if has_cmd claude; then
+    if claude mcp list 2>/dev/null | grep -q "codex-cli"; then
+      codex_mcp_registered="true"
+    fi
+  fi
+
+  # Check OpenAI auth
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    openai_auth="true"
+  elif [ -f ".env" ] && grep -q "OPENAI_API_KEY" ".env" 2>/dev/null; then
+    openai_auth="true"
+  fi
+
+  # Determine overall availability
+  if [ "$codex_cli_installed" = "true" ] && [ "$codex_mcp_registered" = "true" ]; then
+    available="true"
+  fi
+
+  # Build warning if not available
+  if [ "$available" = "false" ]; then
+    local steps=""
+    if [ "$codex_cli_installed" = "false" ]; then
+      steps="npm i -g @openai/codex          # install Codex CLI\n"
+    fi
+    if [ "$openai_auth" = "false" ]; then
+      steps="${steps}codex auth                       # login to OpenAI\n"
+    fi
+    if [ "$codex_mcp_registered" = "false" ]; then
+      steps="${steps}claude mcp add --scope user codex-cli -- codex mcp-server\n"
+    fi
+    warning="Codex MCP not available — quest will run Claude-only (all roles).\nTo enable dual-model mode (Claude + Codex), run:\n  ${steps}Then restart this Claude Code session."
+  fi
+
+  cat <<EOJSON
+{
+  "orchestrator": "claude",
+  "second_model": "codex",
+  "available": ${available},
+  "checks": {
+    "codex_cli_installed": ${codex_cli_installed},
+    "codex_mcp_registered": ${codex_mcp_registered},
+    "openai_auth": ${openai_auth}
+  },
+  "warning": $(if [ -n "$warning" ]; then printf '%s' "$warning" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'; else echo 'null'; fi)
+}
+EOJSON
+
+  if [ "$available" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+###############################################################################
+# Codex-led session: probe for Claude bridge
+###############################################################################
+
+probe_claude_bridge() {
+  local claude_cli_installed="false"
+  local bridge_script_exists="false"
+  local bridge_reachable="false"
+  local available="false"
+  local warning=""
+
+  # Check Claude CLI
+  if has_cmd claude; then
+    claude_cli_installed="true"
+  fi
+
+  # Check bridge script
+  if [ -f "scripts/claude_cli_bridge.py" ]; then
+    bridge_script_exists="true"
+  fi
+
+  # Run the real probe if both exist
+  if [ "$claude_cli_installed" = "true" ] && [ "$bridge_script_exists" = "true" ]; then
+    local probe_dir=".quest/_preflight_probe"
+    mkdir -p "$probe_dir"
+    if python3 scripts/quest_claude_probe.py --quest-dir "$probe_dir" --model opus >/dev/null 2>&1; then
+      bridge_reachable="true"
+      available="true"
+    fi
+    rm -rf "$probe_dir"
+  fi
+
+  # Build warning if not available
+  if [ "$available" = "false" ]; then
+    local steps=""
+    if [ "$claude_cli_installed" = "false" ]; then
+      steps="Install Claude CLI: npm i -g @anthropic-ai/claude-code\n  "
+    fi
+    steps="${steps}Authenticate: claude auth"
+    warning="Claude bridge not available — quest will run Codex-only (all roles).\nEnsure Claude CLI is installed and authenticated:\n  ${steps}"
+  fi
+
+  cat <<EOJSON
+{
+  "orchestrator": "codex",
+  "second_model": "claude",
+  "available": ${available},
+  "checks": {
+    "claude_cli_installed": ${claude_cli_installed},
+    "bridge_script_exists": ${bridge_script_exists},
+    "bridge_reachable": ${bridge_reachable}
+  },
+  "warning": $(if [ -n "$warning" ]; then printf '%s' "$warning" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'; else echo 'null'; fi)
+}
+EOJSON
+
+  if [ "$available" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+case "$ORCHESTRATOR" in
+  claude)
+    probe_codex
+    ;;
+  codex)
+    probe_claude_bridge
+    ;;
+  *)
+    echo "Unknown orchestrator: $ORCHESTRATOR (expected: claude or codex)" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/quest_preflight.sh
+++ b/scripts/quest_preflight.sh
@@ -25,7 +25,11 @@ ORCHESTRATOR=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --orchestrator)
-      ORCHESTRATOR="${2:-}"
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "Usage: quest_preflight.sh --orchestrator claude|codex" >&2
+        exit 2
+      fi
+      ORCHESTRATOR="$2"
       shift 2
       ;;
     *)


### PR DESCRIPTION
## Summary
Replace the markdown-instruction-based second-model probe (SKILL.md Step 2b) with a deterministic shell script that both Claude and Codex orchestrators call, returning structured JSON. The .md instruction approach was unreliable -- models would skip or misinterpret the probe, look in wrong paths, or paraphrase warnings.

## Changes
- **Script** (`scripts/quest_preflight.sh`):
  - `--orchestrator claude`: checks codex CLI installed, MCP registered, OpenAI auth
  - `--orchestrator codex`: checks claude CLI installed, bridge script exists, bridge reachable
  - Returns JSON with `available` bool, per-check detail, and `warning` string array
  - Exit 0 = second model available, exit 1 = unavailable
- **SKILL.md**: Step 2b calls the script, parses JSON, displays warning array before route options
- **workflow.md**: Codex probe defers to preflight cache, falls back to running the script
- **Installer**: Added `quest_preflight.sh` to `EXECUTABLE_FILES` array for +x on install
- **Manifest**: Added `scripts/quest_preflight.sh`

## Validation

### Installer
- [x] `./quest_installer.sh --branch preflight-script` installs `quest_preflight.sh` with execute permission
- [x] Installer detects missing Codex MCP and offers to register it

### Preflight script directly
- [x] `./scripts/quest_preflight.sh --orchestrator claude` returns valid JSON with all checks
- [x] With Codex MCP removed: returns `"available": false` with warning array, exit 1
- [x] `./scripts/quest_preflight.sh --orchestrator codex` returns valid JSON
- [x] With bridge script renamed: returns `"available": false`, exit 1
- [x] Warning output is clean JSON array (no `\u2014` unicode escapes or `\\n` blobs)

### Quest integration (Claude orchestrator)
- [x] `/quest "Add a README.md"` runs preflight before route options
- [x] Warning blockquote shows all lines (heading + setup commands)
- [x] Route option labels show "(Claude-only)"
- [x] User sees the warning before choosing a quest mode

### Quest integration (Codex orchestrator)
- [x] `%quest "analyze repo"` runs bridge probe before route options
- [x] Missing bridge detected, warning shown before route options
- [x] Option labels show "(Codex-only)"

### Issues found and fixed during testing
1. Model looked for script at `.skills/quest/scripts/` instead of repo root -- fixed path and wording
2. Installer didn't set +x on the script -- added to EXECUTABLE_FILES
3. Warning JSON used python json.dumps producing unicode escapes -- switched to plain string array
4. Model only displayed first warning line -- clarified "display every line"

Watch for: `claude mcp list` may show codex-cli at project scope even after removing user scope -- preflight correctly detects any scope.

> [!NOTE]
> Once this merges, close PR #78 (`codex-setup-and-dual-plan-idea`) -- the .md-instruction probe is fully superseded by this script approach.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by Claude Opus 4.6 (1M context), Codex in Collaboration with KjellKod
</pre>
