### PR TITLE
Add Claude Insights ideas batch with dual-mode sanity checks

### DIFF
--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-04-15 | [claude-insights-ideas](claude-insights-ideas_2026-04-15.md) | > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-in... |
 | 2026-04-13 | [feedback-intent-routing](feedback-intent-routing_2026-04-13.md) | Consolidate the Quest routing and feedback-intent ideas into one canonical delegation proposal. Use `ideas/2026-04-13... |
 | 2026-04-13 | [prompt-surface-consolidation](prompt-surface-consolidation_2026-04-13.md) | > 3. Prompt Surface / Instruction Architecture > > Consolidate Quest prompt-surface improvement docs into one canonic... |
 | 2026-04-12 | [caveman-review](caveman-review_2026-04-12.md) | Review completed. Decision: NO ACTION. |

--- a/docs/quest-journal/claude-insights-ideas_2026-04-15.md
+++ b/docs/quest-journal/claude-insights-ideas_2026-04-15.md
@@ -1,0 +1,109 @@
+# Quest Journal: Translate Claude Insights Evaluation into Sanity-Checked Ideas Documents
+
+- Quest ID: `claude-insights-ideas_2026-04-15__1629`
+- Completed: 2026-04-15
+- Mode: solo
+- Quality: Platinum
+- Outcome: > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-insights.md but it's not as visual)
+> create very clear, super technical ideas doc...
+
+## What Shipped
+
+| File | Purpose | Status | Tier |
+|---|---|---|---|
+| `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md` | Define a safe hook strategy for branch/directory verification before edits, including non-git fallback behavior. | proposed | 1 |
+| `ideas/2026-04-15-claude-rule-confirm-pwd-bran...
+
+## Files Changed
+
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_01_plan/plan.md`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_01_plan/handoff.json`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_01_plan/review_plan-reviewer-a.md`
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`
+- `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md`
+- `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md`
+- `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md`
+- `ideas/2026-04-15-precommit-status-diffstat-discipline.md`
+- `ideas/2026-04-15-subagent-path-constraints-hardening.md`
+- `ideas/2026-04-15-tool-failure-two-attempt-cap.md`
+- `ideas/2026-04-15-autonomous-pr-shepherd-headless.md`
+- `ideas/2026-04-15-claude-insights-priorities.md`
+- `ideas/README.md`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_02_implementation/pr_description.md`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_02_implementation/handoff.json`
+- `.quest/claude-insights-ideas_2026-04-15__1629/phase_03_review/review_code-reviewer-a.md`
+
+## Iterations
+
+- Plan iterations: 1
+- Fix iterations: 0
+
+## Agents
+
+- **The Implementer** (builder): 
+
+## This is where it all began...
+
+> > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-insights.md but it's not as visual)
+> create very clear, super technical ideas doc...
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 3 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 2 reviews"
+    },
+    {
+      "icon": "[SOLO]",
+      "title": "Solo Adventurer",
+      "desc": "Completed quest with a single companion"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 2"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 17
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-04-15-autonomous-pr-shepherd-headless.md
+++ b/ideas/2026-04-15-autonomous-pr-shepherd-headless.md
@@ -1,0 +1,48 @@
+---
+title: Autonomous PR Shepherd (Headless) Staged Design
+purpose: Define a guarded path to headless PR lifecycle automation built on existing pr-shepherd capabilities.
+audience:
+  - quest-developers
+  - quest-users
+scope: Long-horizon automation for PR shepherding with strict safety boundaries.
+status: idea
+owner: kjell
+---
+
+## Problem
+The evaluation shows high operational load in PR lifecycle work (20 PR-management sessions and 18 PR-shepherding sessions). Repetition is high-value automation territory, but current friction patterns (wrong branch/path, validation drift) can be amplified if autonomous loops are enabled too early.
+
+## Proposal
+Build headless PR shepherding on top of the existing `.skills/pr-shepherd/SKILL.md`, using the evaluation's headless invocation pattern (`claude -p ... --allowedTools ... --output-format json`) for scheduled/non-interactive execution. Hard constraint from the evaluation should be preserved: autonomous shepherd prepares for merge but never merges.
+
+Prerequisite gate: Tier 1 and Tier 2 guardrails from this batch should land first.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside this repo, existing `pr-shepherd` process and quality gates provide a stable baseline for incremental headless support (`--headless` mode, safe retry limits, no-merge policy).
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in usage varies by branch conventions, test commands, and CI systems. Headless mode needs per-repo configuration (for example `.quest/shepherd.config.yaml`) to avoid hardcoded assumptions.
+
+### Conflicts and Required Adaptations
+Direct overlap exists with `.skills/pr-shepherd/SKILL.md`. This idea should extend that skill, not create a second shepherd implementation. Keep ownership unified and safety constraints explicit.
+
+## Actionable Steps
+1. Audit current `.skills/pr-shepherd/SKILL.md` flow and identify extension points for non-interactive operation.
+2. Add a `--headless` execution mode with deterministic retries and polling limits.
+3. Define `.quest/shepherd.config.yaml` schema for repo-specific branch/test/CI behavior.
+4. Enforce hard constraints: never merge, branch verification before edits, stop on permissions/protection failures.
+5. Roll out in stages after Tier 1-2 guardrails are proven.
+
+## Cross-References
+- `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md`
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`
+- `ideas/2026-04-15-claude-insights-priorities.md`
+
+## Risks / Non-Goals
+- Non-goal: autonomous merge rights.
+- Risk: automation loops can repeat bad assumptions quickly without context guardrails.
+- Risk: cross-repo CI variability can break headless flows unless config is explicit and validated.
+
+## Success Signal
+A headless shepherd can process PR updates, CI failures, and review replies end-to-end without manual babysitting while respecting the never-merge boundary.

--- a/ideas/2026-04-15-claude-insights-priorities.md
+++ b/ideas/2026-04-15-claude-insights-priorities.md
@@ -1,0 +1,109 @@
+---
+title: Claude Insights Priorities (2026-04-15)
+purpose: Canonical priority index translating evaluation suggestions into Quest-specific, sanity-checked proposals and explicit skips.
+audience:
+  - quest-developers
+  - quest-users
+scope: Prioritization and coverage map for Claude insights follow-up ideas.
+status: proposed
+owner: kjell
+---
+
+## Context
+The source evaluation spans 1,542 messages across 97 sessions (2026-03-16 to 2026-04-15). Top friction counts are `Wrong Approach (55)`, `Buggy Code (25)`, `Misunderstood Request (21)`, and `Excessive Changes (12)`. The dominant pattern is workspace/branch/path targeting error, so ranking prioritizes controls that reduce wrong-location edits and validation drift before adding heavier automation.
+
+## Problem
+The raw evaluation contains many strong suggestions, but without a canonical priority index the recommendations can be implemented out of order, duplicated across policy surfaces, or applied without outside-in compatibility safeguards. That risks solving lower-impact problems first while the primary friction pattern (wrong branch/directory/path) remains unresolved.
+
+## Proposal
+Create a single user-authoritative index that preserves tier order, maps each suggestion to a destination proposal, and records required Quest-specific adaptations (non-git fallback, additive hooks, no duplicate skills, existing workflow hardening). This document is the coordination layer for the other eight idea files.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside-repo work benefits from explicit sequencing and ownership boundaries so implementation quests can execute in a stable order and avoid policy drift.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in use needs explicit compatibility annotations (especially `vcs_available == false` handling and repo-specific PR/CI variability), which this index centralizes.
+
+### Conflicts and Required Adaptations
+Without this index, overlapping governance docs can diverge. This file resolves overlap by pointing each evaluation item to one destination file (or explicit skip reason), then cross-linking canonicals.
+
+## Canonical Priority Ranking (User-Authoritative)
+This ordering is copied from the quest brief and treated as authoritative.
+
+### Tier 1 — Do this week (highest ROI)
+1. **PreToolUse hook for branch/directory verification** — Directly attacks #1 friction (wrong-branch edits). Low effort, automatic, zero behavior change from user. The `.claude/settings.json` snippet in the report is copy-paste ready.
+2. **CLAUDE.md rule: confirm `pwd` + `git branch --show-current` before edits** — Belt-and-suspenders with the hook. Costs nothing; Claude self-corrects when hook output looks wrong.
+3. **CLAUDE.md rule: never dismiss acceptance criteria** — Zero-effort addition that prevents a recurring, specific failure mode (the `--help timeout` episode, pytest-as-manual-validation, etc.).
+
+### Tier 2 — Do this month (compound returns)
+4. **Custom `/pr-create` skill with verification checklist** — 20 PR-management + 18 PR-shepherding sessions; small per-PR wins compound fast. Encodes "verify script names, run documented commands, stage all files."
+5. **CLAUDE.md rule: pre-commit `git status` + `git diff --stat`** — Fixes the "forgot to stage `.skills` changes" pattern. Cheap.
+6. **CLAUDE.md rule: sub-agent path constraints** — 268 Agent invocations with recurring wrong-directory writes from Codex sub-agents. Meaningful, but only kicks in during quest workflows.
+
+### Tier 3 — Higher-leverage but more investment
+7. **CLAUDE.md rule: cap tool-failure investigation at 2 attempts** — Targets rabbit-holing (#2 friction). Harder to enforce via text rules alone; interrupting early may still work better in practice.
+8. **Autonomous PR Shepherd (headless mode)** — Big payoff, but only worth building after Tiers 1–2 harden conventions. Running an autonomous agent on current friction patterns would amplify failures, not reduce them.
+
+### Skip or defer
+- **Parallel multi-repo quest orchestration** — Ambitious, but single-repo friction isn't solved yet. Premature.
+- **TDD bug-fix agent** — Nice framing, but bug-fix sessions aren't the top pain point; wrong-branch edits are.
+
+## File Pointers
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md` — Hook-level context visibility before write/edit.
+- `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md` — Policy-level pre-edit context confirmation.
+- `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md` — Completion gate for explicit ACs.
+- `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md` — PR checklist via existing `pr-assistant`.
+- `ideas/2026-04-15-precommit-status-diffstat-discipline.md` — Staging/diffstat discipline before commit.
+- `ideas/2026-04-15-subagent-path-constraints-hardening.md` — Postflight path-compliance hardening for sub-agents.
+- `ideas/2026-04-15-tool-failure-two-attempt-cap.md` — Two-attempt investigation cap.
+- `ideas/2026-04-15-autonomous-pr-shepherd-headless.md` — Staged headless PR shepherd concept.
+
+## Skip Bucket
+- **Parallel multi-repo quest orchestration** — deferred; core single-repo execution discipline issues are still unresolved.
+- **TDD bug-fix agent** — deferred; not aligned to top friction source from this evaluation.
+- **Batch security scans (evaluation headless example)** — useful pattern, but orthogonal to current Quest workflow priorities; better handled as a standalone scripted workflow, not a Quest idea in this batch.
+
+## Sanity-Check Modifications to Raw Suggestions
+- **Hook snippet adaptation:** merge additively into `.claude/settings.json`; do not overwrite existing `SessionStart` and `PostToolUse Write|Edit` audit hooks.
+- **`git branch --show-current` adaptation:** degrade safely when `vcs_available == false` by using fallback command behavior.
+- **`/pr-create` adaptation:** routed to extending `.skills/pr-assistant/SKILL.md`, not creating a duplicate skill surface.
+- **Sub-agent path constraints adaptation:** framed as hardening of existing controls in `.skills/quest/delegation/workflow.md` (`expected_artifacts_for_role`, `prepare_artifact_files`).
+- **PostToolUse Bash diff hook adaptation:** flagged as too noisy if global; recommend bounded commit-adjacent usage only.
+
+## Coverage Map
+| Evaluation suggestion | Destination |
+|---|---|
+| CLAUDE.md add: confirm directory+branch before edits | `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md` |
+| Hook: `PreToolUse` branch/dir echo | `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md` |
+| CLAUDE.md add: never dismiss acceptance criteria | `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md` |
+| CLAUDE.md add: PR descriptions must match real scripts/paths/tests | `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md` |
+| Custom skill suggestion: `/pr-create` checklist | `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md` (extension of existing `pr-assistant`) |
+| CLAUDE.md add: pre-commit `git status` + `git diff --stat` | `ideas/2026-04-15-precommit-status-diffstat-discipline.md` |
+| Hook: `PostToolUse Bash` unstaged-diff print | `ideas/2026-04-15-precommit-status-diffstat-discipline.md` (bounded/noise-controlled adaptation) |
+| CLAUDE.md add: explicit sub-agent path constraints and validation | `ideas/2026-04-15-subagent-path-constraints-hardening.md` |
+| New usage pattern: sub-agent path constraints in delegation | `ideas/2026-04-15-subagent-path-constraints-hardening.md` |
+| CLAUDE.md add: cap tool investigation at 2 attempts | `ideas/2026-04-15-tool-failure-two-attempt-cap.md` |
+| Headless mode: autonomous PR shepherd | `ideas/2026-04-15-autonomous-pr-shepherd-headless.md` |
+| Headless mode: batch security scans | Skip bucket (defer to standalone script path) |
+| Horizon: parallel multi-repo orchestration | Skip bucket |
+| Horizon: test-driven bug-fix iteration agent | Skip bucket |
+
+## Actionable Steps
+1. Keep this file updated as the single source for rank order and skip/defer decisions.
+2. Require implementation quests to reference this index when selecting next policy/hardening work.
+3. For each implemented item, append an execution/journal pointer and mark status progression in both this file and `ideas/README.md`.
+4. Reject new overlapping proposals unless they map cleanly into this index or replace an existing entry with rationale.
+
+## Cross-References
+- `ideas/2026-04-13-instruction-architecture.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+- `ideas/handoff-validation-and-failure-ux.md`
+
+## Risks / Non-Goals
+- Non-goal: implementing policy/hook/skill changes in this documentation quest.
+- Risk: if canonical ownership is not enforced, these ideas can reintroduce policy duplication.
+- Risk: Tier 3 automation before Tier 1/2 hardening can amplify existing failure modes.
+
+## Success Signal
+All evaluation suggestions map to either a concrete proposal file or an explicit skip/defer rationale, and teams can execute the ranked list without ambiguity about dual-mode behavior.

--- a/ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md
+++ b/ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md
@@ -1,0 +1,49 @@
+---
+title: CLAUDE Rule - Confirm PWD and Branch Before Edits
+purpose: Add an execution-discipline rule that requires explicit workspace context checks before editing.
+audience:
+  - quest-developers
+  - quest-users
+scope: Policy-level pre-edit context verification.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation reports 55 wrong-approach events, with repeated branch/directory mistakes across multi-repo sessions and worktrees. The same pattern appears both in direct edits and in delegated work, so a policy-level check is needed in addition to hook-level visibility.
+
+## Proposal
+Adopt the evaluation rule text verbatim, with Quest compatibility notes:
+
+> "When working across multiple repos or worktrees, always confirm the current working directory and active branch before making any edits. Run `git branch --show-current` and `pwd` before starting work."
+
+Quest-specific adaptation: prefer `pwd` plus `git branch --show-current 2>/dev/null || echo 'no git'` so the rule remains usable when `vcs_available == false`.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside the Quest repo this is trivial and complementary to hooks. It provides a human-readable policy reminder that matches daily branch-based development.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in execution can be non-git or detached from normal VCS assumptions. The rule still helps if phrased with graceful fallback to `pwd`-only behavior.
+
+### Conflicts and Required Adaptations
+This idea overlaps with policy-sprawl concerns in `ideas/2026-04-13-instruction-architecture.md`. The rule should land in the canonical execution-discipline section (or its pointer file), not as another untracked one-off line.
+
+## Actionable Steps
+1. Add an `Execution Discipline` subsection in `CLAUDE.md` (or canonical policy file) for pre-edit context checks.
+2. Use command text that is safe in non-git contexts: `pwd && (git branch --show-current 2>/dev/null || echo 'no git')`.
+3. Link this rule to the hook proposal to make policy + enforcement discoverable together.
+4. In Quest prompts for builder/reviewer roles, include a short reminder that pre-edit context confirmation is mandatory.
+
+## Cross-References
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`
+- `ideas/2026-04-13-instruction-architecture.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+
+## Risks / Non-Goals
+- Non-goal: policy text alone does not enforce behavior.
+- Risk: duplicating the same rule in multiple files increases drift.
+- Risk: strict wording without non-git fallback can produce false failures outside-in.
+
+## Success Signal
+Quest prompts and local workflow docs consistently include the pre-edit context command, and wrong-repo/branch incidents are materially reduced in follow-up evaluations.

--- a/ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md
+++ b/ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md
@@ -1,0 +1,49 @@
+---
+title: CLAUDE Rule - Never Dismiss Acceptance Criteria
+purpose: Codify strict acceptance-criteria adherence to prevent avoidable rework and reviewer pushback.
+audience:
+  - quest-developers
+  - quest-users
+scope: Completion-policy guardrail for acceptance criteria.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation cites a concrete failure where Claude dismissed a missing `--help` timeout requirement as "not worth fixing" even though it was explicit acceptance criteria. The same section also flags PR text that treated pytest commands as "manual validation," which caused reviewer pushback and rework.
+
+## Proposal
+Adopt the evaluation rule text as a hard policy:
+
+> "Never dismiss acceptance criteria as 'not worth fixing.' If the user specifies acceptance criteria, every item must be satisfied before considering the task complete."
+
+Quest-specific adaptation: echo this rule in role prompts (`builder.md`, `plan-reviewer.md`) so completion criteria are checked during execution and review, not only in global policy text.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+This aligns with existing Quest quality discipline. Plan and review phases already structure criteria; this rule clarifies that criteria are completion gates, not suggestions.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in workflows often encode acceptance criteria in issue text or PR comments. The same rule applies verbatim and prevents "partial done" outcomes.
+
+### Conflicts and Required Adaptations
+No direct conflict with existing hooks or skills. This is policy-only, but it should be tracked in `quest-policy-canonicalization-and-enforcement-roadmap.md` as a candidate for enforceable checks in prompts and review gates.
+
+## Actionable Steps
+1. Add the exact rule text to the canonical execution-discipline policy surface.
+2. Add matching reminder language to `.skills/quest/agents/builder.md`.
+3. Add matching reviewer checklist language to `.skills/quest/agents/plan-reviewer.md` and code-review roles.
+4. In PR-generation workflows, require that validation steps map directly to each listed acceptance criterion.
+
+## Cross-References
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+- `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md`
+- `ideas/2026-04-13-instruction-architecture.md`
+
+## Risks / Non-Goals
+- Non-goal: expanding scope beyond user-requested criteria.
+- Risk: rigid interpretation can block progress if criteria are ambiguous; prompts should require explicit assumptions instead of silent dismissal.
+- Risk: without enforcement hooks/checklists, the rule can still be skipped under pressure.
+
+## Success Signal
+No Quest completion is marked done while any explicit acceptance criterion remains unmet, and PR review feedback no longer flags criteria as ignored or reclassified as optional.

--- a/ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md
+++ b/ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md
@@ -1,0 +1,56 @@
+---
+title: PR Create Checklist via Existing PR Assistant
+purpose: Improve PR accuracy by extending the existing pr-assistant skill with a verification checklist mode.
+audience:
+  - quest-developers
+  - quest-users
+scope: PR creation workflow quality and validation discipline.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation documents repeated PR quality drift: wrong script names (`npm run server` vs `npm run dev:server`), incorrect file/test paths, and manual steps presented as automated validation. Given high PR volume (20 PR-management + 18 PR-shepherding sessions), these small errors compound into repeated review friction.
+
+## Proposal
+Use the evaluation's 7-step PR creation checklist, but apply it by extending existing `.skills/pr-assistant/SKILL.md` instead of creating a duplicate `/pr-create` skill:
+
+1. Run `pwd` and `git branch --show-current`
+2. Run `git status` (all staged)
+3. Run relevant test/lint commands
+4. `gh pr create`
+5. Verify PR description paths/script names/test commands against code
+6. Run each command listed in PR testing section
+7. Report PR URL
+
+Quest-specific adaptation: integrate this into current `pr-assistant` flow as "verification checklist mode" and align output with AGENTS readability-first review expectations.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+This is a direct enhancement to an existing skill and avoids workflow fragmentation. It also complements `AGENTS.md` PR review gate language (readability-first, KISS/YAGNI/SRP/DRY).
+
+### Outside-in use (Quest invoked from another repo)
+Quest typically runs outside-in; a single canonical `pr-assistant` with checklist mode travels better than introducing repo-specific duplicate commands. Checklist items remain valid across repos with only command substitutions.
+
+### Conflicts and Required Adaptations
+There is direct overlap with `.skills/pr-assistant/SKILL.md`. Resolution is additive extension (new checklist section or linked checklist doc), not new slash-command registration.
+
+## Actionable Steps
+1. Add a "Verification Checklist" subsection to `.skills/pr-assistant/SKILL.md`.
+2. Require branch/path confirmation and staged-file checks before PR creation.
+3. Add a dry-run subflow that executes each command listed in the PR `## Validation` section.
+4. Fail PR generation when listed commands do not run or do not match repository scripts/paths.
+5. Keep ownership in `pr-assistant`; do not introduce a parallel `/pr-create` skill.
+
+## Cross-References
+- `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md`
+- `ideas/2026-04-15-precommit-status-diffstat-discipline.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+
+## Risks / Non-Goals
+- Non-goal: replacing `pr-shepherd`; this is pre-submission quality control.
+- Risk: extra checks can slow very small PRs; use a compact checklist for low-diff changes.
+- Risk: duplicate checklist logic in multiple skills can drift; keep one canonical source in `pr-assistant`.
+
+## Success Signal
+PR descriptions consistently reference valid script names and paths, and commands in `## Validation` are executable and verified before PR submission.

--- a/ideas/2026-04-15-precommit-status-diffstat-discipline.md
+++ b/ideas/2026-04-15-precommit-status-diffstat-discipline.md
@@ -1,0 +1,49 @@
+---
+title: Pre-Commit Status and Diffstat Discipline
+purpose: Reduce missed files and staging mistakes by requiring explicit pre-commit status and diffstat checks.
+audience:
+  - quest-developers
+  - quest-users
+scope: Commit-readiness checks and bounded hook options.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation repeatedly notes forgotten unstaged files (including `.skills` and config changes) discovered late in the commit/PR flow. This creates avoidable rework and undermines confidence that PRs represent the full intended change set.
+
+## Proposal
+Adopt the evaluation rule verbatim as commit discipline:
+
+> "Before committing and pushing, run `git status` and `git diff --stat` to ensure ALL modified files are staged. Never assume only the files you edited are the ones that changed."
+
+Quest-specific adaptation: keep hook enforcement bounded. The evaluation's broad `PostToolUse Bash` diff hook is informative but likely too noisy if triggered on every bash call.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+This complements existing workflow expectations and catches accidental file drift before commit, especially in Quest docs/skill changes.
+
+### Outside-in use (Quest invoked from another repo)
+When `vcs_available == false`, the rule should degrade to a no-op with explicit note, not a hard failure. In git-backed repos, it remains fully applicable.
+
+### Conflicts and Required Adaptations
+`.skills/git-commit-assistant/SKILL.md` currently validates manifest + staged diff style, but does not explicitly require `git status` and `git diff --stat` checks for full working-tree awareness. This idea should extend that skill rather than adding parallel commit rules.
+
+## Actionable Steps
+1. Add explicit `git status` + `git diff --stat` checks to `.skills/git-commit-assistant/SKILL.md`.
+2. Add a pre-commit checklist item requiring "all expected files staged."
+3. If adding hook support, scope it to commit-adjacent commands (or dedicated pre-commit event) rather than all bash invocations.
+4. Add `vcs_available == false` fallback text so no-VCS workflows do not break.
+
+## Cross-References
+- `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md`
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+
+## Risks / Non-Goals
+- Non-goal: forcing all workflows to use hooks.
+- Risk: unbounded hooks produce alert fatigue and can be ignored.
+- Risk: strict gating without no-VCS fallback can block outside-in scenarios unnecessarily.
+
+## Success Signal
+Commit workflows consistently show full-file awareness before push, and follow-up sessions no longer report missing staged files as recurring friction.

--- a/ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md
+++ b/ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md
@@ -1,0 +1,61 @@
+---
+title: PreToolUse Branch/Directory Verification Hook
+purpose: Add a safe, additive hook pattern that surfaces branch and directory context before edits.
+audience:
+  - quest-developers
+  - quest-users
+scope: Hook-level observability guardrails for Edit/Write actions.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation identifies wrong-location edits as the top friction pattern (`Wrong Approach` = 55), with repeated incidents where changes landed in the wrong branch, wrong directory, or wrong nested Quest path. The report explicitly calls out that Codex sub-agents wrote to incorrect directories and forced recovery cycles.
+
+## Proposal
+Use the exact hook command from the evaluation before `Edit|Write` tool calls so branch/directory context is always visible:
+
+```json
+{
+  "matcher": "Edit|Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "echo '📍 Branch:' $(git branch --show-current) '| Dir:' $(pwd)"
+    }
+  ]
+}
+```
+
+Quest-specific adaptation: merge this additively into existing hooks and add non-git fallback behavior for outside-in runs where repository VCS is unavailable.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside this repo, branch and path are almost always available; printing both before writes directly targets the most frequent error class with minimal behavior change.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in sessions can run with `vcs_available == false` in `.skills/quest/delegation/workflow.md`, so `git branch --show-current` may fail. The hook should degrade safely (for example, `git branch --show-current 2>/dev/null || echo 'no git'`) while still printing `pwd`.
+
+### Conflicts and Required Adaptations
+`.claude/settings.json` already has `SessionStart` and a `PostToolUse` `Write|Edit` audit hook. This proposal must be an additive merge, not a replacement, to avoid stomping existing audit behavior.
+
+## Actionable Steps
+1. Inspect current hooks with `jq '.hooks' .claude/settings.json`.
+2. Add a `PreToolUse` entry for `Edit|Write` containing the evaluation command.
+3. Adapt the command to tolerate non-git workspaces using `2>/dev/null` fallback.
+4. Validate in two contexts: a git repo and a temporary non-git directory.
+5. Document the hook intent in `AGENTS.md` or a canonical policy pointer file so the rule is discoverable.
+
+## Cross-References
+- `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md`
+- `ideas/2026-04-15-subagent-path-constraints-hardening.md`
+- `ideas/2026-04-13-instruction-architecture.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+
+## Risks / Non-Goals
+- Non-goal: this does not guarantee correctness; it only improves context visibility.
+- Risk: noisy output can be ignored if overused, so the message should stay short and consistent.
+- Risk: overwriting `.claude/settings.json` hooks would regress existing audit logging.
+
+## Success Signal
+During edits, every `Edit|Write` action logs branch+directory context (or explicit `no git` fallback), and wrong-directory edits decrease in subsequent Quest sessions.

--- a/ideas/2026-04-15-subagent-path-constraints-hardening.md
+++ b/ideas/2026-04-15-subagent-path-constraints-hardening.md
@@ -1,0 +1,50 @@
+---
+title: Sub-Agent Path Constraints Hardening
+purpose: Harden existing Quest path controls by validating sub-agent artifact paths after execution.
+audience:
+  - quest-developers
+  - quest-users
+scope: Delegation safety and output-path compliance.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation highlights repeated sub-agent path failures: wrong directories, nested quest folders, and wiped workspace artifacts across high-volume agent usage (268 Agent invocations). These incidents were costly because errors were discovered after work completed, not at post-run validation time.
+
+## Proposal
+Use the evaluation guidance as a hardening extension:
+
+> "When spawning sub-agents or using quest workflows, explicitly pass the correct working directory and target file paths. Validate sub-agent output paths before accepting their work."
+
+Quest-specific adaptation: this is not net-new architecture. `.skills/quest/delegation/workflow.md` already references `expected_artifacts_for_role(...)` and `prepare_artifact_files(...)`; the gap is stronger post-invocation validation against on-disk results.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside this repo, hardening can reuse existing workflow contracts and add explicit verification before handoff acceptance. This lowers recovery effort when sub-agents misplace files.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in invocation still runs the same Quest delegation workflow. Path verification remains valid and should respect `vcs_available` mode differences (checks must be filesystem-based, not git-dependent).
+
+### Conflicts and Required Adaptations
+No structural conflict with current workflow. Required adaptation is additive: validate `handoff.json` artifact claims against actual filesystem paths and fail/flag mismatches before routing.
+
+## Actionable Steps
+1. Add a post-invocation validator (for example `scripts/quest_artifact_postflight.py`) that compares declared artifacts to on-disk files.
+2. Validate each declared path is within expected role path boundaries.
+3. Log mismatches to `.quest/<id>/logs/path_compliance.log` with phase, role, and offending path.
+4. Mark runs with mismatches as recoverable failure requiring retry or fallback before accepting agent output.
+5. Reference `expected_artifacts_for_role(...)` and `prepare_artifact_files(...)` directly in validator docs to avoid rule drift.
+
+## Cross-References
+- `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+- `ideas/handoff-validation-and-failure-ux.md`
+
+## Risks / Non-Goals
+- Non-goal: redesigning delegation architecture from scratch.
+- Risk: overly strict checks can reject valid edge-case outputs if path normalization is wrong.
+- Risk: adding validation without clear failure UX can increase confusion; tie into handoff diagnostics.
+
+## Success Signal
+Sub-agent runs that write outside expected paths are detected immediately, logged, and blocked from silent acceptance.

--- a/ideas/2026-04-15-tool-failure-two-attempt-cap.md
+++ b/ideas/2026-04-15-tool-failure-two-attempt-cap.md
@@ -1,0 +1,49 @@
+---
+title: Tool Failure Two-Attempt Cap
+purpose: Limit unproductive tool-internals investigation and prioritize fast limitation reporting.
+audience:
+  - quest-developers
+  - quest-users
+scope: Investigation-depth policy for failing tool/API calls.
+status: proposed
+owner: kjell
+---
+
+## Problem
+The evaluation identifies rabbit-holing as a major friction source, with repeated sessions spent exploring tool schemas or internals instead of executing requested work. This pattern was the second-largest frustration family after wrong-branch/path errors.
+
+## Proposal
+Adopt the rule text from the evaluation:
+
+> "When a tool or API call fails, do NOT spend more than 2 attempts investigating the tool's internals or source code. Instead, report the limitation clearly and ask the user how they'd like to proceed."
+
+Quest-specific adaptation: align this with existing workflow fallback behavior so "attempt cap" covers ad-hoc investigation loops not already bounded by Quest runtime ladders.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside Quest, this curbs deep dives into tooling internals during user tasks and keeps progress focused on deliverables.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in tasks often hit unfamiliar tools; this rule is more valuable there because unknown integrations can trigger long, low-value investigations.
+
+### Conflicts and Required Adaptations
+`.skills/quest/delegation/workflow.md` already has bounded retry/fallback ladders for handoff failures. This proposal is complementary and targets exploratory rabbit-holing outside those explicit fallback paths.
+
+## Actionable Steps
+1. Add the two-attempt cap language to canonical execution-discipline policy text.
+2. Add role prompt reminder: after second failed investigative attempt, produce a concise limitation report and next options.
+3. In long sessions, track attempt count in running notes to avoid silent cap violations.
+4. During review, treat "third+ internals attempt without escalation" as a process defect.
+
+## Cross-References
+- `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+- `ideas/2026-04-13-instruction-architecture.md`
+
+## Risks / Non-Goals
+- Non-goal: forbidding all debugging after two failures.
+- Risk: strict cap may stop too early on near-fixable issues; mitigation is clear escalation options, not unlimited investigation.
+- Risk: without instrumentation, cap violations may still happen silently.
+
+## Success Signal
+Failed-tool sessions either recover within two attempts or escalate clearly; long investigations into internals without user-visible progress become rare.

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -47,6 +47,19 @@ architecture docs.
 | `claude-cli-login-context.md` | reference | Operational note: external `claude` CLI login must be validated in the same execution context; an open app session is not enough. |
 | `codex_calls_claude.sh` | reference | Older experimental bash bridge prototype retained as a reference alongside the supported Python bridge. |
 
+### Execution Discipline and Observability
+| File | Status | Purpose |
+|---|---|---|
+| `2026-04-15-claude-insights-priorities.md` | proposed | Canonical Tier/Skip index mapping evaluation suggestions to sanity-checked Quest proposals. |
+| `2026-04-15-pretooluse-branch-dir-verification-hook.md` | proposed | Safe branch/directory verification hook strategy with non-git and existing-hook compatibility. |
+| `2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md` | proposed | CLAUDE.md context-confirmation rule to reduce wrong-repo/branch edits. |
+| `2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md` | proposed | Guardrail against rejecting explicit acceptance criteria as optional. |
+| `2026-04-15-pr-create-checklist-via-pr-assistant.md` | proposed | PR checklist workflow via existing `pr-assistant` to avoid duplicate skill drift. |
+| `2026-04-15-precommit-status-diffstat-discipline.md` | proposed | Pre-commit staging verification discipline with optional bounded hook. |
+| `2026-04-15-subagent-path-constraints-hardening.md` | proposed | Hardening plan for sub-agent path constraints and output-path validation. |
+| `2026-04-15-tool-failure-two-attempt-cap.md` | proposed | Two-attempt cap rule for failing tool investigations to limit rabbit-holing. |
+| `2026-04-15-autonomous-pr-shepherd-headless.md` | idea | Long-horizon autonomous PR shepherd design with strict safety boundaries. |
+
 ### Graduated
 | Idea | Destination |
 |---|---|


### PR DESCRIPTION
## Summary
Translate the 2026-04-15 Claude Code Insights evaluation into nine Quest-native idea proposals plus a master priorities index, preserving the user-authoritative Tier 1/2/3/Skip ranking verbatim, and sanity-checking every suggestion against Quest's inside-repo and outside-in usage modes.
- Documentation-only PR. No code, hooks, skills, or policy files were modified outside `ideas/` and `docs/quest-journal/`.
- Each idea documents what happens when `vcs_available == false`, when existing hooks in `.claude/settings.json` already occupy the matcher, and when the proposed capability already exists (e.g., `.skills/pr-assistant/`, `workflow.md` sub-agent artifact prep).

## Changes
- **Ideas — Tier 1 (execution discipline)**:
  - `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md` — safe branch/dir verification hook with non-git fallback and additive-merge requirement
  - `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md` — CLAUDE.md context-confirmation rule before any edit
  - `ideas/2026-04-15-claude-rule-never-dismiss-acceptance-criteria.md` — guardrail against dismissing user-stated AC as "not worth fixing"
- **Ideas — Tier 2 (compound returns)**:
  - `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md` — extend `.skills/pr-assistant/` with a verification checklist instead of introducing a duplicate `/pr-create` skill
  - `ideas/2026-04-15-precommit-status-diffstat-discipline.md` — pre-commit `git status` + `git diff --stat` rule with bounded (not every-Bash) hook option
  - `ideas/2026-04-15-subagent-path-constraints-hardening.md` — hardening plan that cites existing `expected_artifacts_for_role` / `prepare_artifact_files` and adds post-invocation path validation
- **Ideas — Tier 3 (higher investment)**:
  - `ideas/2026-04-15-tool-failure-two-attempt-cap.md` — two-attempt cap on tool-internals investigation before reporting to user
  - `ideas/2026-04-15-autonomous-pr-shepherd-headless.md` — staged, safety-first autonomous PR shepherd with a hard "never merge" boundary (depends on Tier 1-2 landing first)
- **Ideas — Master index**:
  - `ideas/2026-04-15-claude-insights-priorities.md` — canonical Tier/Skip map covering all 17 evaluation suggestions (CLAUDE.md x6, Hooks x2, Skills x1, Headless x2, Usage Patterns x3, Horizon x3) with explicit rejection reasons for parallel multi-repo orchestration, TDD bug-fix agent, and batch security scans
- **Documentation**:
  - `ideas/README.md` — new "Execution Discipline and Observability" section indexing the nine new files
  - `docs/quest-journal/claude-insights-ideas_2026-04-15.md` — quest journal entry (1 plan iteration, 0 fix iterations, Platinum tier, solo mode)
  - `docs/quest-journal/README.md` — index row for the new journal entry

## Validation
- [ ] **Read the master priorities index**: open `ideas/2026-04-15-claude-insights-priorities.md` and confirm the Tier 1 → Tier 2 → Tier 3 → Skip ordering matches the canonical ranking provided in the quest brief, and that every evaluation suggestion has either a Tier file pointer or a Skip reason.
- [ ] **Spot-check dual-mode coverage on a git-dependent idea**: open `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md` and confirm the `### Outside-in use (Quest invoked from another repo)` subsection explicitly addresses the `vcs_available == false` case (hook must not fail on non-git workspaces).
- [ ] **Confirm no duplicate skill proposal**: open `ideas/2026-04-15-pr-create-checklist-via-pr-assistant.md` and confirm it extends `.skills/pr-assistant/SKILL.md` rather than proposing a new `/pr-create` slash command.
- [ ] **Confirm scope boundary**: run `git diff main...HEAD --name-only` and confirm every path is under `ideas/` or `docs/quest-journal/`. No `.claude/`, `.skills/`, `AGENTS.md`, `scripts/`, or workflow files should appear.

Watch for: follow-up work is expected to be one PR per Tier item (hook, CLAUDE.md consolidation, `pr-assistant` checklist extension). This PR intentionally defers those implementations — every idea file is a proposal, not an implementation.

## Notes
- The user's Tier 1/2/3/Skip ranking was treated as authoritative throughout — refined wording is allowed, but no tier reordering or cross-tier swaps were made.
- `ideas/2026-04-15-autonomous-pr-shepherd-headless.md` is marked `idea` (not `proposed`) because it depends on Tier 1-2 guardrails landing first; the evaluation explicitly flagged the risk of amplifying current friction if shipped early.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Codex gpt-5.4 <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>