### PR TITLE
Generic cleanup, dashboard, skills, completion of quests workflows 

### DIFF
--- a/.github/workflows/codex-ci-review.yml
+++ b/.github/workflows/codex-ci-review.yml
@@ -105,9 +105,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Fetch ALL inline review comments (bot + human) with thread info
-          gh api --paginate --slurp "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-            --jq 'map(.[]) | map({id, in_reply_to_id, user: .user.login, path, line, body})' \
-            > /tmp/existing_comments.json 2>/dev/null || echo "[]" > /tmp/existing_comments.json
+          # Use --paginate with --jq (no --slurp) to stream pages through jq individually.
+          # Wrap output in a JSON array for downstream consumption.
+          echo "[" > /tmp/existing_comments.json
+          gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | {id, in_reply_to_id, user: .user.login, path, line, body}' 2>/tmp/fetch_comments_err.log \
+            | awk 'NR>1{print ","} {printf "%s",$0}' >> /tmp/existing_comments.json
+          echo "]" >> /tmp/existing_comments.json
+
+          # Validate JSON; fall back to empty array if fetch failed
+          if ! python3 -c "import json; json.load(open('/tmp/existing_comments.json'))" 2>/dev/null; then
+            echo "::warning::Failed to fetch existing comments. Dedup will be skipped."
+            cat /tmp/fetch_comments_err.log >&2 || true
+            echo "[]" > /tmp/existing_comments.json
+          fi
 
       - name: Build review prompt
         if: steps.check-key.outputs.skip != 'true'

--- a/.github/workflows/codex-ci-review.yml
+++ b/.github/workflows/codex-ci-review.yml
@@ -104,18 +104,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           # Fetch ALL inline review comments (bot + human) with thread info
           # Use --paginate with --jq (no --slurp) to stream pages through jq individually.
           # Wrap output in a JSON array for downstream consumption.
-          echo "[" > /tmp/existing_comments.json
-          gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+          if gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
             --jq '.[] | {id, in_reply_to_id, user: .user.login, path, line, body}' 2>/tmp/fetch_comments_err.log \
-            | awk 'NR>1{print ","} {printf "%s",$0}' >> /tmp/existing_comments.json
-          echo "]" >> /tmp/existing_comments.json
-
-          # Validate JSON; fall back to empty array if fetch failed
-          if ! python3 -c "import json; json.load(open('/tmp/existing_comments.json'))" 2>/dev/null; then
-            echo "::warning::Failed to fetch existing comments. Dedup will be skipped."
+            | awk 'NR>1{print ","} {printf "%s",$0}' > /tmp/existing_comments_body.json; then
+            # Wrap in JSON array
+            printf '[%s]' "$(cat /tmp/existing_comments_body.json)" > /tmp/existing_comments.json
+            # Validate JSON structure
+            if ! python3 -c "import json; json.load(open('/tmp/existing_comments.json'))" 2>/dev/null; then
+              echo "::warning::Fetched comments but JSON is malformed. Dedup will be skipped."
+              echo "[]" > /tmp/existing_comments.json
+            fi
+          else
+            echo "::warning::Failed to fetch existing comments (gh api exit $?). Dedup will be skipped."
             cat /tmp/fetch_comments_err.log >&2 || true
             echo "[]" > /tmp/existing_comments.json
           fi

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -88,6 +88,7 @@ scripts/quest_celebrate/quest_data.py
 scripts/quest_celebrate/quest-celebrate.sh
 scripts/quest_complete.py
 scripts/quest_preflight.sh
+scripts/quest_state.py
 
 [user-customized]
 # These files are NEVER overwritten - upstream changes create .quest_updated suffix

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -86,6 +86,7 @@ scripts/quest_celebrate/progress.py
 scripts/quest_celebrate/terminal.py
 scripts/quest_celebrate/quest_data.py
 scripts/quest_celebrate/quest-celebrate.sh
+scripts/quest_complete.py
 scripts/quest_preflight.sh
 
 [user-customized]

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -107,9 +107,14 @@ Rules:
 
 ### Validation section
 
+#### Purpose
+
+The goal of validation is not just correctness — it is comprehension. Write steps as a guided walkthrough so that a reviewer who follows them will have *used* the new functionality and built a mental model of the change, not just confirmed it didn't error.
+
 #### Principles
 
 - **Reduce reviewer ambiguity** — every step must be executable without context the reviewer doesn't have
+- **Resolve all commands and addresses** — every step must include the full runnable command or address. Never write "run the tests" — write the actual command. For services, resolve host, port, and base path from the project's configuration.
 - **Cheapest path first** — lead with validations needing no special tooling, credentials, or setup
 - **Separate tooling requirements** — clearly distinguish local-only checks from steps needing external access
 - **Point to real files** — reference actual paths and configs in the repo, not abstract examples
@@ -118,21 +123,31 @@ Rules:
 #### Rules
 
 - Use checkboxes (`- [ ]`) for every verification step.
-- Describe the action and the expected outcome in one line (e.g. "Run X, confirm Y").
 - Only include steps that a human needs to perform. Skip anything CI already covers.
 - Order steps from cheapest to most expensive — local commands first, external integrations last.
 - If there is a known risk or edge case worth watching, add a `Watch for:` line at the end — no checkbox, just a heads-up.
 - Keep it short. 2-5 steps is typical. If you need more, the PR may be too large.
 
-#### Manual validation scenarios
+#### Structured format (required for every non-CI step)
 
-When a feature requires manual testing (for example external integrations, UI behavior, or end-to-end flows), each manual validation scenario must include:
-1. **Prerequisites** — what must be set up before testing (env vars, credentials, fixture files, test data, app state)
-2. **Exact command or action** — the specific command, tool call, API request, or UI action to perform. Include copy-pasteable examples when helpful.
-3. **Expected result** — what the reviewer should observe, including specific fields, files, status codes, or visible behavior.
+Every validation step that is not a simple automated command must use this structure:
+
+1. **Prerequisites** — what must be set up before testing (env vars, credentials, running services, test data, app state)
+2. **Action** — the specific command, API request, or UI action to perform. Include full addresses and copy-pasteable commands.
+3. **Expected result** — what the reviewer should observe, including specific fields, status codes, or visible behavior.
 4. **Negative/edge cases** — include at least one when the feature introduces meaningful failure modes or graceful-degradation behavior.
 
-Do not write vague steps like "test this with the real API" or "verify the UI works". Write the setup, action, and expected outcome clearly enough that a reviewer can execute the check without guessing.
+Do not write vague steps like "test this with the real API" or "verify it works". Write the setup, action, and expected outcome clearly enough that someone unfamiliar with the project can execute the check without guessing.
+
+#### Example (illustrative — adapt to your project)
+
+Bad:
+`- [ ] Verify the new command works`
+
+Good:
+`- [ ] **Walkthrough — run the new export command**: Prerequisites: build the project (`make` or project-equivalent). Action: run `./quest export --format json --output /tmp/out.json`, then inspect `/tmp/out.json`. Expected: valid JSON containing entries matching the current quest state, with `status` and `slug` fields populated. Then run with a nonexistent quest dir (`--quest-dir /tmp/bogus`) — observe a clear error message and non-zero exit code.`
+
+The good example walks the reviewer through the feature so they understand what was built, not just whether it errors.
 
 ### Notes section (optional)
 

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -107,14 +107,32 @@ Rules:
 
 ### Validation section
 
-Each checkbox should be a concrete verification step — what to do and what result to expect. A reviewer reading the list should be able to pull the branch and verify without guessing.
+#### Principles
 
-Rules:
+- **Reduce reviewer ambiguity** — every step must be executable without context the reviewer doesn't have
+- **Cheapest path first** — lead with validations needing no special tooling, credentials, or setup
+- **Separate tooling requirements** — clearly distinguish local-only checks from steps needing external access
+- **Point to real files** — reference actual paths and configs in the repo, not abstract examples
+- **Truthful and bounded** — only claim what the validation actually proves; don't overstate coverage
+
+#### Rules
+
 - Use checkboxes (`- [ ]`) for every verification step.
 - Describe the action and the expected outcome in one line (e.g. "Run X, confirm Y").
-- Only include steps that a human needs to perform. Skip anything CI already covers (linting, syntax checks, type checks).
+- Only include steps that a human needs to perform. Skip anything CI already covers.
+- Order steps from cheapest to most expensive — local commands first, external integrations last.
 - If there is a known risk or edge case worth watching, add a `Watch for:` line at the end — no checkbox, just a heads-up.
 - Keep it short. 2-5 steps is typical. If you need more, the PR may be too large.
+
+#### Manual validation scenarios
+
+When a feature requires manual testing (for example external integrations, UI behavior, or end-to-end flows), each manual validation scenario must include:
+1. **Prerequisites** — what must be set up before testing (env vars, credentials, fixture files, test data, app state)
+2. **Exact command or action** — the specific command, tool call, API request, or UI action to perform. Include copy-pasteable examples when helpful.
+3. **Expected result** — what the reviewer should observe, including specific fields, files, status codes, or visible behavior.
+4. **Negative/edge cases** — include at least one when the feature introduces meaningful failure modes or graceful-degradation behavior.
+
+Do not write vague steps like "test this with the real API" or "verify the UI works". Write the setup, action, and expected outcome clearly enough that a reviewer can execute the check without guessing.
 
 ### Notes section (optional)
 

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -18,8 +18,9 @@ Use **inline-first** commenting by default.
 3. Create a **draft** PR via `gh pr create --draft`.
 
 ### Step 2: Wait for CI
-1. Sleep ~60 seconds to let CI workflows start and (hopefully) finish.
-2. Run `gh pr checks <PR_NUMBER>` to observe CI status.
+1. Run `gh pr checks <PR_NUMBER>` to get an early read.
+2. If any checks are still pending, sleep ~180 seconds.
+3. Run `gh pr checks <PR_NUMBER>` again to observe final CI status.
 
 ### Step 3: Evaluate CI Results
 - **All checks pass** → proceed to Step 4.

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -907,34 +907,13 @@ After plan approval, present the plan interactively before proceeding to build.
    - Optional fallback (non-interactive/runtime-only): `python3 scripts/quest_celebrate/celebrate.py --quest-dir .quest/<id> --style epic || true`
    - This step is fire-and-forget: if celebration fails, quest completion continues
 
-4. **Create quest journal entry and archive** (automated via script):
-    ```bash
-    python3 scripts/quest_complete.py --quest-dir .quest/<id>
-    ```
-    This script handles all of the following automatically:
-    - Creates `docs/quest-journal/<slug>_<YYYY-MM-DD>.md` with quest metadata, summary, files changed, iterations, agent credits, and an embedded `celebration_data` JSON block (for future `/celebrate` replay)
-    - Inserts a row at the top of `docs/quest-journal/README.md` index table
-    - Moves `.quest/<id>/` to `.quest/archive/<id>/`
-
-    The script reads all quest artifacts (state.json, handoff files, quest_brief.md, plan.md, reviews) and computes quality tier, achievements, and metrics automatically.
-
-    **If the script fails**, fall back to manual creation:
-    - Write journal entry manually following the format in existing entries
-    - Move quest directory to archive manually
-
-    **Idea file cleanup** (manual, after script runs):
-    - If quest originated from an idea file:
-      - Quote the original idea content under "This is where it all began..."
-      - Remove the idea file (e.g., `ideas/my-idea.md`)
-      - Add a `done` row to `ideas/README.md` index: `| done | ~~idea-slug~~ | One-line pitch. See [journal](../docs/quest-journal/slug_date.md). |`
-
-5. **Show summary:**
+4. **Show summary** (before archiving — quest directory still exists):
     - Quest ID
     - Files changed (from `git diff --name-only` and `state.json` artifact paths)
     - Total iterations (plan + fix, from `state.json`)
     - Parallel execution stats (read from `.quest/<id>/logs/parallelism.log` if it exists — show each line)
     - Location of artifacts (will be archived to `.quest/archive/<id>/`)
-    - Location of journal entry
+    - Location of journal entry (will be created next)
 
 6. **Context health report:**
    If `.quest/<id>/logs/context_health.log` exists, display it in full:
@@ -990,12 +969,33 @@ After plan approval, present the plan interactively before proceeding to build.
    - If compliance is <50%:
       "Low compliance -- discard approach is not effective. Recommend upgrading to run_in_background: true."
 
-6. **Verify archival** (already done by `quest_complete.py` in step 4):
+6. **Create quest journal entry and archive** (automated via script):
+    ```bash
+    python3 scripts/quest_complete.py --quest-dir .quest/<id>
+    ```
+    This script handles all of the following automatically:
+    - Creates `docs/quest-journal/<slug>_<YYYY-MM-DD>.md` with quest metadata, summary, files changed, iterations, agent credits, and an embedded `celebration_data` JSON block (for future `/celebrate` replay)
+    - Inserts a row at the top of `docs/quest-journal/README.md` index table
+    - Moves `.quest/<id>/` to `.quest/archive/<id>/`
+
+    The script reads all quest artifacts (state.json, handoff files, quest_brief.md, plan.md, reviews) and computes quality tier, achievements, and metrics automatically.
+
+    **If the script fails**, fall back to manual creation:
+    - Write journal entry manually following the format in existing entries
+    - Move quest directory to archive manually
+
+    **Idea file cleanup** (manual, after script runs):
+    - If quest originated from an idea file:
+      - Quote the original idea content under "This is where it all began..."
+      - Remove the idea file (e.g., `ideas/my-idea.md`)
+      - Add a `done` row to `ideas/README.md` index: `| done | ~~idea-slug~~ | One-line pitch. See [journal](../docs/quest-journal/slug_date.md). |`
+
+7. **Verify archival:**
     - Confirm `.quest/archive/<id>/` exists
     - Confirm `.quest/<id>/` no longer exists
     - `.quest/` root should only contain active quests, `archive/`, and `audit.log`
 
-7. **Next steps suggestion:**
+8. **Next steps suggestion:**
     ```
     Review changes: git diff
     Commit: git add -p && git commit
@@ -1003,12 +1003,12 @@ After plan approval, present the plan interactively before proceeding to build.
     - **Draft PR:** use `.skills/pr-assistant/SKILL.md` (preserve any existing bot-managed PR sections when editing PR body)
     - **PR review gate:** post an explicit review comment on the draft/ready PR, then merge only after NIT filtering using `AGENTS.md` rubric (readability-first, KISS/YAGNI/SRP/DRY, simple robust over complex elegance, avoid mocking-hell)
 
-8. **Context reset suggestion:**
+9. **Context reset suggestion:**
     ```
     Quest complete. Consider running /clear before your next quest to reset context.
     ```
 
-9. **Check for Quest updates:**
+10. **Check for Quest updates:**
    After the quest completes, check if a Quest update is available (if enough time has passed since the last check).
 
    **Configuration:**

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -384,6 +384,7 @@ gates.max_plan_iterations (default: 4)
    ```
    mcp__codex__codex(
      model: <models.plan-reviewer-b from allowlist>,
+     sandbox_permissions: "workspace-write",
      prompt: "You are Plan Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -394,7 +395,7 @@ gates.max_plan_iterations (default: 4)
      Quest brief: .quest/<id>/quest_brief.md
      Plan to review: .quest/<id>/phase_01_plan/plan.md
 
-     Artifact files have been prepared for you. Overwrite these files directly:
+     Write ONLY to these review artifact files (do NOT modify any source code):
      - .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
      - .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -407,6 +408,7 @@ gates.max_plan_iterations (default: 4)
    ```
    mcp__codex__codex(
      model: <models.plan-reviewer-b from allowlist>,
+     sandbox_permissions: "workspace-write",
      prompt: "You are Plan Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -416,7 +418,7 @@ gates.max_plan_iterations (default: 4)
 
      List up to 5 issues, highest severity first.
 
-     Artifact files have been prepared for you. Overwrite these files directly:
+     Write ONLY to these review artifact files (do NOT modify any source code):
      - .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
      - .quest/<id>/phase_01_plan/handoff_plan-reviewer-b.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -720,6 +722,7 @@ After plan approval, present the plan interactively before proceeding to build.
    ```
    mcp__codex__codex(
      model: <models.code-reviewer-b from allowlist>,
+     sandbox_permissions: "workspace-write",
      prompt: "You are Code Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -733,9 +736,9 @@ After plan approval, present the plan interactively before proceeding to build.
      Changed files: <file list>
      Diff summary: <git diff --stat>
 
-     Review ONLY the files listed above. Use git diff for details.
+     Review ONLY the files listed above. Use git diff for details. Do NOT modify any source code.
 
-     Artifact files have been prepared for you. Overwrite these files directly:
+     Write ONLY to these review artifact files:
      - .quest/<id>/phase_03_review/review_code-reviewer-b.md
      - .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -748,6 +751,7 @@ After plan approval, present the plan interactively before proceeding to build.
    ```
    mcp__codex__codex(
      model: <models.code-reviewer-b from allowlist>,
+     sandbox_permissions: "workspace-write",
      prompt: "You are Code Reviewer B.
      Non-interactive rule: do not ask questions and do not return STATUS: needs_human. If details are missing, make explicit assumptions and continue.
 
@@ -758,10 +762,10 @@ After plan approval, present the plan interactively before proceeding to build.
      Changed files: <file list>
      Diff summary: <git diff --stat>
 
-     Review ONLY the files listed above.
+     Review ONLY the files listed above. Do NOT modify any source code.
      List up to 5 issues, highest severity first.
 
-     Artifact files have been prepared for you. Overwrite these files directly:
+     Write ONLY to these review artifact files:
      - .quest/<id>/phase_03_review/review_code-reviewer-b.md
      - .quest/<id>/phase_03_review/handoff_code-reviewer-b.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -834,7 +838,7 @@ After plan approval, present the plan interactively before proceeding to build.
 
 2. **Invoke Fixer** (default Codex `mcp__codex__codex`, Claude runtime fallback):
    - Read `models.fixer` from allowlist.
-   - If fixer model is Codex, invoke via `mcp__codex__codex`.
+   - If fixer model is Codex, invoke via `mcp__codex__codex` with `sandbox_permissions: "workspace-write"`.
    - If fixer model is Claude, invoke through Claude runtime (native `Task(...)` when available, bridge in Codex-led sessions).
    - Prompt: Reference file paths only, do not embed content:
      - Code review A: `.quest/<id>/phase_03_review/review_code-reviewer-a.md`
@@ -845,7 +849,7 @@ After plan approval, present the plan interactively before proceeding to build.
    - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `review_fix_feedback_discussion.md` and `handoff_fixer.json` in `.quest/<id>/phase_03_review/`.
    - Require the prompt to include:
      - If using Codex path: `Read your instructions: .skills/quest/agents/fixer.md`
-     - Artifact files have been prepared for you. Overwrite these files directly:
+     - Write ONLY to these artifact files (source code changes go through normal edits):
        - `.quest/<id>/phase_03_review/review_fix_feedback_discussion.md`
        - `.quest/<id>/phase_03_review/handoff_fixer.json`
      - Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -903,40 +907,22 @@ After plan approval, present the plan interactively before proceeding to build.
    - Optional fallback (non-interactive/runtime-only): `python3 scripts/quest_celebrate/celebrate.py --quest-dir .quest/<id> --style epic || true`
    - This step is fire-and-forget: if celebration fails, quest completion continues
 
-4. **Create quest journal entry:**
-    - Create `docs/quest-journal/` directory if it doesn't exist
-    - Write to `docs/quest-journal/<slug>_<YYYY-MM-DD>.md`
-    - Include: quest ID, completion date, summary, files changed, iterations
-    - **Include a `celebration_data` JSON block** at the end of the journal entry. This block enables future `/celebrate` invocations to replay a rich celebration from the journal alone, even after the quest archive directory is cleaned up. The block should be embedded between HTML comment markers:
+4. **Create quest journal entry and archive** (automated via script):
+    ```bash
+    python3 scripts/quest_complete.py --quest-dir .quest/<id>
+    ```
+    This script handles all of the following automatically:
+    - Creates `docs/quest-journal/<slug>_<YYYY-MM-DD>.md` with quest metadata, summary, files changed, iterations, agent credits, and an embedded `celebration_data` JSON block (for future `/celebrate` replay)
+    - Inserts a row at the top of `docs/quest-journal/README.md` index table
+    - Moves `.quest/<id>/` to `.quest/archive/<id>/`
 
-      ```markdown
-      ## Celebration Data
+    The script reads all quest artifacts (state.json, handoff files, quest_brief.md, plan.md, reviews) and computes quality tier, achievements, and metrics automatically.
 
-      <!-- celebration-data-start -->
-      ```json
-      {
-        "quest_mode": "workflow",
-        "agents": [{"name": "...", "model": "...", "role": "..."}],
-        "achievements": [{"icon": "⭐️", "title": "...", "desc": "..."}],
-        "metrics": [{"icon": "📊", "label": "..."}],
-        "quality": {"tier": "Gold", "icon": "🥇", "grade": "B"},
-        "quote": {"text": "...", "attribution": "..."},
-        "victory_narrative": "...",
-        "test_count": 42,
-        "tests_added": 10,
-        "files_changed": 7
-      }
-      ```
-      <!-- celebration-data-end -->
-      ```
+    **If the script fails**, fall back to manual creation:
+    - Write journal entry manually following the format in existing entries
+    - Move quest directory to archive manually
 
-      The orchestrator should populate this from the quest artifacts it already read. Agents, achievements, and metrics should be context-aware and specific — not generic. The quality tier uses the full honest scale: Diamond/Platinum/Gold/Silver/Bronze/Tin/Cardboard/Abandoned.
-
-      **Solo mode adjustments for celebration_data:**
-      - Set `"quest_mode": "solo"` in the JSON
-      - Solo quests will show fewer agents (expected) — note this in the context health report rather than treating it as missing data
-
-    - Insert a row at the top of `docs/quest-journal/README.md` index table (after the header row) with date, quest link, and one-line outcome. The table is in reverse chronological order (newest first).
+    **Idea file cleanup** (manual, after script runs):
     - If quest originated from an idea file:
       - Quote the original idea content under "This is where it all began..."
       - Remove the idea file (e.g., `ideas/my-idea.md`)
@@ -1004,10 +990,9 @@ After plan approval, present the plan interactively before proceeding to build.
    - If compliance is <50%:
       "Low compliance -- discard approach is not effective. Recommend upgrading to run_in_background: true."
 
-6. **Archive the quest working directory:**
-    - Create `.quest/archive/` if it doesn't exist
-    - Move `.quest/<id>/` to `.quest/archive/<id>/`
-    - The journal entry in `docs/quest-journal/` is the permanent record; the archive preserves raw artifacts for reference
+6. **Verify archival** (already done by `quest_complete.py` in step 4):
+    - Confirm `.quest/archive/<id>/` exists
+    - Confirm `.quest/<id>/` no longer exists
     - `.quest/` root should only contain active quests, `archive/`, and `audit.log`
 
 7. **Next steps suggestion:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,16 +13,19 @@ This document defines the coding conventions and architecture boundaries for thi
 
 ## Core Principles
 
-### Code Quality
+We drive with a quality mindset in everything — planning, reviewing, and building.
+
 - **KISS** (Keep It Simple, Stupid) — Prefer simple solutions over clever ones
 - **DRY** (Don't Repeat Yourself) — Extract common patterns, but not prematurely
 - **YAGNI** (You Aren't Gonna Need It) — Don't add features until they're needed
-- **SRP** (Single Responsibility Principle) — Each module/function should do one thing
+- **SRP** (Single Responsibility Principle) — Each change, function or module should focusing on doing one thing
 
-### Change Philosophy
+## Change Discipline
+
 - Prefer minimal, focused changes
 - Avoid broad refactors unless they fix real bugs
 - Don't add "improvements" that weren't requested
+- Run linters, formatting, and tests before commits
 - Test real logic, skip trivial code (getters, imports, types)
 
 ## Testing Expectations

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Solo mode skips Reviewer B and the Arbiter. Same pipeline, just faster.
 > *Context contamination is a system failure, not a user habit.*
 > *Speed without rigor only accelerates failure.*
 
+**Engineering principles baked into every agent:**
+- **KISS** — Prefer simple solutions over clever ones
+- **DRY** — Extract common patterns, but not prematurely
+- **YAGNI** — Don't add features until they're needed
+- **SRP** — Each change, function or module should focusing on doing one thing
+
+These aren't guidelines — they're the first thing every agent reads. `AGENTS.md` shapes how agents think, plan, review, and build. The process enforces the philosophy; the philosophy produces the quality.
+
 Quest is built on a conviction: **scaling AI output without scaling engineering discipline is a dead end.** We don't trust single outputs, human or machine. We trust repeatable processes backed by evidence. The system makes correct behavior easy and incorrect behavior hard.
 
 We're not replacing human judgment. We're amplifying it.

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -465,20 +465,20 @@
       <p class="eyebrow">QUEST INTELLIGENCE</p>
       <h1>Quest Portfolio Dashboard</h1>
       <div class="hero-subtitle">Board-level visibility into quest outcomes, execution momentum, and strategic throughput.</div>
-      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Feb 21, 2026, 04:40 AM UTC</span></div>
+      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Mar 21, 2026, 06:18 AM UTC</span></div>
     </div>
     <div class="kpi-grid">
       <article class="kpi-card">
         <p class="kpi-label">Total Quests</p>
-        <p class="kpi-value">23</p>
+        <p class="kpi-value">30</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">Finished</p>
-        <p class="kpi-value kpi-value--finished">19</p>
+        <p class="kpi-value kpi-value--finished">28</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">In Progress</p>
-        <p class="kpi-value kpi-value--in-progress">2</p>
+        <p class="kpi-value kpi-value--in-progress">0</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">Blocked</p>
@@ -510,48 +510,130 @@
     <section class="quests-section" id="quest-portfolio">
       <div class="quests-header">
         <h2>Quest Portfolio</h2>
-        <p class="panel-subtitle">23 quests represented</p>
+        <p class="panel-subtitle">30 quests represented</p>
       </div>
       <div class="quest-grid">
         <article class="quest-card">
           <div class="quest-card-header">
+            <h3 class="quest-card-title">Quest Dispatcher</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">Retired from `ideas/` on 2026-03-09.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/quest-dispatcher_2026-03-09.md">Quest Dispatcher 2026 03 09</a></span>
+            <span><b>Completion Date:</b> Mar 09, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Codex-Led Claude Bridge Runtime Hardening</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">Status: complete</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/codex-led-claude-bridge-runtime-hardening_2026-03-09.md">Codex Led Claude Bridge Runtime Hardening 2026 03 09</a></span>
+            <span><b>Completion Date:</b> Mar 09, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Codex -&gt; Claude Shell-Out Prototypes</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">Status: complete</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/codex-calls-claude_2026-03-09.md">Codex Calls Claude 2026 03 09</a></span>
+            <span><b>Completion Date:</b> Mar 09, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">celebration-from-journal</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span> <span class="badge" style="background:rgba(52, 211, 153, 0.15);color:#34d399;border:1px solid rgba(52, 211, 153, 0.3)" title="Near-perfect — minor issues, one-pass fix">🏆 PLATINUM</span></div>
+          </div>
+          <p class="quest-pitch">Bridged two isolated data readers (celebrate `quest_data.py` and dashboard `loaders.py`) so that `/celebrate` can replay celebrations from archived journal entries. Added an 8-tier candid quality scale where smooth quests get Diamond and rough ones get Tin or Cardboard. Dashboard cards now show quality tier badges with hover tooltips, agent model &quot;Cast&quot; lines, and test counts.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/celebration-from-journal_2026-03-06.md">celebration-from-journal_2026-03-06__1200</a></span>
+            <span><b>Completion Date:</b> Mar 06, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 1</span>
+            <span><b>Cast:</b> human, Claude Opus</span>
+            <span><b>Tests:</b> 154 (34 new)</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">pr-inline-commenting-playbook</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- Quest ID: `pr-inline-commenting-playbook_2026-03-05__0250` - Completed: 2026-03-05 - Outcome: Added a practical inline comment playbook to PR shepherd guidance so review replies are kind, precise, and actionable.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/pr-inline-commenting-playbook_2026-03-05.md">pr-inline-commenting-playbook_2026-03-05__0250</a></span>
+            <span><b>Completion Date:</b> Mar 05, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 0</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">celebrate-v2</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- Quest ID: `celebrate-v2_2026-03-05__0643` - Completed: 2026-03-05 - Outcome: Reworked quest celebration system with deep artifact reading, block-letter titles, dynamic achievements, impact metrics, quality scores, and cinematic movie-style credits.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/celebrate-v2_2026-03-05.md">celebrate-v2_2026-03-05__0643</a></span>
+            <span><b>Completion Date:</b> Mar 05, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 1</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">quest-completion-animations</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- Quest ID: `quest-completion-animations_2026-03-04__1953` - Completed: 2026-03-04 - Outcome: Implemented Quest Completion Animation System with 4 animation styles, 38 passing tests, and integration into quest workflow.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/quest-completion-animations_2026-03-04.md">quest-completion-animations_2026-03-04__1953</a></span>
+            <span><b>Completion Date:</b> Mar 04, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 1</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">OpenCode Model Suitability Guide</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">Created comprehensive documentation (`docs/guides/opencode-model-suitability.md`) mapping all 32 OpenCode models to Quest orchestration roles. The guide includes:</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/opencode-model-suitability_2026-02-28.md">opencode-model-suitability_2026-02-28__1755</a></span>
+            <span><b>Completion Date:</b> Feb 28, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 0</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">PR Body Gate</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">Added `.github/workflows/pr-body-gate.yml` — a GitHub Actions workflow that validates PR bodies contain four required headings: - `## Summary` - `## Changes` - `## Validation` - `## Notes`</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/pr-body-gate_2026-02-22.md">Pr Body Gate 2026 02 22</a></span>
+            <span><b>Completion Date:</b> Feb 22, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
             <h3 class="quest-card-title">Phase 4 Role Wiring</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Relocated six Quest role files from `.ai/roles/` to `.skills/quest/agents/`, then updated runtime references, validators, metadata, and docs to match the new ownership model.</p>
           <p class="quest-meta">
-            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/phase4-role-wiring_2026-02-18.md">Phase4 Role Wiring 2026 02 18</a></span>
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/phase4-role-wiring_2026-02-18.md">phase4-role-wiring_2026-02-17__2218</a></span>
             <span><b>Completion Date:</b> Feb 18, 2026</span>
           </p>
         </article>
         <article class="quest-card">
           <div class="quest-card-header">
-            <h3 class="quest-card-title">Quest Brief</h3>
-            <span class="badge badge--in-progress">IN PROGRESS</span>
-          </div>
-          <p class="quest-pitch">$quest let&#x27;s implment in this branch the phase4 approach, ref ideas (own document + architecture evolution). Make sure you follow all the quests instructions to the letter, updating state, showing me the plan etc, etc. Make sure we have dual reviewers, arbiter, dual coders, arbiter etc. etc.</p>
-          <p class="quest-meta">
-            <span><b>Quest ID:</b> phase4-role-relocation_2026-02-17__2152</span>
-            <span><b>Updated:</b> Feb 18, 2026</span>
-            <span><b>Iterations:</b> plan 2 / fix 0</span>
-          </p>
-        </article>
-        <article class="quest-card">
-          <div class="quest-card-header">
-            <h3 class="quest-card-title">Quest Brief</h3>
-            <span class="badge badge--in-progress">IN PROGRESS</span>
-          </div>
-          <p class="quest-pitch">$quest Let&#x27;s analyze and review with a very candid and honest approach, pros and cons for the next possible step on the Quest architecture evolution. We want to keep a KISS approach. We don&#x27;t want to complicate things, and we absolutely want to make sure that the orchestration and agents are laser-focused. We don&#x27;t want context pollution. For suggestions on how it can be implemented, we also want to make sure that this approach works both with Codex being the orchestrator of the running sub-agents (Codex sub-agents versus cloud). If there are other approaches to solve this cleanup, then we can suggest those as well. If it&#x27;s better to leave it as is, we can be honest and mention that as well. We don&#x27;t want to make a change unless it actually makes a tangible improvement.</p>
-          <p class="quest-meta">
-            <span><b>Quest ID:</b> quest-architecture-evolution-review_2026-02-17__2129</span>
-            <span><b>Updated:</b> Feb 18, 2026</span>
-            <span><b>Iterations:</b> plan 3 / fix 0</span>
-          </p>
-        </article>
-        <article class="quest-card">
-          <div class="quest-card-header">
             <h3 class="quest-card-title">State Validation Script</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Implemented `scripts/validate-quest-state.sh` — the first system-enforced correctness check for Quest phase transitions. The shell script validates state.json integrity, phase transition legality, artifact prerequisites, semantic content checks (arbiter verdict, review outcomes via jq on handoff JSON), and iteration bounds before every phase transition.</p>
           <p class="quest-meta">
@@ -562,7 +644,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Close Remaining Context Leaks (Phase 2b)</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Implemented the handoff.json structured file pattern to close the remaining context leaks in the Quest orchestrator. Every agent now writes a tiny JSON file (~200 bytes) alongside its artifacts, and the orchestrator reads this file for routing decisions instead of processing full agent responses.</p>
           <p class="quest-meta">
@@ -573,8 +655,8 @@
         </article>
         <article class="quest-card">
           <div class="quest-card-header">
-            <h3 class="quest-card-title">Quest: Dashboard Layout Redesign</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <h3 class="quest-card-title">Dashboard Layout Redesign</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Restructured the Quest Dashboard layout to match the target executive &quot;Quest Intelligence&quot; design from PR #21. The dashboard now features the &quot;QUEST INTELLIGENCE&quot; branding eyebrow, &quot;Quest Portfolio Dashboard&quot; title, 5 KPI cards (Total, Finished, In Progress, Blocked, Abandoned), side-by-side chart panels (Status Distribution doughnut + Final Status Over Time line chart), and a unified Quest Portfolio section with redesigned cards showing full pitch text and labeled metadata.</p>
           <p class="quest-meta">
@@ -585,7 +667,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Harden URL Rendering</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Fixed HTML attribute injection (XSS) vulnerability in the Quest Dashboard&#x27;s URL rendering. Added `_sanitize_url()` function that validates scheme (HTTPS-only), validates GitHub URL pattern via regex, and applies HTML attribute escaping before any URL is interpolated into `href=&quot;...&quot;` attributes. Also escaped fallback relative paths, removed stderr side effect from loaders, and unified the `github_url` missing-value convention.</p>
           <p class="quest-meta">
@@ -597,7 +679,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Dashboard Visual Polish</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Restored visual features from the PR #21 prototype that were cut during the dashboard-v2 implementation. Added ambient CSS glows (green, blue, amber blurred circles behind content), interactive Chart.js doughnut and stacked area charts, and gradient enhancements on cards and section headers. Chart.js 4.4.7 is vendored and inlined at render time — the dashboard remains a single self-contained HTML file with no external dependencies. Graceful degradation ensures the dashboard still works if the vendor file is missing.</p>
           <p class="quest-meta">
@@ -608,8 +690,8 @@
         </article>
         <article class="quest-card">
           <div class="quest-card-header">
-            <h3 class="quest-card-title">Quest: Dashboard V2</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <h3 class="quest-card-title">Dashboard V2</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Built the Quest Dashboard: a self-contained Python package that generates a static HTML dashboard from quest journal entries and active quest state files. Three status sections (Finished, In Progress, Abandoned) with dark navy theme, elevator pitch cards, journal/PR links, and muted metadata. Single-file HTML output with no external dependencies.</p>
           <p class="quest-meta">
@@ -621,7 +703,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">ci-python-quest</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Added a GitHub Actions workflow to run the Python test suite (pytest) on every push to main and PR targeting main. This ensures the 36 Quest Dashboard unit and integration tests are enforced in CI, preventing regressions from slipping through undetected.</p>
           <p class="quest-meta">
@@ -631,8 +713,8 @@
         </article>
         <article class="quest-card">
           <div class="quest-card-header">
-            <h3 class="quest-card-title">Quest: Dashboard Final Implementation</h3>
-            <span class="badge badge--abandoned">ABANDONED</span>
+            <h3 class="quest-card-title">Dashboard Final Implementation</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--abandoned">ABANDONED</span></div>
           </div>
           <p class="quest-pitch">First attempt at building the Quest Dashboard. Plan was approved by arbiter after one iteration, but the build phase was interrupted when models were switched from Sonnet to Opus. Rather than resuming, a new quest (dashboard-v2) was created using this quest&#x27;s approved plan as input. Dashboard-v2 completed successfully.</p>
           <p class="quest-meta">
@@ -643,7 +725,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">codex-ci-review</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Ported the Codex CI code review workflow from candid_talent_edge (PR #164) to the Quest framework repository. Added a GitHub Actions workflow that triggers OpenAI Codex as an automated code reviewer when a PR transitions from draft to ready-for-review, a Quest-adapted CI code reviewer skill, and registered the new skill in the catalog and manifest.</p>
           <p class="quest-meta">
@@ -655,7 +737,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">thin-orchestrator</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Implemented Phase 2 of the Quest architecture evolution: the &quot;thin orchestrator&quot; principle. The Quest orchestrator now passes file paths to subagents instead of embedding content, reducing context growth from O(n*content_size) to O(n*one_line).</p>
           <p class="quest-meta">
@@ -667,7 +749,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">skill-strategy</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Analyzed how Quest should organize, manage, and distribute skills. Researched community best practices (Agent Skills standard, plugin marketplaces, distribution patterns). Produced strategic recommendations.</p>
           <p class="quest-meta">
@@ -678,7 +760,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">handoff-contract-fix</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Fixed handoff contract inconsistencies across Quest role files and workflow. Standardized all 6 role files on `---HANDOFF---` text format with STATUS/ARTIFACTS/NEXT/SUMMARY fields, removed &quot;Context Is In Your Prompt&quot; contradictions, and made workflow prompts explicitly request handoff format.</p>
           <p class="quest-meta">
@@ -690,7 +772,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Delegation-Based Intake Gate</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Decomposed the monolithic `.skills/quest/SKILL.md` (635 lines) into a slim routing entry point (73 lines) plus three delegation files under `.skills/quest/delegation/`. The delegation pattern structurally enforces intake quality — vague input routes to a dedicated questioning phase before planning begins, while detailed input goes directly to the workflow.</p>
           <p class="quest-meta">
@@ -702,7 +784,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Caching Strategy Exploration</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Comprehensive research exploration mapping 11 distinct caching strategies applicable to the Quest AI agent system. The quest produced two educational research documents and a quest index README — no code changes, as the research itself was the deliverable.</p>
           <p class="quest-meta">
@@ -714,7 +796,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Weekly Update Check</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Implemented automatic weekly update checking for Quest. After a quest completes, the system checks if updates are available (respecting a configurable interval) and prompts the user to update if a newer version exists upstream.</p>
           <p class="quest-meta">
@@ -726,7 +808,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">quest-council-mode</h3>
-            <span class="badge badge--abandoned">ABANDONED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--abandoned">ABANDONED</span></div>
           </div>
           <p class="quest-pitch">Planned a dual-planning-track feature for `/quest` where users could choose between &quot;Quest&quot; (fast, single plan) and &quot;Quest Council&quot; (rigorous, two competing plans merged by arbiter). Plan was approved after 2 iterations but was never built.</p>
           <p class="quest-meta">
@@ -737,7 +819,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">validate-and-launch</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">First-ever quest run on the extracted repository. Validated that the Quest blueprint was correctly extracted from the source repo, created the `ideas/` directory for tracking future work, and updated the README with public domain messaging.</p>
           <p class="quest-meta">
@@ -749,7 +831,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">interactive-plan-presentation</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Enhanced the quest orchestration to present plans interactively rather than dumping the full plan at once. Users now see a brief summary first, then can opt into a phase-by-phase walkthrough with the ability to request changes at each step.</p>
           <p class="quest-meta">
@@ -761,7 +843,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Installer Script</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Created a single unified installer script (`scripts/quest_installer.sh`) that installs and updates Quest in any repository.</p>
           <p class="quest-meta">
@@ -772,7 +854,7 @@
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">CI Quest Validation</h3>
-            <span class="badge badge--finished">FINISHED</span>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
           </div>
           <p class="quest-pitch">Implemented GitHub Actions CI and local pre-commit hooks that validate quest-related artifacts to prevent broken configurations from being committed.</p>
           <p class="quest-meta">
@@ -784,7 +866,7 @@
     </section>
 
     <footer class="footer">
-      Generated on 2026-02-21 04:40:42 UTC
+      Generated on 2026-03-21 06:18:55 UTC
     </footer>
   </div>
   <script>
@@ -797,7 +879,7 @@ document.addEventListener('DOMContentLoaded', function() {
       data: {
         labels: ['In Progress', 'Blocked', 'Abandoned', 'Finished', 'Unknown'],
         datasets: [{
-          data: [2, 0, 2, 19, 0],
+          data: [0, 0, 2, 28, 0],
           backgroundColor: [
             getComputedStyle(document.documentElement).getPropertyValue('--status-in-progress').trim(),
             getComputedStyle(document.documentElement).getPropertyValue('--status-blocked').trim(),
@@ -831,11 +913,11 @@ document.addEventListener('DOMContentLoaded', function() {
     new Chart(timeCtx, {
       type: 'line',
       data: {
-        labels: ["2026-02"],
+        labels: ["2026-02", "2026-03"],
         datasets: [
           {
             label: 'Finished',
-            data: [19],
+            data: [21, 7],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-finished').trim(),
             fill: false,
             tension: 0.25,
@@ -844,7 +926,7 @@ document.addEventListener('DOMContentLoaded', function() {
           },
           {
             label: 'In Progress',
-            data: [2],
+            data: [0, 0],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-in-progress').trim(),
             fill: false,
             tension: 0.25,
@@ -853,7 +935,7 @@ document.addEventListener('DOMContentLoaded', function() {
           },
           {
             label: 'Blocked',
-            data: [0],
+            data: [0, 0],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-blocked').trim(),
             fill: false,
             tension: 0.25,
@@ -862,7 +944,7 @@ document.addEventListener('DOMContentLoaded', function() {
           },
           {
             label: 'Abandoned',
-            data: [2],
+            data: [2, 0],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-abandoned').trim(),
             fill: false,
             tension: 0.25,
@@ -871,7 +953,7 @@ document.addEventListener('DOMContentLoaded', function() {
           },
           {
             label: 'Unknown',
-            data: [0],
+            data: [0, 0],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-unknown').trim(),
             fill: false,
             tension: 0.25,

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -465,16 +465,16 @@
       <p class="eyebrow">QUEST INTELLIGENCE</p>
       <h1>Quest Portfolio Dashboard</h1>
       <div class="hero-subtitle">Board-level visibility into quest outcomes, execution momentum, and strategic throughput.</div>
-      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Mar 21, 2026, 06:26 AM UTC</span></div>
+      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Mar 21, 2026, 06:37 AM UTC</span></div>
     </div>
     <div class="kpi-grid">
       <article class="kpi-card">
         <p class="kpi-label">Total Quests</p>
-        <p class="kpi-value">37</p>
+        <p class="kpi-value">38</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">Finished</p>
-        <p class="kpi-value kpi-value--finished">35</p>
+        <p class="kpi-value kpi-value--finished">36</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">In Progress</p>
@@ -510,9 +510,22 @@
     <section class="quests-section" id="quest-portfolio">
       <div class="quests-header">
         <h2>Quest Portfolio</h2>
-        <p class="panel-subtitle">37 quests represented</p>
+        <p class="panel-subtitle">38 quests represented</p>
       </div>
       <div class="quest-grid">
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Quest Housekeeping Blitz</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span> <span class="badge" style="background:rgba(96, 165, 250, 0.15);color:#60a5fa;border:1px solid rgba(96, 165, 250, 0.3)" title="Solid — issues caught, fixed cleanly">🥇 GOLD</span></div>
+          </div>
+          <p class="quest-pitch">- Quest ID: `quest-housekeeping-blitz_2026-03-21__0600` - Completed: 2026-03-21 - Mode: solo - Quality: Gold - Outcome: Forensic sweep across stale quests, missing journals, broken automation, and a Codex sandbox permission footgun.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md">quest-housekeeping-blitz_2026-03-21__0600</a></span>
+            <span><b>Completion Date:</b> Mar 21, 2026</span>
+            <span><b>Iterations:</b> plan 1 / fix 0</span>
+            <span><b>Cast:</b> Claude Opus</span>
+          </p>
+        </article>
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Installer Codex Setup and Bridge Timeout</h3>
@@ -948,7 +961,7 @@
     </section>
 
     <footer class="footer">
-      Generated on 2026-03-21 06:26:03 UTC
+      Generated on 2026-03-21 06:37:15 UTC
     </footer>
   </div>
   <script>
@@ -961,7 +974,7 @@ document.addEventListener('DOMContentLoaded', function() {
       data: {
         labels: ['In Progress', 'Blocked', 'Abandoned', 'Finished', 'Unknown'],
         datasets: [{
-          data: [0, 0, 2, 35, 0],
+          data: [0, 0, 2, 36, 0],
           backgroundColor: [
             getComputedStyle(document.documentElement).getPropertyValue('--status-in-progress').trim(),
             getComputedStyle(document.documentElement).getPropertyValue('--status-blocked').trim(),
@@ -999,7 +1012,7 @@ document.addEventListener('DOMContentLoaded', function() {
         datasets: [
           {
             label: 'Finished',
-            data: [21, 14],
+            data: [21, 15],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-finished').trim(),
             fill: false,
             tension: 0.25,

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -465,16 +465,16 @@
       <p class="eyebrow">QUEST INTELLIGENCE</p>
       <h1>Quest Portfolio Dashboard</h1>
       <div class="hero-subtitle">Board-level visibility into quest outcomes, execution momentum, and strategic throughput.</div>
-      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Mar 21, 2026, 06:18 AM UTC</span></div>
+      <div class="meta-row"><span class="meta-label">DATA GENERATED:</span> <span class="meta-value">Mar 21, 2026, 06:26 AM UTC</span></div>
     </div>
     <div class="kpi-grid">
       <article class="kpi-card">
         <p class="kpi-label">Total Quests</p>
-        <p class="kpi-value">30</p>
+        <p class="kpi-value">37</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">Finished</p>
-        <p class="kpi-value kpi-value--finished">28</p>
+        <p class="kpi-value kpi-value--finished">35</p>
       </article>
       <article class="kpi-card">
         <p class="kpi-label">In Progress</p>
@@ -510,9 +510,91 @@
     <section class="quests-section" id="quest-portfolio">
       <div class="quests-header">
         <h2>Quest Portfolio</h2>
-        <p class="panel-subtitle">30 quests represented</p>
+        <p class="panel-subtitle">37 quests represented</p>
       </div>
       <div class="quest-grid">
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Installer Codex Setup and Bridge Timeout</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PRs: #78, #80 - Merged: 2026-03-20 to 2026-03-21 - Outcome: Installer handles Codex MCP setup; bridge timeout raised to 30 minutes.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/installer-codex-and-bridge-timeout_2026-03-21.md">Installer Codex And Bridge Timeout 2026 03 21</a></span>
+            <span><b>Completion Date:</b> Mar 21, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">README Rewrite for Clarity and Brevity</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PR: #76 - Merged: 2026-03-20 - Outcome: Documentation cut by more than half without losing substance.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/readme-rewrite_2026-03-20.md">Readme Rewrite 2026 03 20</a></span>
+            <span><b>Completion Date:</b> Mar 20, 2026</span>
+            <span><b>PR:</b> <a href="https://github.com/KjellKod/quest/pull/76">#76</a></span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Atomic State Transitions and Presentation Gate</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PR: #77 - Merged: 2026-03-20 - Outcome: Closed the state-transition footgun and enforced the mandatory presentation gate.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/atomic-state-transitions_2026-03-20.md">Atomic State Transitions 2026 03 20</a></span>
+            <span><b>Completion Date:</b> Mar 20, 2026</span>
+            <span><b>PR:</b> <a href="https://github.com/KjellKod/quest/pull/77">#77</a></span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Stage Artifacts Before Runtime Fallback</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PR: #74 - Merged: 2026-03-19 - Outcome: Artifact preparation is now explicit and happens before role execution, not during.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/artifact-staging_2026-03-19.md">Artifact Staging 2026 03 19</a></span>
+            <span><b>Completion Date:</b> Mar 19, 2026</span>
+            <span><b>PR:</b> <a href="https://github.com/KjellKod/quest/pull/74">#74</a></span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Codex MCP Docs and Model Dispatch Cleanup</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PRs: #70, #72, #73 - Merged: 2026-03-16 to 2026-03-17 - Outcome: Codex MCP setup docs overhauled, allowlist cleaned up, model dispatch reads from config instead of hardcoding.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/codex-mcp-docs-cleanup_2026-03-17.md">Codex Mcp Docs Cleanup 2026 03 17</a></span>
+            <span><b>Completion Date:</b> Mar 17, 2026</span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">/gpt Skill</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PR: #71 - Merged: 2026-03-16 - Outcome: New skill for delegating tasks to Codex via MCP.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/gpt-skill_2026-03-16.md">Gpt Skill 2026 03 16</a></span>
+            <span><b>Completion Date:</b> Mar 16, 2026</span>
+            <span><b>PR:</b> <a href="https://github.com/KjellKod/quest/pull/71">#71</a></span>
+          </p>
+        </article>
+        <article class="quest-card">
+          <div class="quest-card-header">
+            <h3 class="quest-card-title">Codex-Led Claude Bridge Runtime</h3>
+            <div style="display:flex;gap:0.5rem"><span class="badge badge--finished">FINISHED</span></div>
+          </div>
+          <p class="quest-pitch">- PR: #68 - Merged: 2026-03-13 - Outcome: First-class Codex-led Claude runtime path for Quest orchestration.</p>
+          <p class="quest-meta">
+            <span><b>Quest ID:</b> <a href="https://github.com/KjellKod/quest/blob/main/docs/quest-journal/codex-led-claude-runtime_2026-03-13.md">Codex Led Claude Runtime 2026 03 13</a></span>
+            <span><b>Completion Date:</b> Mar 13, 2026</span>
+            <span><b>PR:</b> <a href="https://github.com/KjellKod/quest/pull/68">#68</a></span>
+          </p>
+        </article>
         <article class="quest-card">
           <div class="quest-card-header">
             <h3 class="quest-card-title">Quest Dispatcher</h3>
@@ -866,7 +948,7 @@
     </section>
 
     <footer class="footer">
-      Generated on 2026-03-21 06:18:55 UTC
+      Generated on 2026-03-21 06:26:03 UTC
     </footer>
   </div>
   <script>
@@ -879,7 +961,7 @@ document.addEventListener('DOMContentLoaded', function() {
       data: {
         labels: ['In Progress', 'Blocked', 'Abandoned', 'Finished', 'Unknown'],
         datasets: [{
-          data: [0, 0, 2, 28, 0],
+          data: [0, 0, 2, 35, 0],
           backgroundColor: [
             getComputedStyle(document.documentElement).getPropertyValue('--status-in-progress').trim(),
             getComputedStyle(document.documentElement).getPropertyValue('--status-blocked').trim(),
@@ -917,7 +999,7 @@ document.addEventListener('DOMContentLoaded', function() {
         datasets: [
           {
             label: 'Finished',
-            data: [21, 7],
+            data: [21, 14],
             borderColor: getComputedStyle(document.documentElement).getPropertyValue('--status-finished').trim(),
             fill: false,
             tension: 0.25,

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-03-21 | [quest-housekeeping-blitz](quest-housekeeping-blitz_2026-03-21.md) | Forensic sweep of stale quests, missing journal entries, broken archive/celebration automation, and a Codex sandbox p... |
 | 2026-03-21 | [installer-codex-and-bridge-timeout](installer-codex-and-bridge-timeout_2026-03-21.md) | Installer handles Codex MCP setup; bridge timeout raised from 90s to 30 minutes. (PRs #78, #80) |
 | 2026-03-20 | [atomic-state-transitions](atomic-state-transitions_2026-03-20.md) | Atomic state transitions close the validate+mutate footgun; mandatory presentation gate enforced. (PR #77) |
 | 2026-03-20 | [readme-rewrite](readme-rewrite_2026-03-20.md) | README cut from 594 to ~150 lines; philosophy extracted to own doc; bridge architecture documented. (PR #76) |

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,13 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-03-21 | [installer-codex-and-bridge-timeout](installer-codex-and-bridge-timeout_2026-03-21.md) | Installer handles Codex MCP setup; bridge timeout raised from 90s to 30 minutes. (PRs #78, #80) |
+| 2026-03-20 | [atomic-state-transitions](atomic-state-transitions_2026-03-20.md) | Atomic state transitions close the validate+mutate footgun; mandatory presentation gate enforced. (PR #77) |
+| 2026-03-20 | [readme-rewrite](readme-rewrite_2026-03-20.md) | README cut from 594 to ~150 lines; philosophy extracted to own doc; bridge architecture documented. (PR #76) |
+| 2026-03-19 | [artifact-staging](artifact-staging_2026-03-19.md) | Explicit artifact staging before role execution; tighter runtime fallback; workspace-local artifacts. (PR #74) |
+| 2026-03-17 | [codex-mcp-docs-cleanup](codex-mcp-docs-cleanup_2026-03-17.md) | Codex MCP docs overhauled, allowlist cleaned up, model dispatch reads from config. (PRs #70, #72, #73) |
+| 2026-03-16 | [gpt-skill](gpt-skill_2026-03-16.md) | New /gpt skill for delegating tasks to Codex via MCP; co-author trailer labels updated. (PR #71) |
+| 2026-03-13 | [codex-led-claude-runtime](codex-led-claude-runtime_2026-03-13.md) | First-class Codex-led Claude runtime path with bridge helpers and trust boundary preservation. (PR #68) |
 | 2026-03-06 | [celebration-from-journal](celebration-from-journal_2026-03-06.md) | Quality tiers (Diamond→Cardboard), embedded celebration_data JSON in journals, dashboard tier badges with tooltips, agent model credits, test counts. Solo adventure. |
 | 2026-03-05 | [celebrate-v2](celebrate-v2_2026-03-05.md) | Reworked celebration system with deep artifact reading, block-letter titles, achievements, quality scores, and cinematic movie credits. |
 | 2026-03-05 | [pr-inline-commenting-playbook](pr-inline-commenting-playbook_2026-03-05.md) | Added a practical inline-commenting playbook to PR shepherd guidance, including tone, severity, and signature conventions. |

--- a/docs/quest-journal/artifact-staging_2026-03-19.md
+++ b/docs/quest-journal/artifact-staging_2026-03-19.md
@@ -1,0 +1,15 @@
+# Stage Artifacts Before Runtime Fallback
+
+- PR: #74
+- Merged: 2026-03-19
+- Outcome: Artifact preparation is now explicit and happens before role execution, not during.
+
+## What Shipped
+
+- **Explicit artifact staging**: Quest prepares all required artifacts (brief, plan, reviews) in the workspace before dispatching a role, rather than assuming the role will find them.
+- **Tighter runtime fallback**: Fallback retries no longer re-prepare artifacts -- they reuse what was already staged.
+- **Workspace-local artifacts**: Artifacts stay within the quest workspace directory, keeping sandboxed runs self-contained.
+
+## Why It Matters
+
+Roles were sometimes failing because artifacts were not yet written when execution started. Making staging explicit eliminates that race condition and makes fallback retries cheaper and more predictable.

--- a/docs/quest-journal/atomic-state-transitions_2026-03-20.md
+++ b/docs/quest-journal/atomic-state-transitions_2026-03-20.md
@@ -1,0 +1,15 @@
+# Atomic State Transitions and Presentation Gate
+
+- PR: #77
+- Merged: 2026-03-20
+- Outcome: Closed the state-transition footgun and enforced the mandatory presentation gate.
+
+## What Shipped
+
+- **Atomic state transitions**: Replaced the two-step validate-then-mutate pattern with a single atomic call. Invalid transitions like `building->building` are now rejected at the API level.
+- **Mandatory presentation gate**: The plan presentation step can no longer be skipped. Attempting to transition from planning to building without presenting raises an error.
+- Updated `scripts/quest_state.py` with the new transition logic and validation.
+
+## Why It Matters
+
+The old pattern allowed a race where validation passed but the state had already changed before the mutation landed. Atomic transitions make invalid states unrepresentable. The presentation gate ensures humans always see the plan before a build starts -- a core Quest principle.

--- a/docs/quest-journal/codex-led-claude-runtime_2026-03-13.md
+++ b/docs/quest-journal/codex-led-claude-runtime_2026-03-13.md
@@ -1,0 +1,16 @@
+# Codex-Led Claude Bridge Runtime
+
+- PR: #68
+- Merged: 2026-03-13
+- Outcome: First-class Codex-led Claude runtime path for Quest orchestration.
+
+## What Shipped
+
+- **Codex-led Claude bridge runtime** so Quest can dispatch Claude-designated roles through `scripts/quest_claude_runner.py` when Codex is the orchestrator.
+- **Runtime helpers** (`quest_claude_probe.py`, bridge preflight) ensure the Claude CLI is available before dispatching.
+- **Trust boundary preserved**: Codex retains privileged review roles while Claude handles builder/planner work through the bridge.
+- Workflow and role docs updated to describe host-specific runtime dispatch and solo-mode behavior.
+
+## Why It Matters
+
+Before this, running a Quest with Codex as orchestrator required manual prompt engineering to invoke Claude. Now the bridge is a Quest-owned runtime path -- the operator describes the task, not the plumbing.

--- a/docs/quest-journal/codex-mcp-docs-cleanup_2026-03-17.md
+++ b/docs/quest-journal/codex-mcp-docs-cleanup_2026-03-17.md
@@ -1,0 +1,15 @@
+# Codex MCP Docs and Model Dispatch Cleanup
+
+- PRs: #70, #72, #73
+- Merged: 2026-03-16 to 2026-03-17
+- Outcome: Codex MCP setup docs overhauled, allowlist cleaned up, model dispatch reads from config instead of hardcoding.
+
+## What Shipped
+
+- **MCP server fix** (PR#70): Replaced `@anthropic/codex-mcp-server` npm package references with the correct `codex mcp-server` CLI invocation across docs, agent files, workflow, and runtime code.
+- **Docs overhaul and allowlist cleanup** (PR#72): Rewrote Codex MCP setup documentation. Cleaned up allowlist config. Workflow now reads role models from `allowlist.json` instead of hardcoding them.
+- **Installer alignment** (PR#73): Aligned model-dispatch docs with installer coverage. Codex-led Claude bridge assets documented, validated, and shipped by manifest.
+
+## Why It Matters
+
+The Codex MCP integration went through rapid iteration. These three PRs stabilized the setup docs, fixed a wrong package name that would break new installs, and made model dispatch config-driven rather than scattered across prose.

--- a/docs/quest-journal/gpt-skill_2026-03-16.md
+++ b/docs/quest-journal/gpt-skill_2026-03-16.md
@@ -1,0 +1,14 @@
+# /gpt Skill
+
+- PR: #71
+- Merged: 2026-03-16
+- Outcome: New skill for delegating tasks to Codex via MCP.
+
+## What Shipped
+
+- **`.skills/gpt/SKILL.md`**: Standalone skill teaching Claude how to delegate reviews, analysis, implementation, and second opinions to Codex through MCP tools.
+- **Co-author trailer labels** updated to reflect which model actually did the work, improving attribution in commit history.
+
+## Why It Matters
+
+Before this, using Codex from Claude required knowing the MCP tool names and invocation patterns. The `/gpt` skill packages that knowledge so any Claude session can delegate to Codex with a single command.

--- a/docs/quest-journal/installer-codex-and-bridge-timeout_2026-03-21.md
+++ b/docs/quest-journal/installer-codex-and-bridge-timeout_2026-03-21.md
@@ -1,0 +1,14 @@
+# Installer Codex Setup and Bridge Timeout
+
+- PRs: #78, #80
+- Merged: 2026-03-20 to 2026-03-21
+- Outcome: Installer handles Codex MCP setup; bridge timeout raised to 30 minutes.
+
+## What Shipped
+
+- **Installer Codex support** (PR#78): `quest_installer.sh` now offers Codex CLI and MCP server setup as part of the install flow. When the Codex probe fails at quest startup, the error message includes actionable fix commands instead of a generic failure.
+- **Bridge timeout** (PR#80): Default subprocess timeout for the Claude bridge raised from 90 seconds to 30 minutes. Cross-reference comments added in both files where the default is defined, so future changes stay in sync.
+
+## Why It Matters
+
+90 seconds was too short for any non-trivial Claude role execution through the bridge. Builder roles routinely take 5-15 minutes. The installer change means new users get Codex MCP working out of the box instead of hitting a cryptic probe failure after install.

--- a/docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md
+++ b/docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md
@@ -1,0 +1,65 @@
+# Quest Journal: Quest Housekeeping Blitz
+
+- Quest ID: `quest-housekeeping-blitz_2026-03-21__0600`
+- Completed: 2026-03-21
+- Mode: solo
+- Quality: Gold
+- Outcome: Forensic sweep across stale quests, missing journals, broken automation, and a Codex sandbox permission footgun.
+
+## What Shipped
+
+- **Dashboard brought current**: 23 to 37 quests visible. 7 journal entries backfilled for 10 merged PRs (Mar 13-21) that had no journal coverage.
+- **8 orphaned quests archived**: 3 completed-but-unarchived, 5 stalled/abandoned, 1 orphaned directory cleaned up.
+- **Codex sandbox fix**: Added `sandbox_permissions: "workspace-write"` to all 5 Codex MCP invocations (plan reviewer full/fast, code reviewer full/fast, fixer) that were missing it. Clarified prompt wording to distinguish artifact writes from source code modifications.
+- **Automated quest completion**: New `scripts/quest_complete.py` replaces ~40 lines of manual Step 7 instructions. Reads quest artifacts, generates journal entry with celebration_data JSON, updates README index, and archives the quest directory.
+
+## Files Changed
+
+- `.quest-manifest`
+- `.skills/quest/delegation/workflow.md`
+- `docs/dashboard/index.html`
+- `docs/quest-journal/README.md`
+- `docs/quest-journal/*.md` (7 new journal entries)
+- `scripts/quest_complete.py` (new)
+
+## Iterations
+
+- Plan iterations: 1
+- Fix iterations: 0
+
+## This is where it all began...
+
+> "take a look at the .quests and take a look at archived quests and took a look at our portfolio dashboard, did we archive things that didn't get into the dashboard?"
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {"name": "claude-opus-4.6", "model": "claude-opus-4-6", "role": "The Investigator & Fixer"}
+  ],
+  "achievements": [
+    {"icon": "🕵️", "title": "Archaeology Badge", "desc": "Excavated 8 orphaned quests from .quest/ graveyard"},
+    {"icon": "📝", "title": "Journal Scribe", "desc": "Wrote 7 journal entries covering 10 invisible PRs"},
+    {"icon": "🔓", "title": "Permission Exorcist", "desc": "Found missing sandbox_permissions across 5 Codex invocations"},
+    {"icon": "🤖", "title": "Automation Bootstrapper", "desc": "Built quest_complete.py to replace manual Step 7"},
+    {"icon": "🎯", "title": "Root Cause Triple", "desc": "Diagnosed 3 separate issues in one session"}
+  ],
+  "metrics": [
+    {"icon": "📊", "label": "Dashboard: 23 to 37 quests"},
+    {"icon": "🧹", "label": "8 orphaned quests archived"},
+    {"icon": "🔧", "label": "5 Codex invocations patched"},
+    {"icon": "📝", "label": "7 journal entries backfilled"}
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "B"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 12
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/readme-rewrite_2026-03-20.md
+++ b/docs/quest-journal/readme-rewrite_2026-03-20.md
@@ -1,0 +1,16 @@
+# README Rewrite for Clarity and Brevity
+
+- PR: #76
+- Merged: 2026-03-20
+- Outcome: Documentation cut by more than half without losing substance.
+
+## What Shipped
+
+- **README**: Cut from 594 lines to ~150. Focuses on what Quest is, how to install it, and how to use it.
+- **Presentation doc**: Reduced from 575 to ~320 lines.
+- **Philosophy doc** (new): Full manifesto extracted from README into its own file, so the README stays practical.
+- **Bridge architecture** documented as a first-class concept rather than buried in implementation notes.
+
+## Why It Matters
+
+The README had grown into a manifesto-plus-tutorial-plus-architecture-doc. Splitting concerns means new users get a fast onramp, while the philosophy and architecture details remain accessible for those who want depth.

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -198,6 +198,9 @@ def main() -> int:
 
     # Determine slug and outcome
     slug = data.slug or state.get("slug", quest_dir.name.split("_")[0])
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug):
+        print(f"Error: invalid slug '{slug}'. Must match [a-z0-9][a-z0-9-]*", file=sys.stderr)
+        return 1
     outcome = data.brief_summary or data.plan_summary or "Completed."
     # Sanitize outcome for README markdown table: collapse newlines, escape pipes
     outcome = re.sub(r"\s*\n\s*", " ", outcome).replace("|", "\\|")

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -199,16 +199,25 @@ def main() -> int:
     # Determine slug and outcome
     slug = data.slug or state.get("slug", quest_dir.name.split("_")[0])
     outcome = data.brief_summary or data.plan_summary or "Completed."
-    # Truncate outcome for README table
+    # Sanitize outcome for README markdown table: collapse newlines, escape pipes
+    outcome = re.sub(r"\s*\n\s*", " ", outcome).replace("|", "\\|")
     if len(outcome) > 120:
         outcome = outcome[:117] + "..."
 
-    # Find journal directory (relative to repo root)
-    repo_root = quest_dir
+    # Find journal directory (walk up to repo root)
+    repo_root = quest_dir.resolve()
+    found = False
     for _ in range(5):
         if (repo_root / "docs" / "quest-journal").exists():
+            found = True
             break
-        repo_root = repo_root.parent
+        parent = repo_root.parent
+        if parent == repo_root:
+            break
+        repo_root = parent
+    if not found:
+        print(f"Error: could not find docs/quest-journal/ above {quest_dir}", file=sys.stderr)
+        return 1
     journal_dir = repo_root / "docs" / "quest-journal"
 
     if not args.skip_journal:

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -207,23 +207,23 @@ def main() -> int:
     if len(outcome) > 120:
         outcome = outcome[:117] + "..."
 
-    # Find journal directory (walk up to repo root)
-    repo_root = quest_dir.resolve()
-    found = False
-    for _ in range(5):
-        if (repo_root / "docs" / "quest-journal").exists():
-            found = True
-            break
-        parent = repo_root.parent
-        if parent == repo_root:
-            break
-        repo_root = parent
-    if not found:
-        print(f"Error: could not find docs/quest-journal/ above {quest_dir}", file=sys.stderr)
-        return 1
-    journal_dir = repo_root / "docs" / "quest-journal"
-
+    journal_path = None
     if not args.skip_journal:
+        # Find journal directory (walk up to repo root)
+        repo_root = quest_dir.resolve()
+        found = False
+        for _ in range(5):
+            if (repo_root / "docs" / "quest-journal").exists():
+                found = True
+                break
+            parent = repo_root.parent
+            if parent == repo_root:
+                break
+            repo_root = parent
+        if not found:
+            print(f"Error: could not find docs/quest-journal/ above {quest_dir}", file=sys.stderr)
+            return 1
+        journal_dir = repo_root / "docs" / "quest-journal"
         journal_dir.mkdir(parents=True, exist_ok=True)
         journal_file = journal_dir / f"{slug}_{completion_date.isoformat()}.md"
 
@@ -237,6 +237,7 @@ def main() -> int:
             # Update README index
             _update_readme_index(journal_dir, slug, completion_date, outcome)
             print(f"README index updated")
+        journal_path = str(journal_file)
 
     if not args.skip_archive:
         archive_path = _archive_quest(quest_dir)
@@ -244,7 +245,7 @@ def main() -> int:
 
     print(json.dumps({
         "slug": slug,
-        "journal": str(journal_dir / f"{slug}_{completion_date.isoformat()}.md"),
+        "journal": journal_path,
         "archived": not args.skip_archive,
         "quality_tier": data.quality_tier,
     }))

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Automate quest completion: journal entry creation, README update, and archival.
+
+Usage:
+    python3 scripts/quest_complete.py --quest-dir .quest/<id>
+
+This script is called by the orchestrator during Step 7 of the quest workflow.
+It reads quest artifacts, generates a journal entry with embedded celebration_data,
+updates the journal README index, and moves the quest to the archive.
+
+The celebration animation itself is NOT handled here — it runs via the /celebrate
+skill or the Python celebrate.py script before this script is called.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# Add scripts/ to path so we can import quest_celebrate
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from quest_celebrate.quest_data import (
+    QuestData,
+    friendly_model_name,
+    load_quest_data,
+)
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _build_celebration_json(data: QuestData) -> dict:
+    """Build the celebration_data JSON block from QuestData."""
+    return {
+        "quest_mode": data.quest_mode or "unknown",
+        "agents": [
+            {"name": a.name, "model": a.model, "role": a.role_title}
+            for a in data.agents
+        ],
+        "achievements": [
+            {"icon": a.icon, "title": a.title, "desc": a.description}
+            for a in data.achievements
+        ],
+        "metrics": [
+            {"icon": "📊", "label": f"Plan iterations: {data.plan_iterations}"},
+            {"icon": "🔧", "label": f"Fix iterations: {data.fix_iterations}"},
+            {"icon": "📝", "label": f"Review findings: {data.review_count}"},
+        ],
+        "quality": {
+            "tier": data.quality_tier,
+            "grade": data.quality_tier[0] if data.quality_tier else "?",
+        },
+        "test_count": data.test_count,
+        "tests_added": data.tests_added,
+        "files_changed": len(data.files_changed),
+    }
+
+
+def _generate_journal_entry(data: QuestData, completion_date: date) -> str:
+    """Generate a markdown journal entry from quest data."""
+    lines = []
+
+    # Title
+    title = data.name or data.slug or data.quest_id
+    lines.append(f"# Quest Journal: {title}")
+    lines.append("")
+
+    # Metadata
+    lines.append(f"- Quest ID: `{data.quest_id}`")
+    lines.append(f"- Completed: {completion_date.isoformat()}")
+    if data.quest_mode:
+        lines.append(f"- Mode: {data.quest_mode}")
+    if data.quality_tier:
+        lines.append(f"- Quality: {data.quality_tier}")
+    lines.append(f"- Outcome: {data.brief_summary or data.plan_summary or 'Completed successfully.'}")
+    lines.append("")
+
+    # What shipped
+    if data.plan_summary:
+        lines.append("## What Shipped")
+        lines.append("")
+        lines.append(data.plan_summary)
+        lines.append("")
+
+    # Files changed
+    if data.files_changed:
+        lines.append("## Files Changed")
+        lines.append("")
+        for f in data.files_changed:
+            lines.append(f"- `{f}`")
+        lines.append("")
+
+    # Iterations
+    lines.append("## Iterations")
+    lines.append("")
+    lines.append(f"- Plan iterations: {data.plan_iterations}")
+    lines.append(f"- Fix iterations: {data.fix_iterations}")
+    lines.append("")
+
+    # Agents
+    if data.agents:
+        lines.append("## Agents")
+        lines.append("")
+        for agent in data.agents:
+            model_label = friendly_model_name(agent.model)
+            lines.append(f"- **{agent.role_title}** ({agent.name}): {model_label}")
+        lines.append("")
+
+    # Brief as origin quote
+    if data.brief_summary:
+        lines.append("## This is where it all began...")
+        lines.append("")
+        lines.append(f"> {data.brief_summary}")
+        lines.append("")
+
+    # Celebration data JSON block
+    celebration = _build_celebration_json(data)
+    lines.append("## Celebration Data")
+    lines.append("")
+    lines.append("<!-- celebration-data-start -->")
+    lines.append("```json")
+    lines.append(json.dumps(celebration, indent=2, ensure_ascii=False))
+    lines.append("```")
+    lines.append("<!-- celebration-data-end -->")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _update_readme_index(journal_dir: Path, slug: str, completion_date: date, outcome: str) -> None:
+    """Insert a row at the top of the journal README index table."""
+    readme = journal_dir / "README.md"
+    if not readme.exists():
+        return
+
+    content = readme.read_text()
+    # Find the header row separator and insert after it
+    # Format: | Date | Quest | Outcome |
+    #         |------|-------|---------|
+    #         | new row here |
+    pattern = r"(\| Date \| Quest \| Outcome \|\n\|[-\s|]+\|\n)"
+    new_row = f"| {completion_date.isoformat()} | [{slug}]({slug}_{completion_date.isoformat()}.md) | {outcome} |\n"
+
+    if re.search(pattern, content):
+        content = re.sub(pattern, r"\1" + new_row, content, count=1)
+    else:
+        # Fallback: append to end
+        content += f"\n{new_row}"
+
+    readme.write_text(content)
+
+
+def _archive_quest(quest_dir: Path) -> Path:
+    """Move quest directory to archive. Returns archive path."""
+    archive_root = quest_dir.parent / "archive"
+    archive_root.mkdir(exist_ok=True)
+    dest = archive_root / quest_dir.name
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.move(str(quest_dir), str(dest))
+    return dest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Complete a quest: journal + archive")
+    parser.add_argument("--quest-dir", required=True, help="Path to quest directory")
+    parser.add_argument("--skip-archive", action="store_true", help="Skip archival step")
+    parser.add_argument("--skip-journal", action="store_true", help="Skip journal creation")
+    parser.add_argument("--date", default=None, help="Override completion date (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    quest_dir = Path(args.quest_dir)
+    if not quest_dir.exists():
+        print(f"Error: quest directory not found: {quest_dir}", file=sys.stderr)
+        return 1
+
+    state_file = quest_dir / "state.json"
+    if not state_file.exists():
+        print(f"Error: no state.json in {quest_dir}", file=sys.stderr)
+        return 1
+
+    state = json.loads(state_file.read_text())
+    if state.get("status") != "complete":
+        print(f"Warning: quest status is '{state.get('status')}', not 'complete'", file=sys.stderr)
+
+    # Load quest data
+    data = load_quest_data(quest_dir)
+    completion_date = date.fromisoformat(args.date) if args.date else _today()
+
+    # Determine slug and outcome
+    slug = data.slug or state.get("slug", quest_dir.name.split("_")[0])
+    outcome = data.brief_summary or data.plan_summary or "Completed."
+    # Truncate outcome for README table
+    if len(outcome) > 120:
+        outcome = outcome[:117] + "..."
+
+    # Find journal directory (relative to repo root)
+    repo_root = quest_dir
+    for _ in range(5):
+        if (repo_root / "docs" / "quest-journal").exists():
+            break
+        repo_root = repo_root.parent
+    journal_dir = repo_root / "docs" / "quest-journal"
+
+    if not args.skip_journal:
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        journal_file = journal_dir / f"{slug}_{completion_date.isoformat()}.md"
+
+        if journal_file.exists():
+            print(f"Journal entry already exists: {journal_file}")
+        else:
+            entry = _generate_journal_entry(data, completion_date)
+            journal_file.write_text(entry)
+            print(f"Journal entry created: {journal_file}")
+
+            # Update README index
+            _update_readme_index(journal_dir, slug, completion_date, outcome)
+            print(f"README index updated")
+
+    if not args.skip_archive:
+        archive_path = _archive_quest(quest_dir)
+        print(f"Quest archived: {archive_path}")
+
+    print(json.dumps({
+        "slug": slug,
+        "journal": str(journal_dir / f"{slug}_{completion_date.isoformat()}.md"),
+        "archived": not args.skip_archive,
+        "quality_tier": data.quality_tier,
+    }))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -163,7 +163,7 @@ def _archive_quest(quest_dir: Path) -> Path:
     archive_root.mkdir(exist_ok=True)
     dest = archive_root / quest_dir.name
     if dest.exists():
-        shutil.rmtree(dest)
+        raise FileExistsError(f"Archive already exists: {dest}. Remove it manually to re-archive.")
     shutil.move(str(quest_dir), str(dest))
     return dest
 
@@ -188,7 +188,9 @@ def main() -> int:
 
     state = json.loads(state_file.read_text())
     if state.get("status") != "complete":
-        print(f"Warning: quest status is '{state.get('status')}', not 'complete'", file=sys.stderr)
+        print(f"Error: quest status is '{state.get('status')}', not 'complete'. "
+              "Transition to complete or abandoned first.", file=sys.stderr)
+        return 1
 
     # Load quest data
     data = load_quest_data(quest_dir)

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -149,7 +149,7 @@ def _update_readme_index(journal_dir: Path, slug: str, completion_date: date, ou
     new_row = f"| {completion_date.isoformat()} | [{slug}]({slug}_{completion_date.isoformat()}.md) | {outcome} |\n"
 
     if re.search(pattern, content):
-        content = re.sub(pattern, r"\1" + new_row, content, count=1)
+        content = re.sub(pattern, lambda m: m.group(1) + new_row, content, count=1)
     else:
         # Fallback: append to end
         content += f"\n{new_row}"

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -41,6 +41,9 @@ DRY_RUN_WOULD_SKIP=0
 DRY_RUN_UP_TO_DATE=0
 DRY_RUN_MODIFIED=0
 
+# Track .quest_updated files created during installation
+QUEST_UPDATED_FILES=()
+
 ###############################################################################
 # Cleanup Trap
 ###############################################################################
@@ -1037,6 +1040,7 @@ install_user_customized_file() {
     log_action "Create: $updated_path (upstream has changes)"
   else
     mv "$temp_file" "$updated_path"
+    QUEST_UPDATED_FILES+=("$updated_path")
     log_warn "Created: $updated_path (review and merge manually)"
   fi
   rm -f "$temp_file"
@@ -1118,6 +1122,7 @@ install_merge_carefully_file() {
       log_action "Create: $updated_path (upstream has changes)"
     else
       mv "$temp_file" "$updated_path"
+      QUEST_UPDATED_FILES+=("$updated_path")
       log_warn "Created: $updated_path (merge manually)"
     fi
     rm -f "$temp_file"
@@ -1152,6 +1157,7 @@ install_merge_carefully_file() {
         log_action "Create: $updated_path"
       else
         mv "$temp_file" "$updated_path"
+        QUEST_UPDATED_FILES+=("$updated_path")
         log_info "Created: $updated_path (merge manually)"
       fi
       ;;
@@ -1429,7 +1435,16 @@ print_next_steps() {
   else
     echo "Quest has been updated to version ${UPSTREAM_SHA:0:8}."
     echo ""
-    echo "Review any .quest_updated files for upstream changes to merge."
+    if [ ${#QUEST_UPDATED_FILES[@]} -gt 0 ]; then
+      echo "Files with upstream changes to review and merge:"
+      for f in "${QUEST_UPDATED_FILES[@]}"; do
+        echo "  - $f"
+      done
+      echo ""
+      echo "Compare each .quest_updated file with the original, merge what you want, then delete the .quest_updated file."
+    else
+      echo "All files are up to date. No manual merges needed."
+    fi
     echo ""
   fi
 

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -1332,6 +1332,7 @@ offer_codex_setup() {
   fi
 
   # Codex CLI is available — check if MCP server is registered
+  log_info "Validating agent configurations, please stand by..."
   # Try to detect if claude CLI is available for MCP registration
   if ! command -v claude &>/dev/null; then
     log_warn "Claude CLI not found — cannot register Codex MCP server automatically"


### PR DESCRIPTION
## Summary
- Regenerated the portfolio dashboard (23 → 38 quests) by backfilling 7 journal entries for 10 merged PRs since Mar 9
- Fixed Codex sandbox permission prompt by adding `sandbox_permissions: "workspace-write"` to all reviewer/fixer MCP invocations
- Automated quest completion (journal + README + archive) with new `scripts/quest_complete.py`

## Changes
- **7 new journal entries** in `docs/quest-journal/` covering PRs #68-#80
- **`docs/dashboard/index.html`** regenerated: 36 finished, 2 abandoned
- **`.skills/quest/delegation/workflow.md`**: added `sandbox_permissions: "workspace-write"` to 5 Codex invocations (plan reviewer full/fast, code reviewer full/fast, fixer); clarified artifact write prompts; replaced manual Step 7 with `quest_complete.py` call
- **`scripts/quest_complete.py`** (new): reads quest artifacts, generates journal entry with celebration_data JSON, updates README index, archives quest directory
- **`.quest-manifest`**: added new script

## Validation
- [x] `scripts/validate-manifest.sh` passes
- [x] Dashboard renders correctly with 38 quest cards (`open docs/dashboard/index.html`)
- [x] `quest_complete.py --help` loads without errors
- [x] Dry run of `quest_complete.py` against archived quest produces valid journal entry
- [ ] GitHub Pages deployment triggers after merge (post-merge verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)