### PR TITLE
Increase bridge timeout default from 90s to 30 minutes

### DIFF
--- a/scripts/claude_cli_bridge.py
+++ b/scripts/claude_cli_bridge.py
@@ -31,11 +31,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="json",
         help="Claude output format (default: json)",
     )
+    # NOTE: This default is duplicated in scripts/quest_claude_runner.py.
+    # If you change it here, update it there too.
     parser.add_argument(
         "--timeout",
         type=float,
-        default=90.0,
-        help="Command timeout seconds (default: 90)",
+        default=1800.0,
+        help="Command timeout seconds (default: 1800)",
     )
     parser.add_argument(
         "--model",

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -22,7 +22,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", default="opus")
     # NOTE: This default is duplicated in scripts/claude_cli_bridge.py.
     # If you change it here, update it there too.
-    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument("--timeout", type=float, default=1800.0,
+                        help="Command timeout seconds (default: 1800)")
     parser.add_argument("--permission-mode", default="bypassPermissions")
     parser.add_argument("--bridge-script", default="scripts/claude_cli_bridge.py")
     parser.add_argument("--cwd", default=".")

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -20,7 +20,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt-file", required=True)
     parser.add_argument("--handoff-file", required=True)
     parser.add_argument("--model", default="opus")
-    parser.add_argument("--timeout", type=float, default=90.0)
+    # NOTE: This default is duplicated in scripts/claude_cli_bridge.py.
+    # If you change it here, update it there too.
+    parser.add_argument("--timeout", type=float, default=1800.0)
     parser.add_argument("--permission-mode", default="bypassPermissions")
     parser.add_argument("--bridge-script", default="scripts/claude_cli_bridge.py")
     parser.add_argument("--cwd", default=".")


### PR DESCRIPTION
## Summary
Raise the default bridge subprocess timeout from 90 seconds to 30 minutes so long-running agent tasks are not killed prematurely.
- Adds cross-reference comments in both files where the default is defined so they stay in sync.

> [!NOTE]
> The timeout default is still duplicated across two files. Centralizing it into a shared constant is tracked as a future improvement in `ideas/quest-state-transition-guardrails.md`.

## Changes
- `scripts/claude_cli_bridge.py`: Change `--timeout` default from `90.0` to `1800.0`, add sync comment
- `scripts/quest_claude_runner.py`: Change `--timeout` default from `90.0` to `1800.0`, add sync comment

## Validation
- [x] Run `python scripts/claude_cli_bridge.py --help` and confirm timeout default shows 1800
- [x] Run `python scripts/quest_claude_runner.py --help` and confirm timeout default shows 1800.0

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by Claude Opus 4.6, Codex in Collaboration with KjellKod
</pre>