### PR TITLE
feat: add execution discipline guardrails to builder-facing skills

### DIFF
--- a/.skills/code-reviewer/SKILL.md
+++ b/.skills/code-reviewer/SKILL.md
@@ -233,3 +233,12 @@ A good code review should:
 - ✅ Ensure tests map to acceptance criteria
 - ✅ Prevent secret leaks and basic security failures
 - ✅ Provide actionable feedback with severity
+
+---
+
+## Common Pitfalls
+
+| Shortcut | Why It Fails | Red Flag |
+|----------|-------------|----------|
+| "While you're here, also change..." | Scope creep disguised as review feedback. Refactor suggestions unrelated to the PR add noise and expand scope. | Review comments referencing code outside the diff |
+| Marking missing AC tests as "Should fix" | Untested acceptance criteria ship to production. If an AC exists but has no test, that is a "Must fix", not a suggestion. | AC exists but test coverage column is empty |

--- a/.skills/implementer/SKILL.md
+++ b/.skills/implementer/SKILL.md
@@ -84,7 +84,11 @@ Stop and ask a question if any of these are unclear:
 - error semantics and retryability
 - cross-system integration expectations
 
-If the uncertainty is not impactful, choose the simplest interpretation and record it in the Decision Log.
+If the uncertainty is not impactful, choose the simplest interpretation and record it in the Decision Log with an `ASSUMPTION` tag so reviewers can validate it:
+
+- Assumption: [what you assumed]
+  - context: [what in the plan was ambiguous]
+  - alternative: [what else you considered]
 
 ### Rule 7: Ask before deviating from repo standards
 
@@ -116,6 +120,21 @@ Decision Log format:
   - impact: what this affects
   - followups: planned cleanup/risks
 
+### Rule 8: Scope discipline
+
+Before touching any file, confirm the change is within the approved scope. If you notice something that should be fixed but is out of scope:
+
+1. Do NOT fix it
+2. Record it using the NOTICED pattern in the discussion file:
+
+```
+NOTICED: [file or issue]
+DESCRIPTION: [what you saw]
+RECOMMENDATION: [fix in follow-up quest / add to backlog]
+```
+
+This preserves the observation without polluting the current diff.
+
 ---
 
 ## Implementation Process
@@ -143,3 +162,12 @@ Before starting the next step, verify:
 - tests are deterministic and meaningful
 - no secrets/sensitive data are logged or returned
 - changes are minimal and reviewable
+
+---
+
+## Common Pitfalls
+
+| Shortcut | Why It Fails | Red Flag |
+|----------|-------------|----------|
+| "I'll add tests after I finish the logic" | Bugs compound — a bug in step 1 makes steps 2-5 wrong. Tests written after the fact test implementation, not behavior. | Code files growing without corresponding test files appearing |
+| "Fixing one more thing while I'm here" | Diff grows, review slows, risk compounds. Mixed refactors and features make both harder to review and debug. | Commit message mentions unrelated cleanup |

--- a/.skills/plan-maker/SKILL.md
+++ b/.skills/plan-maker/SKILL.md
@@ -194,6 +194,15 @@ Use Small Plan template, add:
 
 ---
 
+## Common Pitfalls
+
+| Shortcut | Why It Fails | Red Flag |
+|----------|-------------|----------|
+| Listing files without specifying change type | Builder guesses wrong about create vs modify | File list with no "Add/Modify/Delete" annotations |
+| Writing acceptance criteria after the implementation section | Criteria shaped to match the solution, not the problem | AC section reads like a commit description |
+
+---
+
 ## Self-Review Checklist
 
 Before human review:
@@ -233,3 +242,23 @@ Before human review:
 8. Actionable (concrete enough to start)
 9. Shippable not perfect (stop conditions)
 10. No hallucination (flag ambiguity)
+
+---
+
+## Vertical Slicing (Prefer Over Horizontal)
+
+Decompose plans into vertical slices that each deliver observable value end-to-end, rather than horizontal layers that only work when all layers are complete.
+
+**Good (vertical):**
+1. Add "create widget" endpoint + model + one test (proves the slice works)
+2. Add "list widgets" endpoint + query + test
+3. Add validation rules + error test
+
+**Bad (horizontal):**
+1. Create all database models
+2. Create all API endpoints
+3. Write all tests
+
+Each step in a vertical plan can be validated independently. If step 1 works, you have confidence in the pattern before building steps 2-3.
+
+If a step must be horizontal (e.g., database migration before any feature code), note why.

--- a/.skills/quest/agents/builder.md
+++ b/.skills/quest/agents/builder.md
@@ -25,6 +25,7 @@ When running on Codex, this role is non-interactive:
 3. Run tests after each significant change
 4. Write PR description to `.quest/<quest_id>/phase_02_implementation/pr_description.md` following the format in `.skills/pr-assistant/SKILL.md`
 5. Record decisions, touched files, and tests run in `.quest/<quest_id>/phase_02_implementation/builder_feedback_discussion.md`
+6. Record assumptions not covered by the plan in the Decision Log using the `ASSUMPTION` format from `.skills/implementer/SKILL.md` "Stop on impactful uncertainty"
 
 ## Input
 - Approved plan (`.quest/<id>/phase_01_plan/plan.md`)

--- a/.skills/quest/agents/fixer.md
+++ b/.skills/quest/agents/fixer.md
@@ -26,8 +26,9 @@ When running on Codex, this role is non-interactive:
 1. Read the code review notes
 2. Apply targeted fixes for each identified issue
 3. Run tests to verify fixes don't introduce regressions
-4. Record fix decisions, touched files, and tests run in `.quest/<quest_id>/phase_03_review/review_fix_feedback_discussion.md`
-5. Do NOT make unrelated changes — fix only what the review identified
+4. For bug fixes: follow the prove-it pattern from `AGENTS.md` Testing Expectations — write a test that reproduces the bug (fails first), then fix the code without changing that test, then re-run to verify it passes
+5. Record fix decisions, touched files, and tests run in `.quest/<quest_id>/phase_03_review/review_fix_feedback_discussion.md`
+6. Do NOT make unrelated changes — fix only what the review identified
 
 ## Input
 - Code review (`.quest/<id>/phase_03_review/review_code-reviewer-a.md`)


### PR DESCRIPTION
## Summary

Add execution discipline guardrails to Quest's builder-facing skills — pitfall tables, assumption recording, scope discipline, vertical slicing guidance, and prove-it references.

All changes are additive markdown. No new files, no schema changes, no workflow or architecture changes. 71 insertions across 5 files.

## Changes

- **implementer/SKILL.md**: Assumption format added to Rule 5's Decision Log, scope discipline (Rule 8) with NOTICED pattern, pitfall table (2 entries)
- **code-reviewer/SKILL.md**: Pitfall table (2 entries on scope creep and test severity)
- **plan-maker/SKILL.md**: Pitfall table (2 entries), vertical slicing section with good/bad examples
- **quest/agents/fixer.md**: Prove-it pattern reference wired from AGENTS.md Testing Expectations
- **quest/agents/builder.md**: Assumption recording responsibility added

## Context

Quest's orchestration is strong but the skills guiding individual agents during their turn lacked guardrails against common failure modes observed in past quests (thin-orchestrator, ci-quest-validation): silent assumptions, rationalized shortcuts, prove-it violations, and unrecorded scope observations.

Reviewed by Claude (self-review) and Codex (o3, independent review). Codex findings applied: merged assumption rule into Decision Log, relaxed scope wording, trimmed pitfall tables from 12 to 6 entries, removed duplicate horizontal-planning row, fixed brittle rule-number reference.

## Test plan

- [ ] Verify each pitfall table renders correctly in markdown preview
- [ ] Verify implementer Rule 5 assumption format is clear
- [ ] Verify implementer Rule 8 scope wording is not over-strict
- [ ] Verify fixer prove-it reference points to correct AGENTS.md section
- [ ] Verify builder responsibility references section heading, not rule number
- [ ] Run 2-3 quests and observe whether agents reference the new guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)