### PR TITLE
Add execution discipline guardrails and default planner to Codex

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -19,7 +19,7 @@
     "fix_loop": true
   },
   "models": {
-    "planner": "claude",
+    "planner": "gpt-5.4",
     "plan-reviewer-a": "claude",
     "plan-reviewer-b": "gpt-5.4",
     "arbiter": "claude",

--- a/.skills/implementer/SKILL.md
+++ b/.skills/implementer/SKILL.md
@@ -125,7 +125,7 @@ Decision Log format:
 Before touching any file, confirm the change is within the approved scope. If you notice something that should be fixed but is out of scope:
 
 1. Do NOT fix it
-2. Record it using the NOTICED pattern in the discussion file:
+2. Record it using the NOTICED pattern in your Decision Log (Rule 6):
 
 ```
 NOTICED: [file or issue]

--- a/.skills/quest/agents/planner.md
+++ b/.skills/quest/agents/planner.md
@@ -4,7 +4,13 @@
 Creates and refines implementation plans from quest briefs. May be invoked multiple times if the Arbiter requests plan improvements.
 
 ## Tool
-Claude runtime. Use native `Task(subagent_type="planner")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` as the orchestration entrypoint. `scripts/quest_claude_bridge.py` remains the transport layer behind that runner.
+Codex (`mcp__codex-cli__codex`) by default, with Claude runtime as fallback. Use native `Task(subagent_type="planner")` when the orchestrator dispatches to Claude; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` for the Claude fallback path. `scripts/quest_claude_bridge.py` remains the transport layer behind that runner.
+
+When running on Codex, this role is non-interactive:
+- Do not ask questions.
+- Do not return `STATUS: needs_human`.
+- For implementation-detail ambiguity (file layout, naming, minor ordering), make explicit assumptions and continue — note them in the plan.
+- For requirements ambiguity that changes the quest outcome (what to build, acceptance criteria, scope boundary), return `STATUS: blocked` so the orchestrator can fall back to the Claude planner, which can surface clarifying questions to the user.
 
 ## Context Required
 - `.skills/BOOTSTRAP.md` (project bootstrapping)

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -304,10 +304,10 @@ gates.max_plan_iterations (default: 4)
 
 1. **Update state:** `plan_iteration += 1`, `status: in_progress`, `last_role: planner_agent`
 
-2. **Invoke Planner:**
+2. **Invoke Planner** (default Codex `mcp__codex__codex`, Claude runtime fallback):
    - Read `models.planner` from allowlist.
+   - If planner model is Codex, invoke via `mcp__codex__codex` with `sandbox_permissions: "workspace-write"`.
    - If planner model is Claude, invoke through Claude runtime (native `Task(...)` when available, bridge in Codex-led sessions).
-   - If planner model is Codex, invoke via `mcp__codex__codex`.
    - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare `plan.md` and `handoff.json` in `.quest/<id>/phase_01_plan/`.
    - Prompt: Reference file paths only, do not embed artifact content:
      - Quest brief: `.quest/<id>/quest_brief.md`


### PR DESCRIPTION
## Summary
Two related improvements to Quest's builder-facing discipline: additive skill guardrails that reduce scope creep and silent assumptions during plan/build/review/fix, plus a dispatch change that routes the planner through Codex by default with a clear non-interactive contract.

## Changes
- **Skills**:
  - `implementer`: adds assumption-recording format in Rule 5 and scope-discipline guidance (Rule 8); pitfall table added
  - `code-reviewer`: pitfall table covering scope creep and test-severity judgment
  - `plan-maker`: pitfall table and vertical-slicing guidance
  - `fixer`: prove-it pattern reference from `AGENTS.md`
  - `builder`: assumption-recording responsibility
- **Quest agents**:
  - `.skills/quest/agents/planner.md`: Tool section now declares Codex as default runtime (mirrors builder/fixer); adds Codex non-interactive block with a planner-specific rule — return `STATUS: blocked` on requirements ambiguity so Tier-C fallback to Claude planner can surface `needs_human` to the user
- **Config**:
  - `.ai/allowlist.json`: `models.planner` flipped from `claude` to `gpt-5.4`, so the orchestrator dispatches planner work via `mcp__codex-cli__codex`. Claude planner remains available through the Tier-C fallback ladder already defined in `.skills/quest/delegation/workflow.md`.

## Validation
- [ ] **Static check — Codex non-interactive blocks present**: Action: run `grep -nE "When running on Codex" .skills/quest/agents/*.md`. Expected: three matches (builder.md, fixer.md, planner.md). The planner block should also contain the words "blocked" and "requirements ambiguity" — the planner-specific deviation from builder/fixer.
- [ ] **Static check — allowlist dispatch target**: Action: run `jq '.models.planner' .ai/allowlist.json`. Expected: `"gpt-5.4"`.
- [ ] **Walkthrough — quest with a clear brief**: Prerequisites: a quest with an unambiguous brief at `.quest/<id>/quest_brief.md`. Action: invoke `/quest` and observe the planner phase logs. Expected: `Invoke Planner` step dispatches through `mcp__codex-cli__codex`; planner writes `.quest/<id>/phase_01_plan/plan.md` and `handoff.json` with `status: complete`; no `needs_human` emitted from the Codex path.
- [ ] **Walkthrough — ambiguous brief triggers Tier-C fallback**: Prerequisites: a quest with a deliberately ambiguous brief (missing acceptance criteria or contradictory scope). Action: invoke `/quest`. Expected: Codex planner returns `STATUS: blocked`; orchestrator invokes Claude planner via fallback; Claude planner may emit `needs_human` and the orchestrator runs the Q&A loop with the user.
Watch for: silent demotion to Claude via MCP timeout — if the Codex MCP call exceeds the ambient `MCP_TOOL_TIMEOUT`, the orchestrator falls back without an explicit `blocked` signal. Not a regression, but worth noticing during first runs.

## Notes
- The two commits on this branch are thematically distinct (execution-discipline guardrails vs. planner-runtime switch) but were intentionally bundled.
- `.claude/agents/planner.md` (the Claude subagent stub) is unchanged. It still serves the Tier-C fallback path.
- `role_permissions.planner_agent` in the allowlist is unchanged — it governs the Claude fallback; Codex uses `sandbox_permissions: "workspace-write"` inherited from the global default in `.skills/quest/delegation/workflow.md:141`.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>