### PR TITLE
Fix quest journal briefs and archive backfill

### DIFF
--- a/.quest-manifest
+++ b/.quest-manifest
@@ -87,6 +87,7 @@ scripts/quest_celebrate/progress.py
 scripts/quest_celebrate/terminal.py
 scripts/quest_celebrate/quest_data.py
 scripts/quest_celebrate/quest-celebrate.sh
+scripts/backfill_quest_journal.py
 scripts/quest_complete.py
 scripts/quest_preflight.sh
 scripts/quest_state.py

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-04-16 | [quest-dashboard-briefs](quest-dashboard-briefs_2026-04-16.md) | Dashboard quest detail pages now include the brief and celebration context, and archived journal pages were backfill... |
 | 2026-04-15 | [claude-insights-ideas](claude-insights-ideas_2026-04-15.md) | > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-in... |
 | 2026-04-13 | [feedback-intent-routing](feedback-intent-routing_2026-04-13.md) | Consolidate the Quest routing and feedback-intent ideas into one canonical delegation proposal. Use `ideas/2026-04-13... |
 | 2026-04-13 | [prompt-surface-consolidation](prompt-surface-consolidation_2026-04-13.md) | > 3. Prompt Surface / Instruction Architecture > > Consolidate Quest prompt-surface improvement docs into one canonic... |

--- a/docs/quest-journal/caveman-review_2026-04-12.md
+++ b/docs/quest-journal/caveman-review_2026-04-12.md
@@ -34,9 +34,16 @@ Reviewed `.ws/caveman`, captured the useful learnings, and explicitly decided no
 
 - **The Implementer** (builder): 
 
-## This is where it all began...
+## Quest Brief
 
-> `$quest review .ws/caveman. I don't like the full caveman approach but I'm wondering if there are some learnings we can make here? create in .ws your findings, your opinion about their approach and...
+`$quest review .ws/caveman. I don't like the full caveman approach but I'm wondering if there are some learnings we can make here? create in .ws your findings, your opinion about their approach and your recommendation going forward`
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/caveman-review_2026-04-12.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/celebrate-v2_2026-03-05.md
+++ b/docs/quest-journal/celebrate-v2_2026-03-05.md
@@ -35,8 +35,83 @@
 - Plan iterations: 1
 - Fix iterations: 1 (3 issues: dead safe_mode branches, broad PR regex, duplicate data loading)
 
-## This is where it all began...
+## Quest Brief
 
-> The current quest_celebrate implementation is a stripped-down v1 that doesn't match the vision in ideas/quest-completion-animations.md. Rework the epic and silly renderers to deliver the full experience described in the idea file.
->
-> "Shipping should feel like a celebration, not a status update."
+The current quest_celebrate implementation is a stripped-down v1 that doesn't match the vision in ideas/quest-completion-animations.md. Rework the epic and silly renderers to deliver the full experience described in the idea file: big ASCII block-letter quest title, achievements unlocked section (dynamically generated from quest stats), impact metrics, quality score, full movie-style end credits with starring/crew/achievements/quote sections, and gremlin battle + retirement art.
+
+Additional requirements from user:
+- The celebration should dig into ALL quest artifacts: reviews, findings, handovers, the plan, what was achieved
+- Show what the plan was and what was accomplished
+- Show PR info if available — PR number, comments posted
+- Scrolling credits should be SLOWER than current implementation (more cinematic)
+- `epic` should be the default style (not `standard`)
+- `--quest-dir` required, everything else optional with sensible defaults
+- `--help` should show all options with clear descriptions of each style
+- Keep the existing config/terminal detection/safe-mode infrastructure, just make the output match the idea
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/celebrate-v2_2026-03-05.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 13 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 7 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 7"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 16
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/ci-quest-validation_2026-02-04.md
+++ b/docs/quest-journal/ci-quest-validation_2026-02-04.md
@@ -15,7 +15,7 @@ Implemented GitHub Actions CI and local pre-commit hooks that validate quest-rel
 - Role markdown completeness checking
 - Quest journal system (`docs/quest-journal/`)
 
-## This is where it all began... an idea
+## Quest Brief
 
 > # GitHub CI for Commit-Time Quest Validation
 >
@@ -35,3 +35,111 @@ Implemented GitHub Actions CI and local pre-commit hooks that validate quest-rel
 > - Schema validation for all JSON files in `.ai/`
 > - Markdown structure validation for role definitions
 > - Check that `.quest/` is properly gitignored
+
+### Archived Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Implement GitHub Actions CI and local pre-commit hooks that validate quest-related artifacts to prevent broken configurations from being committed.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/ci-quest-validation_2026-02-04.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "fixer",
+      "model": "",
+      "role": "The Bug Slayer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 7 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 3 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "7 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 3"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Bronze",
+    "grade": "B"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/ci-review-severity_2026-04-07.md
+++ b/docs/quest-journal/ci-review-severity_2026-04-07.md
@@ -33,9 +33,18 @@
 - **The Judge** (arbiter): 
 - **The Implementer** (builder): 
 
-## This is where it all began...
+## Quest Brief
 
-> User selection: full quest.
+```
+$quest review our ideas for CI improvements, see docs/security, docs/implementation any idea documents and this # Severity-Based Automated PR Review: Analysis and Adoption Plan
+```
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/ci-review-severity_2026-04-07.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/claude-insights-ideas_2026-04-15.md
+++ b/docs/quest-journal/claude-insights-ideas_2026-04-15.md
@@ -4,8 +4,7 @@
 - Completed: 2026-04-15
 - Mode: solo
 - Quality: Platinum
-- Outcome: > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-insights.md but it's not as visual)
-> create very clear, super technical ideas doc...
+- Outcome: Turned the Claude insights evaluation into sanity-checked technical idea documents with clear prioritization.
 
 ## What Shipped
 
@@ -43,10 +42,20 @@
 
 - **The Implementer** (builder): 
 
-## This is where it all began...
+## Quest Brief
 
-> > review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-insights.md but it's not as visual)
-> create very clear, super technical ideas doc...
+> review ~/Documents/Evaluations/2026-04-15-claude-insights.html (you can also see the markdown, 2026-04-15-claude-insights.md but it's not as visual)
+> create very clear, super technical ideas documents in the ideas folder and rank them in priority of what to try.
+>
+> Sanity check the suggestions, keeping in mind that Quest is used both inside the quest repo itself, but typically used in other repos (or outside other repos operating outside-in).
+> Let's create actionable, easy to understand steps. I believe the suggestions they have are almost verbatim what should be copied into the ideas but we need to sanity check it.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/claude-insights-ideas_2026-04-15.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/codex-led-claude-bridge-runtime-hardening_2026-03-09.md
+++ b/docs/quest-journal/codex-led-claude-bridge-runtime-hardening_2026-03-09.md
@@ -77,3 +77,140 @@ These should stop being operator instructions and become Quest-owned defaults:
 Do not solve this by writing longer user prompts or more operator checklists.
 
 That only hides the orchestration gap instead of fixing it.
+
+## Quest Brief
+
+Implement Codex-led Claude bridge runtime hardening as a solo quest.
+
+Primary context:
+- ideas/codex-led-claude-bridge-runtime-hardening.md
+
+Problem:
+- The Claude bridge works, but Codex-led Quest still does not "just work".
+- Operators still have to restate runtime rules in the prompt:
+  - run the bridge probe first
+  - use the correct Claude runner
+  - use bypassPermissions
+  - grant repo/quest access
+  - enforce non-interactive behavior
+  - prohibit needs_human
+  - use handoff.json polling
+  - use scripts/quest_state.py
+  - respect solo dispatch rules
+- We want those rules to become native Quest behavior.
+
+Goal:
+- Make Codex-led Quest dispatch Claude-designated roles through the native Quest Claude bridge/runtime path without prompt-level babysitting.
+- Make the runner own process waiting, handoff polling, timeout handling, and final status normalization.
+- Eliminate orchestrator wait-state narration like "the planner bridge call is still running".
+
+Required behavior:
+- Before the first Claude-designated role in a Codex-led quest, run scripts/quest_claude_probe.py automatically.
+- For Claude-designated roles in Codex-led runs, dispatch through scripts/quest_claude_runner.py.
+- scripts/claude_cli_bridge.py is the transport layer, not the orchestration entrypoint.
+- The runner must own:
+  - subprocess waiting
+  - handoff.json polling
+  - timeout handling
+  - auth / invocation failure normalization
+  - final structured status return
+- Codex should route from the runner result, not by ad hoc polling or process babysitting.
+- Claude bridge roles must run non-interactive by policy:
+  - no questions
+  - no needs_human
+  - explicit assumptions if context is incomplete
+- Solo mode should be mechanical:
+  - planner
+  - reviewer A
+  - builder
+  - no arbiter
+  - no reviewer B
+
+Implementation expectations:
+- Update Quest orchestration/runtime code and docs, not just prompts.
+- Prefer workflow- and script-owned defaults over operator instructions.
+- Preserve existing handoff.json contracts and context_health.log semantics.
+- Keep the scope focused on Codex-led Claude bridge runtime hardening.
+
+Suggested files to inspect first:
+- .skills/quest/delegation/workflow.md
+- .skills/quest/SKILL.md
+- .skills/quest/agents/*.md
+- scripts/quest_claude_probe.py
+- scripts/quest_claude_runner.py
+- scripts/quest_state.py
+- scripts/claude_cli_bridge.py
+- .ai/quest.md
+- docs/guides/codex-quest-install.md
+- ideas/codex-led-claude-bridge-runtime-hardening.md
+
+Acceptance criteria:
+- A Codex-led solo quest can run a trivial Claude-designated role without the operator restating bridge mechanics.
+- The bridge probe is automatic before first Claude dispatch.
+- Claude dispatch goes through scripts/quest_claude_runner.py automatically.
+- The runner returns a structured final result and owns waiting/polling.
+- Codex no longer improvises bridge wait-state narration.
+- runtime=claude is logged correctly for bridge-backed Claude roles.
+- Workflow/docs make this behavior explicit and native.
+- Native Claude execution remains unchanged for Claude/Opus-orchestrated quests.
+- The bridge runtime activates only when the orchestrator is Codex and the target role is Claude-designated.
+- Tests/documentation cover both host modes:
+  - Claude-led quest -> native Claude path
+  - Codex-led quest -> Claude bridge path
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/codex-led-claude-bridge-runtime-hardening_2026-03-09.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 1 reviews"
+    },
+    {
+      "icon": "[SOLO]",
+      "title": "Solo Adventurer",
+      "desc": "Completed quest with a single companion"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 1"
+    }
+  ],
+  "quality": {
+    "tier": "Abandoned",
+    "grade": "A"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 4
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/feedback-intent-routing_2026-04-13.md
+++ b/docs/quest-journal/feedback-intent-routing_2026-04-13.md
@@ -27,9 +27,16 @@
 
 - **The Implementer** (builder): 
 
-## This is where it all began...
+## Quest Brief
 
-> Consolidate the Quest routing and feedback-intent ideas into one canonical delegation proposal. Use `ideas/2026-04-13-feedback-aware-delegation-keywords.md` as the base and absorb the useful compan...
+Consolidate the Quest routing and feedback-intent ideas into one canonical delegation proposal. Use `ideas/2026-04-13-feedback-aware-delegation-keywords.md` as the base and absorb the useful companion material from `ideas/2026-04-13-intent-anchored-example-prompts.md` where it strengthens the proposal. The successor doc must clearly separate: 1) the problem with inert keyword metadata, 2) feedback-intent classification inside Quest loops, 3) supported intents and routing behavior, 4) low-risk companion improvements in skill authoring, and 5) rollout/guardrails. It must explicitly preserve these rules: start with cheap deterministic matching, keep the intent set small, default ambiguous cases to current behavior, announce surprising routing decisions to the user, and treat example prompts as a companion authoring aid rather than a primary runtime solution. This quest should only produce cleaned-up proposal docs, not implementation changes. Create a new successor document in `ideas/`, retire superseded working docs to `.ws/`, and update `ideas/README.md` plus in-doc cross-references.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/feedback-intent-routing_2026-04-13.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/handoff-contract-fix_2026-02-09.md
+++ b/docs/quest-journal/handoff-contract-fix_2026-02-09.md
@@ -44,7 +44,7 @@ This quest addressed inconsistencies discovered during the thin-orchestrator que
 - Codex-only subagent topology established (gpt-5.3-codex for all non-orchestrator agents)
 - Prepares for Phase 4 (role file elimination)
 
-## This is where it all began...
+## Quest Brief
 
 From the investigation that triggered this quest:
 
@@ -62,6 +62,10 @@ From `ideas/handoff-fix-plan.md`:
 > - No role file claims a JSON-only contract
 > - No "Context Is In Your Prompt" text that contradicts the thin orchestrator
 > - Claude Task tool prompts explicitly ask for the handoff
+
+### Archived Brief
+
+"implement plan ideas/handoff-fix-plan.md using only gpt-5.3-codex agents in all locations except the orchestrator"
 
 ## Iterations
 
@@ -93,3 +97,100 @@ This quest is transitional and Phase-4-compatible. Phase 4 will:
 - Keep only arbiter and quest-agent roles
 
 The handoff contract established here will be preserved when Phase 4 eliminates the role files.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/handoff-contract-fix_2026-02-09.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 9 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 3 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "6 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 3"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Bronze",
+    "grade": "B"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/installer-script_2026-02-04.md
+++ b/docs/quest-journal/installer-script_2026-02-04.md
@@ -54,7 +54,7 @@ Created a single unified installer script (`scripts/quest_installer.sh`) that in
 
 ---
 
-## This is where it all began...
+## Quest Brief
 
 > **ideas/installer-porter-script.md**
 >
@@ -69,8 +69,116 @@ Created a single unified installer script (`scripts/quest_installer.sh`) that in
 
 ---
 
+### Archived Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Idea file: `ideas/installer-porter-script.md`
+
 ## Artifacts
 
 - Quest folder: `.quest/installer-script_2026-02-04__1841/`
 - Plan: `.quest/installer-script_2026-02-04__1841/phase_01_plan/plan.md`
 - Reviews: `.quest/installer-script_2026-02-04__1841/phase_03_review/`
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/installer-script_2026-02-04.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 9 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "6 agents collaborated"
+    },
+    {
+      "icon": "[SOLO]",
+      "title": "Solo Adventurer",
+      "desc": "Completed quest with a single companion"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/interactive-plan-presentation_2026-02-04.md
+++ b/docs/quest-journal/interactive-plan-presentation_2026-02-04.md
@@ -27,3 +27,106 @@ Made the quest system more collaborative — users aren't surprised by what gets
 - Plan iterations: 2
 - Fix iterations: 3
 - Review verdict: Approved
+
+## Quest Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Enhance the quest orchestration system to provide an interactive plan presentation flow that gives users control over how much detail they see and allows them to provide feedback phase-by-phase.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/interactive-plan-presentation_2026-02-04.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 20 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 13 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "6 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 3"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 13"
+    }
+  ],
+  "quality": {
+    "tier": "Tin",
+    "grade": "T"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/multi-cleanup_2026-04-11.md
+++ b/docs/quest-journal/multi-cleanup_2026-04-11.md
@@ -34,9 +34,67 @@
 - **The Judge** (arbiter): 
 - **The Implementer** (builder): 
 
-## This is where it all began...
+## Quest Brief
 
-> Multi-cleanup quest. Continuing on our existing branch. fix/quest-startup-outside-repo. In ideas, we have several things that should be archived. Don't assume that they are done or not done based o...
+Multi-cleanup quest. Continuing on our existing branch. fix/quest-startup-outside-repo. In ideas, we have several things that should be archived. Don't assume that they are done or not done based on what it says in the idea. Actually look in the code and see if it's implemented or not.
+
+Anything that is fully implemented, let's archive it. Anything that is partially implemented, make sure to update the idea documents to make it clear: whatever is remaining, we can sanitize and look into it, whether or not we should actually do it, or if we could just archive them too.
+
+Second, in scripts, we have a bunch of scripts that are not prefixed with quest_. They should be prefixed with quest_. We need to make sure that we don't break when we do this change, since we are calling these scripts from multiple different places. We're installing them with our installer, and they're mentioned in our manifest. So we need to have super high assurance that when we're making this change, it's not breaking.
+
+When we're renaming this anything in the scripts repo to be quests_ as a prefix Then we also need to make sure that when we're running the installer on another repo, these scripts with the old names won't be lingering on. They are being replaced by these ones; we need to handle that scenario.
+
+And lastly, the third part of this script is as follows.
+
+Finish the outside-repo Quest support on branch `fix/quest-startup-outside-repo` in `/Users/kjell/ws/extra/quest`.
+
+Current state:
+- The branch has local commit `72e775d` (`fix: allow quest startup outside git repos`)
+- It is NOT merged or pushed
+- This was a one-off fix, not a Quest-run branch
+- Reviewer found a P1: startup now allows non-git workspaces, but later Quest workflow phases still unconditionally use git commands, so the path is broken end-to-end
+
+Review finding to address:
+- `scripts/quest_startup_branch.py` returns `status: "skipped"` outside git repos
+- But `.skills/quest/delegation/workflow.md` and related completion/review flow still depend on git (`git diff --name-only`, `git diff --stat`, `git diff --numstat`, etc.)
+- Before the patch, Quest blocked early; now it fails later after creating artifacts
+
+Goal:
+Make Quest work outside git repos end-to-end, because that is a common supported operation. Do not just revert to blocking unless you can prove full support is too large and you explain why.
+
+What to do:
+1. Audit the full Quest flow for unconditional git assumptions after startup, especially in:
+   - `.skills/quest/delegation/workflow.md`
+   - any scripts used for review/completion/status summaries
+   - any places that derive changed files/stats from git
+2. Add a proper non-git workspace path through the workflow.
+   - If needed, record an explicit capability/state flag in quest state/startup output
+   - Make later phases degrade gracefully when git is unavailable
+   - Ensure review/completion/reporting still work without repo git metadata
+3. Keep git-backed behavior unchanged for normal repo-based Quest runs
+4. Add/extend tests for the non-git path so this is pinned end-to-end, not just startup
+5. Run validation/tests:
+   - `bash tests/test-quest-runtime.sh`
+   - `bash scripts/validate-quest-config.sh`
+   - `bash scripts/validate-manifest.sh`
+
+Constraints:
+- Minimal focused change
+- No unrelated refactors
+- Don’t merge or push unless explicitly asked
+- If you conclude true end-to-end non-git support needs a broader design, stop and summarize exactly which workflow steps still require git and what the smallest safe follow-up plan is
+
+Deliver:
+- Code changes
+- Test results
+- Short summary of how non-git Quest now behaves
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/multi-cleanup_2026-04-11.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/opencode-model-suitability_2026-02-28.md
+++ b/docs/quest-journal/opencode-model-suitability_2026-02-28.md
@@ -40,3 +40,69 @@ Created comprehensive documentation (`docs/guides/opencode-model-suitability.md`
 ## Context Health
 
 See full report in quest logs. Overall handoff.json compliance: mixed due to agent output variance.
+
+## Quest Brief
+
+Create docs/guides/opencode-model-suitability.md that documents which models available in opencode (from 'opencode models' output) are suitable or unsuitable for each Quest orchestration role (orchestrator, planner, reviewer, arbiter, builder, fixer). For each model, web search/research its actual capabilities — run 'opencode models' to get the full list, then check publicly known benchmarks and characteristics relevant to each role's requirements. DO NOT USE EXA as it might not be available, if that's the case use other ways. See the role requirements on .skills/quest/agents/ definitions. Cross-reference with our testing observations in docs/guides/opencode-model-observations.md where available. Include a recommended default configuration and a budget-friendly free-tier configuration. The document should help future users pick the right model for each slot.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/opencode-model-suitability_2026-02-28.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "builder",
+      "model": "opencode/gpt-5.3-codex",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 1 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 2 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 2"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 7
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/phase4-role-wiring_2026-02-18.md
+++ b/docs/quest-journal/phase4-role-wiring_2026-02-18.md
@@ -43,3 +43,99 @@ Executed after relocation:
 
 - This journal entry records the shipped state and replaces draft planning text that was copied into earlier working notes.
 - Historical entries that reference old paths were not rewritten because they document earlier repository states.
+
+## Quest Brief
+
+`$quest implement ideas/phase4_plan_updated_by_kjell.md`
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/phase4-role-wiring_2026-02-18.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 7 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "5 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 25
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/pr-inline-commenting-playbook_2026-03-05.md
+++ b/docs/quest-journal/pr-inline-commenting-playbook_2026-03-05.md
@@ -19,7 +19,7 @@
 - Plan iterations: 1
 - Fix iterations: 0
 
-## This is where it all began...
+## Quest Brief
 
 > # PR Inline Commenting Playbook (Kind + Useful + Slightly Funny)
 >
@@ -77,3 +77,64 @@
 > `Nice improvement here. One small gremlin: <issue>. This can cause <impact>. Suggestion: <specific change>.`
 >
 > `- Reviewed by <model>, in collaboration with <github username>`
+
+### Archived Brief
+
+`/quest let's implement ideas/pr-inline-commenting-playbook.md`
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/pr-inline-commenting-playbook_2026-03-05.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 4 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 4"
+    }
+  ],
+  "quality": {
+    "tier": "Diamond",
+    "grade": "D"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 8
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/prompt-surface-consolidation_2026-04-13.md
+++ b/docs/quest-journal/prompt-surface-consolidation_2026-04-13.md
@@ -4,9 +4,7 @@
 - Completed: 2026-04-13
 - Mode: solo
 - Quality: Platinum
-- Outcome: > 3. Prompt Surface / Instruction Architecture
->
-> Consolidate Quest prompt-surface improvement docs into one canonical instruction architecture proposal. Merge `ideas/2026-04-13-focused-rule-packs...
+- Outcome: Consolidated overlapping Quest prompt-surface proposals into one canonical instruction architecture document.
 
 ## What Shipped
 
@@ -29,11 +27,35 @@
 - Plan iterations: 1
 - Fix iterations: 0
 
-## This is where it all began...
+## Quest Brief
 
-> > 3. Prompt Surface / Instruction Architecture
+> 3. Prompt Surface / Instruction Architecture
 >
-> Consolidate Quest prompt-surface improvement docs into one canonical instruction architecture proposal. Merge `ideas/2026-04-13-focused-rule-packs...
+> Consolidate Quest prompt-surface improvement docs into one canonical instruction architecture proposal. Merge `ideas/2026-04-13-focused-rule-packs.md` and `ideas/2026-04-13-orchestration-improvement-workflow.md` into a single successor doc, keeping the scope strictly at the proposal/documentation level. The merged doc must clearly separate:
+>
+> 1. selective rule-pack loading
+> 2. canonical ownership of policy families
+> 3. workflow-first skill structure
+> 4. prompt assembly/debugging model
+> 5. migration plan
+>
+> It must explicitly preserve these rules:
+> - this only matters if runtime prompt loading actually changes
+> - avoid pack explosion
+> - keep role wiring separate from policy packs
+> - use workflows as short executable recipes with entry/exit conditions
+> - prefer one medium-value coherent proposal over two overlapping documentation-shape ideas
+>
+> This quest should only produce cleaned-up proposal docs, not implementation changes. Create a new successor document in `ideas/`, retire superseded working docs to `.ws/`, and update `ideas/README.md` plus cross-references so nothing goes stale.
+>
+> Note: Other agents are working with other docs. Don't trip them up. If any document is missing then check the `.ws/` folder as it might have been moved there.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/prompt-surface-consolidation_2026-04-13.md`
 
 ## Celebration Data
 

--- a/docs/quest-journal/quest-completion-animations_2026-03-04.md
+++ b/docs/quest-journal/quest-completion-animations_2026-03-04.md
@@ -64,8 +64,74 @@ Environment variables: `QUEST_ANIMATIONS`, `QUEST_STYLE`, `QUEST_SPEED`, `QUEST_
 - Plan iterations: 1
 - Fix iterations: 1 (config path, CI speed override, TERM=dumb behavior)
 
-## This is where it all began...
+## Quest Brief
 
 > Make quest completion feel like an achievement, not just a checkbox. ASCII animations, progress bars, and end credits create memorable conclusions to multi-agent workflows.
 >
 > "Shipping should feel like a celebration, not a status update."
+
+### Archived Brief
+
+Implement `quest-completion-animations.md` - ASCII art animations and celebration displays for completed quests.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/quest-completion-animations_2026-03-04.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 4 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 4 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 4"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 5
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/quest-dashboard-briefs_2026-04-16.md
+++ b/docs/quest-journal/quest-dashboard-briefs_2026-04-16.md
@@ -1,0 +1,115 @@
+# Quest Journal: quest-dashboard-briefs
+
+- Quest ID: `quest-dashboard-briefs_2026-04-15__2048`
+- Completed: 2026-04-16
+- Mode: workflow
+- Quality: Tin
+- Outcome: Dashboard quest detail pages now include the brief and celebration context, and archived journal pages were backfilled safely.
+
+## What Shipped
+
+**Problem:** Dashboard quest cards already link the Quest ID to journal pages, but the linked journal content is too thin to explain what the quest actually took on. Current completion generation truncates the quest brief to a short quote, omits a reader-facing celebration section/link, and offer...
+
+## Files Changed
+
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_01_plan/plan.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_01_plan/arbiter_verdict.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_02_implementation/pr_description.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_03_review/review_code-reviewer-a.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_03_review/review_code-reviewer-b.md`
+- `.quest/quest-dashboard-briefs_2026-04-15__2048/phase_03_review/review_fix_feedback_discussion.md`
+
+## Iterations
+
+- Plan iterations: 1
+- Fix iterations: 3
+
+## Agents
+
+- **The Implementer** (builder): Codex
+- **The Bug Slayer** (fixer): Codex
+
+## Quest Brief
+
+```text
+$quest it seems our dashboard is broken. https://kjellkod.github.io/quest/ the quest ID links to a document that does not link or provide quest brief information, nor does that document link to the celebration either. example:https://github.com/KjellKod/quest/blob/main/docs/quest-journal/prompt-surface-consolidation_2026-04-13.md
+
+We want to achieve the following
+1. quests going forward has inside the quest id, or elsewhere information about the brief so people can actaully understand what was taken on. The initial prompt should be given in its entirety unless you think the brief is enough. 
+
+2. We need to scoure the .quest directory (~/ws/extra/quest/.quest) or just the linked directory here .quest) so we can look into the archive and patch things up with the needed information. 
+
+The dashboard is more than an insight into what was completed. It should be a guide to the insight into what was achived and we can do that best by sharing the brief the the celebration document. 
+
+Visually the dashboard page is not needed ot change
+```
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/quest-dashboard-briefs_2026-04-16.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "builder",
+      "model": "gpt-5.4",
+      "role": "The Implementer"
+    },
+    {
+      "name": "fixer",
+      "model": "gpt-5.4",
+      "role": "The Bug Slayer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 7 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 3"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Tin",
+    "grade": "T"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 9
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md
+++ b/docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md
@@ -27,9 +27,18 @@
 - Plan iterations: 1
 - Fix iterations: 0
 
-## This is where it all began...
+## Quest Brief
 
-> "take a look at the .quests and take a look at archived quests and took a look at our portfolio dashboard, did we archive things that didn't get into the dashboard?"
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Forensic sweep of stale quests, missing journal entries, broken archive/celebration automation, and a Codex sandbox permission footgun. Archive completed quests, backfill journals for 10 invisible PRs, fix sandbox_permissions on all Codex reviewer/fixer invocations, and automate Step 7 completion flow with a new script.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/quest-housekeeping-blitz_2026-03-21.md`
 
 ## Celebration Data
 
@@ -37,29 +46,40 @@
 ```json
 {
   "quest_mode": "solo",
-  "agents": [
-    {"name": "claude-opus-4.6", "model": "claude-opus-4-6", "role": "The Investigator & Fixer"}
-  ],
+  "agents": [],
   "achievements": [
-    {"icon": "🕵️", "title": "Archaeology Badge", "desc": "Excavated 8 orphaned quests from .quest/ graveyard"},
-    {"icon": "📝", "title": "Journal Scribe", "desc": "Wrote 7 journal entries covering 10 invisible PRs"},
-    {"icon": "🔓", "title": "Permission Exorcist", "desc": "Found missing sandbox_permissions across 5 Codex invocations"},
-    {"icon": "🤖", "title": "Automation Bootstrapper", "desc": "Built quest_complete.py to replace manual Step 7"},
-    {"icon": "🎯", "title": "Root Cause Triple", "desc": "Diagnosed 3 separate issues in one session"}
+    {
+      "icon": "[SOLO]",
+      "title": "Solo Adventurer",
+      "desc": "Completed quest with a single companion"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
   ],
   "metrics": [
-    {"icon": "📊", "label": "Dashboard: 23 to 37 quests"},
-    {"icon": "🧹", "label": "8 orphaned quests archived"},
-    {"icon": "🔧", "label": "5 Codex invocations patched"},
-    {"icon": "📝", "label": "7 journal entries backfilled"}
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 0"
+    }
   ],
   "quality": {
-    "tier": "Gold",
-    "grade": "B"
+    "tier": "Diamond",
+    "grade": "D"
   },
   "test_count": null,
   "tests_added": null,
-  "files_changed": 12
+  "files_changed": 0
 }
 ```
 <!-- celebration-data-end -->

--- a/docs/quest-journal/skill-strategy_2026-02-09.md
+++ b/docs/quest-journal/skill-strategy_2026-02-09.md
@@ -20,3 +20,55 @@ Analyzed how Quest should organize, manage, and distribute skills. Researched co
 ## Artifacts
 
 - Analysis: `.quest/skill-strategy_2026-02-09__1200/phase_01_plan/plan.md`
+
+## Quest Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Analyze how Quest should organize, manage, and distribute skills and customizations. Determine best practices for a drop-in AI orchestration tool that accumulates skills over time.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/skill-strategy_2026-02-09.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [],
+  "achievements": [
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 0"
+    }
+  ],
+  "quality": {
+    "tier": "Diamond",
+    "grade": "D"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/thin-orchestrator_2026-02-09.md
+++ b/docs/quest-journal/thin-orchestrator_2026-02-09.md
@@ -47,7 +47,7 @@ ideas/quest-philosophy-small-core/salvaged-scripts/quest_validate_handoff.py
 - Subagents do targeted file reads based on quest context
 - Prepares for Phase 3 (state validation) and Phase 4 (role consolidation)
 
-## This is where it all began...
+## Quest Brief
 
 From `ideas/quest-architecture-evolution.md`:
 
@@ -56,6 +56,12 @@ From `ideas/quest-architecture-evolution.md`:
 > **Problem:** The orchestrator's context grows with every phase. It accumulates quest briefs, plans, reviews, verdicts, build output, fix details. By the fix loop, the main session is bloated.
 >
 > **Solution:** After each subagent returns, the orchestrator extracts ONE line (the SUMMARY from the handoff) and the artifact path. Nothing else enters the orchestrator's context.
+
+### Archived Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Phase 2 of `ideas/quest-architecture-evolution.md`
 
 ## Iterations
 
@@ -69,3 +75,95 @@ This quest completed Phase 2 of the architecture evolution. Remaining phases:
 - Phase 3: State validation and contracts
 - Phase 4: Role consolidation (collapse 1:1 skills/roles)
 - Phase 5: External agent integration
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/thin-orchestrator_2026-02-09.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 13 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "6 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/validate-and-launch_2026-02-04.md
+++ b/docs/quest-journal/validate-and-launch_2026-02-04.md
@@ -28,3 +28,106 @@ This quest proved the system works end-to-end in its new standalone home. The id
 - Plan iterations: 1
 - Fix iterations: 1
 - Review verdict: Approved
+
+## Quest Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Validate that the Quest blueprint was correctly extracted from the source repository, create infrastructure for tracking future ideas, update the README with public domain messaging, and prepare the repository for public use.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/validate-and-launch_2026-02-04.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "plan-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "fixer",
+      "model": "",
+      "role": "The Bug Slayer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    },
+    {
+      "name": "code-reviewer-b",
+      "model": "openai/gpt-5.3-codex",
+      "role": "The B Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 6 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 4 reviews"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "7 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 4"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/docs/quest-journal/weekly-update-check_2026-02-05.md
+++ b/docs/quest-journal/weekly-update-check_2026-02-05.md
@@ -29,7 +29,7 @@ Implemented automatic weekly update checking for Quest. After a quest completes,
 - [x] AC7: `.quest-last-check` added to `.gitignore`
 - [x] AC8: Idea file status updated to `implemented`
 
-## This is where it all began...
+## Quest Brief
 
 > **From `ideas/weekly-update-check.md`:**
 >
@@ -41,8 +41,101 @@ Implemented automatic weekly update checking for Quest. After a quest completes,
 > - Opt-in update: user decides whether to apply
 > - "Set it and forget it" experience for adopters
 
+### Archived Brief
+
+Full original prompt was not recorded for this quest. This is the best available brief context.
+
+Implement automatic weekly update checking for Quest that notifies users when updates are available after a quest completes.
+
 ## Artifacts
 
 - Plan: `.quest/weekly-update-check_2026-02-04__2349/phase_01_plan/plan.md`
 - Reviews: `.quest/weekly-update-check_2026-02-04__2349/phase_01_plan/review_claude.md`
 - Code Review: `.quest/weekly-update-check_2026-02-04__2349/phase_03_review/review_claude.md`
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/weekly-update-check_2026-02-05.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "unknown",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "anthropic/claude-opus",
+      "role": "The A Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 4 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 2 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[TEAM]",
+      "title": "Full Squad",
+      "desc": "4 agents collaborated"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 2"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 0
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-04-13-review-intelligence-canonical.md
+++ b/ideas/2026-04-13-review-intelligence-canonical.md
@@ -1,6 +1,96 @@
 # Quest Review Intelligence Canonical Proposal
 
-## Status: proposed
+## Status: in-progress
+
+## Quest Prompt (Phase 1 -- Ready to Execute)
+
+This expanded prompt supersedes the original Quest 1 suggestion at the bottom of this document.
+It adds the deferred-findings backlog and planner-startup scan discussed during prioritization.
+
+```text
+/quest "Implement Phase 1 of review-intelligence-canonical: normalize review
+findings and add a review-decisions stage between review and fixer.
+
+Reference: ideas/2026-04-13-review-intelligence-canonical.md
+
+DELIVERABLES
+
+1. Canonical review_findings.json schema (reference Section 1). One JSON shape
+   plus a validator. Written to
+   .quest/<id>/phase_01_plan/review_findings.json and
+   .quest/<id>/phase_03_review/review_findings.json. Required fields:
+   finding_id, source, kind, severity, confidence, path, line, summary,
+   why_it_matters, evidence, action, needs_test, write_scope,
+   related_acceptance_criteria.
+
+2. review_backlog.json artifact (reference Section 2) produced by the arbiter
+   after dual review. Records one decision per finding from the allowed set:
+   fix_now, verify_first, defer, drop, needs_human_decision. Each entry
+   includes decision_confidence, reason, needs_validation, owner, batch. The
+   fixer receives only fix_now and verify_first items.
+
+3. Reusable .skills/review-decisions/SKILL.md so the Quest arbiter and
+   pr-shepherd share one decision policy. Encodes the default decision rules
+   from reference Section 2.
+
+4. Bounded review-loop rules (reference Section 4): 2 iterations default,
+   3 max. At cap, every remaining finding MUST be tagged defer,
+   needs_human_decision, or accepted debt. No silent looping.
+
+5. Deferred findings backlog at .quest/backlog/deferred_findings.jsonl
+   (repo-level, NOT per-quest). On a defer decision, the arbiter appends a
+   record that inherits the canonical finding schema plus four lineage
+   fields: deferred_by_quest, deferred_at (ISO8601), defer_reason,
+   proposed_followup. Append-only JSONL.
+
+6. Planner-startup backlog scan. Before planning, the planner reads
+   deferred_findings.jsonl and surfaces any entry whose write_scope
+   intersects the upcoming quest's likely scope. Present to the user as:
+   'N deferred findings touch this code -- pull into scope?' Use
+   conservative matching in v1 (exact path match only).
+
+7. Focused tests under tests/ covering: finding-schema validation (valid /
+   missing required fields / wrong types), decision-rule selection,
+   merge-and-dedupe across sources, JSONL append correctness, planner
+   backlog-scan match logic.
+
+INTEGRATION TOUCHPOINTS
+
+- .skills/quest/agents/arbiter.md -- require arbiter_backlog.json output
+  alongside arbiter_verdict.md
+- .skills/quest/agents/code-reviewer.md -- emit findings in the canonical
+  schema
+- .skills/quest/agents/planner.md -- add the backlog-scan step to planner
+  startup
+- .skills/quest/delegation/workflow.md -- document the decisions stage and
+  the loop caps
+- Validators live under scripts/ and are invoked from phase-transition
+  checks
+
+OUT OF SCOPE (explicit)
+
+- Memory retrieval (ideas/2026-04-13-quest-memory-architecture.md)
+- CI workflow changes (reference Phase 3)
+- Targeted validation / test selector (reference Phase 2)
+- pr-shepherd batching rules (reference Phase 2)
+- Backlog staleness / retention sweeps (follow-up chore)
+- Triage tooling for the backlog
+
+KILL CRITERIA (from reference doc)
+
+Roll back if reviewers emit more structured data but decisions do not
+improve; if fix loops grow in iteration count without reducing escaped
+issues; if test selection always escalates to full suite.
+
+Ship one coherent bundle: schema + decisions + deferred backlog + planner
+scan. Do not expand into memory, CI, or pr-shepherd batching in this quest."
+```
+
+### What this prompt adds beyond the original Quest 1
+
+- **Item 5 (deferred backlog file)** -- makes `defer` a real decision with a persistent home, not a dead-letter category
+- **Item 6 (planner backlog scan)** -- closes the feedback loop so deferred items resurface opportunistically when we're already touching that code
+- **Explicit kill criteria and out-of-scope sections** -- prevents scope creep into Phase 2/3
 
 ## Why this note exists
 
@@ -454,9 +544,7 @@ Do not keep any part of this if it causes one of these:
 
 ### Quest 1: finding contract and review decisions
 
-```text
-/quest "Implement review finding normalization and review decisions for Quest. Add a canonical review_findings.json contract, a review_backlog.json artifact, and a bounded review-decision stage between review and fixer. In Quest review phases, make arbiter own review-decision output. In PR and CI response flows, make pr-shepherd reuse the same review-decision rules. Add a reusable .skills/review-decisions/SKILL.md policy file, validators, and focused tests. Keep scope limited to artifact generation, merge/dedupe, decisions, and handoff integration. Do not add memory retrieval in this quest."
-```
+**Superseded** -- see expanded prompt at top of this document under "Quest Prompt (Phase 1 -- Ready to Execute)". The expanded version adds deferred-findings backlog (item 5), planner-startup scan (item 6), and explicit scope/kill-criteria sections.
 
 ### Quest 2: targeted validation and PR shepherd batching
 

--- a/scripts/backfill_quest_journal.py
+++ b/scripts/backfill_quest_journal.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Backfill existing quest journal pages from archived quest artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+try:
+    from quest_celebrate.quest_data import extract_metadata_value, load_quest_data
+    from quest_complete import (
+        build_celebration_data_section,
+        build_celebration_section,
+        build_quest_brief_section,
+    )
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from quest_celebrate.quest_data import extract_metadata_value, load_quest_data
+    from quest_complete import (
+        build_celebration_data_section,
+        build_celebration_section,
+        build_quest_brief_section,
+    )
+
+
+UTC = timezone.utc
+
+
+def _find_repo_root(start: Path) -> Path:
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "docs" / "quest-journal").exists() and (candidate / ".quest").exists():
+            return candidate
+    raise FileNotFoundError(f"Could not find repo root above {start}")
+
+
+def _extract_journal_quest_id(journal_path: Path) -> str | None:
+    return extract_metadata_value(journal_path.read_text(encoding="utf-8"), "quest id")
+
+
+def _extract_journal_completed_date(journal_path: Path) -> date | None:
+    content = journal_path.read_text(encoding="utf-8")
+    completed = extract_metadata_value(content, "completed") or extract_metadata_value(content, "date")
+    if completed:
+        try:
+            return date.fromisoformat(completed[:10])
+        except ValueError:
+            pass
+
+    match = re.search(r"(\d{4})-(\d{2})-(\d{2})", journal_path.name)
+    if match:
+        try:
+            return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        except ValueError:
+            return None
+    return None
+
+
+def _archive_completion_date(archive_dir: Path) -> date:
+    data = load_quest_data(archive_dir)
+    for value in (data.updated_at, data.created_at):
+        if not value:
+            continue
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC).date()
+        except ValueError:
+            continue
+    return datetime.now(UTC).date()
+
+
+def _find_matching_journal(
+    archive_dir: Path,
+    journal_dir: Path,
+    journal_by_quest_id: dict[str, Path],
+    duplicate_quest_ids: set[str],
+) -> tuple[Path | None, str | None]:
+    data = load_quest_data(archive_dir)
+    if not data.quest_id:
+        return None, f"{archive_dir.name}: missing quest_id in archive data"
+
+    if data.quest_id in duplicate_quest_ids:
+        return None, f"{archive_dir.name}: duplicate Quest ID match in journal entries"
+
+    if data.quest_id in journal_by_quest_id:
+        return journal_by_quest_id[data.quest_id], None
+
+    completion_date = _archive_completion_date(archive_dir).isoformat()
+    fallback_candidates = sorted(journal_dir.glob(f"{data.slug}_{completion_date}*.md"))
+    if len(fallback_candidates) > 1:
+        return None, (
+            f"{archive_dir.name}: ambiguous slug/date fallback "
+            f"({', '.join(path.name for path in fallback_candidates)})"
+        )
+    if len(fallback_candidates) == 1:
+        return fallback_candidates[0], None
+
+    return None, f"{archive_dir.name}: no matching journal entry found"
+
+
+def _replace_or_insert_section(
+    content: str,
+    heading_patterns: tuple[str, ...],
+    replacement: str,
+    *,
+    before_patterns: tuple[str, ...] = (),
+) -> str:
+    compiled = [
+        re.compile(
+            rf"(?ms)^##\s+(?:{pattern})\s*$.*?(?=^##\s+|\Z)",
+            re.IGNORECASE,
+        )
+        for pattern in heading_patterns
+    ]
+    for pattern in compiled:
+        if pattern.search(content):
+            return pattern.sub(replacement.rstrip() + "\n\n", content, count=1)
+
+    for before_pattern in before_patterns:
+        match = re.search(
+            rf"(?m)^##\s+(?:{before_pattern})\s*$",
+            content,
+            re.IGNORECASE,
+        )
+        if match:
+            return content[: match.start()] + replacement.rstrip() + "\n\n" + content[match.start() :]
+
+    if content and not content.endswith("\n"):
+        content += "\n"
+    return content.rstrip() + "\n\n" + replacement.rstrip() + "\n"
+
+
+def _extract_section_block(content: str, heading_patterns: tuple[str, ...]) -> str | None:
+    for heading_pattern in heading_patterns:
+        match = re.search(
+            rf"(?ms)^##\s+(?:{heading_pattern})\s*$.*?(?=^##\s+|\Z)",
+            content,
+            re.IGNORECASE,
+        )
+        if match:
+            return match.group(0).rstrip()
+    return None
+
+
+def _section_body(section: str) -> str:
+    lines = section.splitlines()
+    if len(lines) <= 1:
+        return ""
+    return "\n".join(lines[1:]).strip()
+
+
+def _normalize_section_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def _preferred_brief_section(content: str, generated_section: str) -> str:
+    existing_section = _extract_section_block(
+        content,
+        ("Quest Brief", r"This is where it all began[^\n]*"),
+    )
+    if not existing_section:
+        return generated_section
+
+    existing_body = _section_body(existing_section)
+    generated_body = _section_body(generated_section)
+    if not existing_body:
+        return generated_section
+    if not generated_body:
+        return "## Quest Brief\n\n" + existing_body.strip() + "\n"
+
+    existing_normalized = _normalize_section_text(existing_body)
+    generated_normalized = _normalize_section_text(generated_body)
+    if len(existing_normalized) <= len(generated_normalized):
+        return generated_section
+
+    if generated_normalized and generated_normalized not in existing_normalized:
+        return (
+            "## Quest Brief\n\n"
+            + existing_body.strip()
+            + "\n\n### Archived Brief\n\n"
+            + generated_body.strip()
+            + "\n"
+        )
+
+    return "## Quest Brief\n\n" + existing_body.strip() + "\n"
+
+
+def _patch_journal_content(content: str, archive_dir: Path, repo_root: Path, journal_path: Path) -> str:
+    data = load_quest_data(archive_dir)
+    journal_rel_path = journal_path.relative_to(repo_root)
+
+    quest_brief_section = build_quest_brief_section(data)
+    if quest_brief_section:
+        quest_brief_section = _preferred_brief_section(content, quest_brief_section)
+        content = _replace_or_insert_section(
+            content,
+            ("Quest Brief", r"This is where it all began[^\n]*"),
+            quest_brief_section,
+            before_patterns=("Celebration", "Celebration Data"),
+        )
+
+    celebration_section = build_celebration_section(journal_rel_path)
+    if celebration_section:
+        content = _replace_or_insert_section(
+            content,
+            ("Celebration",),
+            celebration_section,
+            before_patterns=("Celebration Data",),
+        )
+
+    content = _replace_or_insert_section(
+        content,
+        ("Celebration Data",),
+        build_celebration_data_section(data),
+    )
+
+    return content.rstrip() + "\n"
+
+
+def backfill_journal_entries(
+    repo_root: Path,
+    quest_id: str | None = None,
+    write: bool = True,
+) -> dict[str, object]:
+    """Patch existing journal pages from archive quests."""
+    journal_dir = repo_root / "docs" / "quest-journal"
+    archive_root = repo_root / ".quest" / "archive"
+    if not archive_root.is_dir():
+        return {
+            "patched": [],
+            "unchanged": [],
+            "skipped": [],
+        }
+
+    journal_paths = [path for path in sorted(journal_dir.glob("*.md")) if path.name != "README.md"]
+    journal_by_quest_id: dict[str, Path] = {}
+    duplicate_quest_ids: set[str] = set()
+    for journal_path in journal_paths:
+        journal_quest_id = _extract_journal_quest_id(journal_path)
+        if journal_quest_id:
+            if journal_quest_id in journal_by_quest_id:
+                duplicate_quest_ids.add(journal_quest_id)
+                journal_by_quest_id.pop(journal_quest_id, None)
+                continue
+            journal_by_quest_id[journal_quest_id] = journal_path
+
+    archive_dirs = sorted(path for path in archive_root.iterdir() if path.is_dir())
+    if quest_id:
+        archive_dirs = [path for path in archive_dirs if path.name == quest_id]
+
+    patched: list[str] = []
+    unchanged: list[str] = []
+    skipped: list[str] = []
+
+    for archive_dir in archive_dirs:
+        journal_path, warning = _find_matching_journal(
+            archive_dir,
+            journal_dir,
+            journal_by_quest_id,
+            duplicate_quest_ids,
+        )
+        if warning:
+            skipped.append(warning)
+            continue
+
+        if journal_path is None:
+            skipped.append(f"{archive_dir.name}: matching journal path missing unexpectedly")
+            continue
+        existing = journal_path.read_text(encoding="utf-8")
+        rendered = _patch_journal_content(existing, archive_dir, repo_root, journal_path)
+
+        if existing == rendered:
+            unchanged.append(journal_path.name)
+            continue
+
+        if write:
+            journal_path.write_text(rendered, encoding="utf-8")
+        patched.append(journal_path.name)
+
+    return {
+        "patched": patched,
+        "unchanged": unchanged,
+        "skipped": skipped,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backfill quest journal pages from archived quests")
+    parser.add_argument("--repo-root", default=".", help="Repository root (default: current directory)")
+    parser.add_argument("--quest-id", default=None, help="Only backfill one archived quest ID")
+    parser.add_argument("--dry-run", action="store_true", help="Report changes without writing files")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = _find_repo_root(Path(args.repo_root))
+    result = backfill_journal_entries(repo_root, quest_id=args.quest_id, write=not args.dry_run)
+
+    print(f"Patched: {len(result['patched'])}")
+    for path in result["patched"]:
+        print(f"  patched: {path}")
+
+    print(f"Unchanged: {len(result['unchanged'])}")
+    for path in result["unchanged"]:
+        print(f"  unchanged: {path}")
+
+    print(f"Skipped: {len(result['skipped'])}")
+    for warning in result["skipped"]:
+        print(f"  skipped: {warning}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_quest_journal.py
+++ b/scripts/backfill_quest_journal.py
@@ -59,7 +59,7 @@ def _extract_journal_completed_date(journal_path: Path) -> date | None:
     return None
 
 
-def _archive_completion_date(archive_dir: Path) -> date:
+def _archive_completion_date(archive_dir: Path) -> date | None:
     data = load_quest_data(archive_dir)
     for value in (data.updated_at, data.created_at):
         if not value:
@@ -68,7 +68,7 @@ def _archive_completion_date(archive_dir: Path) -> date:
             return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC).date()
         except ValueError:
             continue
-    return datetime.now(UTC).date()
+    return None
 
 
 def _find_matching_journal(
@@ -87,8 +87,12 @@ def _find_matching_journal(
     if data.quest_id in journal_by_quest_id:
         return journal_by_quest_id[data.quest_id], None
 
-    completion_date = _archive_completion_date(archive_dir).isoformat()
-    fallback_candidates = sorted(journal_dir.glob(f"{data.slug}_{completion_date}*.md"))
+    completion_date = _archive_completion_date(archive_dir)
+    if completion_date is None:
+        return None, f"{archive_dir.name}: missing or invalid completion date; cannot use slug/date fallback"
+
+    completion_date_str = completion_date.isoformat()
+    fallback_candidates = sorted(journal_dir.glob(f"{data.slug}_{completion_date_str}*.md"))
     if len(fallback_candidates) > 1:
         return None, (
             f"{archive_dir.name}: ambiguous slug/date fallback "

--- a/scripts/quest_celebrate/quest_data.py
+++ b/scripts/quest_celebrate/quest_data.py
@@ -6,6 +6,8 @@ try/except for graceful degradation -- missing or malformed files produce
 empty defaults, never crashes.
 """
 
+from __future__ import annotations
+
 import json
 import re
 from dataclasses import dataclass, field
@@ -52,6 +54,8 @@ class QuestData:
 
     # From quest_brief.md
     brief_summary: str = ""
+    brief_body: str = ""
+    brief_source: str = ""
 
     # From plan.md
     plan_summary: str = ""
@@ -172,18 +176,15 @@ def _read_state_json(quest_dir: Path) -> dict:
         return {}
 
 
-def _read_quest_brief(quest_dir: Path) -> Tuple[str, str]:
-    """Extract name and summary from quest_brief.md.
-
-    Returns (name, summary). Falls back to empty strings.
-    """
+def _read_quest_brief(quest_dir: Path) -> Tuple[str, str, str, str]:
+    """Extract name, summary, full body, and source from quest_brief.md."""
     brief_path = quest_dir / "quest_brief.md"
     if not brief_path.exists():
-        return "", ""
+        return "", "", "", ""
     try:
         text = brief_path.read_text(encoding="utf-8")
     except IOError:
-        return "", ""
+        return "", "", "", ""
 
     name = ""
     # Try "# Quest Brief: <title>"
@@ -196,24 +197,74 @@ def _read_quest_brief(quest_dir: Path) -> Tuple[str, str]:
         if heading_match:
             name = heading_match.group(1).strip()
 
-    # Extract summary: look for "## User Input" section, or first paragraph
-    summary = ""
-    user_input_match = re.search(
-        r"## User Input\s*\n+(.+?)(?:\n\n|\n##|\Z)", text, re.DOTALL
+    def extract_section(heading_patterns: tuple[str, ...]) -> str:
+        for heading_pattern in heading_patterns:
+            match = re.search(
+                rf"{heading_pattern}\s*\n+(.+?)(?=^##\s+|\Z)",
+                text,
+                re.IGNORECASE | re.MULTILINE | re.DOTALL,
+            )
+            if match:
+                section = match.group(1).strip()
+                if section:
+                    return section
+        return ""
+
+    def first_level_two_section() -> str:
+        matches = list(re.finditer(r"^##\s+(.+?)\s*$", text, re.MULTILINE))
+        for idx, match in enumerate(matches):
+            heading = match.group(1).strip().lower()
+            if heading == "router classification":
+                continue
+            start = match.end()
+            end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+            section = text[start:end].strip()
+            if section:
+                return section
+        return ""
+
+    def summarize(markdown: str) -> str:
+        cleaned_lines: list[str] = []
+        in_code_block = False
+        for raw_line in markdown.splitlines():
+            stripped = raw_line.strip()
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+            if in_code_block:
+                continue
+            stripped = re.sub(r"^\s*>\s?", "", stripped)
+            if stripped:
+                cleaned_lines.append(stripped)
+        summary = re.sub(r"\s+", " ", " ".join(cleaned_lines)).strip()
+        if len(summary) > 200:
+            summary = summary[:197] + "..."
+        return summary
+
+    brief_body = extract_section(
+        (
+            r"^##\s+User Input(?:\s+\(Original Prompt\))?\s*$",
+            r"^##\s+User Request\s*$",
+            r"^##\s+Original User Input\s*$",
+            r"^##\s+Original Request\s*$",
+        )
     )
-    if user_input_match:
-        summary = user_input_match.group(1).strip()
-    else:
-        # First non-heading paragraph
+    brief_source = "original_prompt" if brief_body else ""
+
+    if not brief_body:
+        brief_body = first_level_two_section()
+        if brief_body:
+            brief_source = "brief_section"
+
+    if not brief_body:
         para_match = re.search(r"\n\n([^#\n].+?)(?:\n\n|\Z)", text, re.DOTALL)
         if para_match:
-            summary = para_match.group(1).strip()
+            brief_body = para_match.group(1).strip()
+            brief_source = "brief_paragraph"
 
-    # Truncate summary to first ~200 chars for display
-    if len(summary) > 200:
-        summary = summary[:197] + "..."
+    brief_summary = summarize(brief_body) if brief_body else ""
 
-    return name, summary
+    return name, brief_summary, brief_body, brief_source
 
 
 def _read_plan_summary(quest_dir: Path) -> str:
@@ -719,7 +770,7 @@ def extract_celebration_data_from_journal(content: str) -> Optional[dict]:
         return None
 
 
-def _extract_metadata(content: str, key: str) -> str:
+def extract_metadata_value(content: str, key: str) -> str | None:
     """Extract journal metadata from bold, list-item, or plain formats."""
     patterns = [
         rf"\*\*{re.escape(key)}:\s*\*\*\s*(.+?)(?:\n|$)",
@@ -731,6 +782,13 @@ def _extract_metadata(content: str, key: str) -> str:
         match = re.search(pattern, content, re.IGNORECASE | re.MULTILINE)
         if match:
             return match.group(1).strip().strip("`")
+    return None
+
+
+def _extract_metadata(content: str, key: str) -> str:
+    value = extract_metadata_value(content, key)
+    if value is not None:
+        return value
     return ""
 
 
@@ -900,10 +958,12 @@ def load_quest_data(quest_dir: Path) -> QuestData:
             data.name = parts[0].replace("-", " ").title()
 
     # 2. quest_brief.md
-    brief_name, brief_summary = _read_quest_brief(quest_dir)
+    brief_name, brief_summary, brief_body, brief_source = _read_quest_brief(quest_dir)
     if brief_name:
         data.name = brief_name
     data.brief_summary = brief_summary
+    data.brief_body = brief_body
+    data.brief_source = brief_source
 
     # 3. plan.md
     data.plan_summary = _read_plan_summary(quest_dir)

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -63,7 +63,77 @@ def _build_celebration_json(data: QuestData) -> dict:
     }
 
 
-def _generate_journal_entry(data: QuestData, completion_date: date) -> str:
+def _journal_outcome(data: QuestData) -> str:
+    """Return the best short journal outcome summary."""
+    plan_summary = data.plan_summary.strip()
+    preferred = (
+        plan_summary
+        if plan_summary and not re.match(r"^\*{0,2}problem\*{0,2}:", plan_summary, re.IGNORECASE)
+        else (data.brief_summary or "Completed successfully.")
+    )
+    collapsed = re.sub(r"(?m)^\s*>\s?", "", preferred)
+    return re.sub(r"\s+", " ", collapsed).strip()
+
+
+def build_quest_brief_section(data: QuestData) -> str:
+    """Build the reader-facing quest brief section."""
+    body = (data.brief_body or data.brief_summary).strip()
+    if not body:
+        return ""
+
+    lines = ["## Quest Brief", ""]
+    if data.brief_source != "original_prompt":
+        lines.append(
+            "Full original prompt was not recorded for this quest. "
+            "This is the best available brief context."
+        )
+        lines.append("")
+    lines.append(body)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_celebration_section(journal_rel_path: Path | None) -> str:
+    """Build the reader-facing celebration section."""
+    if journal_rel_path is None:
+        return ""
+
+    journal_ref = journal_rel_path.as_posix()
+    return "\n".join(
+        [
+            "## Celebration",
+            "",
+            "This journal embeds the celebration payload used by `/celebrate`.",
+            "",
+            "- [Jump to Celebration Data](#celebration-data)",
+            f"- Replay locally: `/celebrate {journal_ref}`",
+            "",
+        ]
+    )
+
+
+def build_celebration_data_section(data: QuestData) -> str:
+    """Build the machine-readable celebration payload section."""
+    celebration = _build_celebration_json(data)
+    return "\n".join(
+        [
+            "## Celebration Data",
+            "",
+            "<!-- celebration-data-start -->",
+            "```json",
+            json.dumps(celebration, indent=2, ensure_ascii=False),
+            "```",
+            "<!-- celebration-data-end -->",
+            "",
+        ]
+    )
+
+
+def build_journal_entry(
+    data: QuestData,
+    completion_date: date,
+    journal_rel_path: Path | None = None,
+) -> str:
     """Generate a markdown journal entry from quest data."""
     lines = []
 
@@ -79,7 +149,7 @@ def _generate_journal_entry(data: QuestData, completion_date: date) -> str:
         lines.append(f"- Mode: {data.quest_mode}")
     if data.quality_tier:
         lines.append(f"- Quality: {data.quality_tier}")
-    lines.append(f"- Outcome: {data.brief_summary or data.plan_summary or 'Completed successfully.'}")
+    lines.append(f"- Outcome: {_journal_outcome(data)}")
     lines.append("")
 
     # What shipped
@@ -113,22 +183,17 @@ def _generate_journal_entry(data: QuestData, completion_date: date) -> str:
             lines.append(f"- **{agent.role_title}** ({agent.name}): {model_label}")
         lines.append("")
 
-    # Brief as origin quote
-    if data.brief_summary:
-        lines.append("## This is where it all began...")
-        lines.append("")
-        lines.append(f"> {data.brief_summary}")
+    quest_brief_section = build_quest_brief_section(data)
+    if quest_brief_section:
+        lines.append(quest_brief_section.rstrip())
         lines.append("")
 
-    # Celebration data JSON block
-    celebration = _build_celebration_json(data)
-    lines.append("## Celebration Data")
-    lines.append("")
-    lines.append("<!-- celebration-data-start -->")
-    lines.append("```json")
-    lines.append(json.dumps(celebration, indent=2, ensure_ascii=False))
-    lines.append("```")
-    lines.append("<!-- celebration-data-end -->")
+    celebration_section = build_celebration_section(journal_rel_path)
+    if celebration_section:
+        lines.append(celebration_section.rstrip())
+        lines.append("")
+
+    lines.append(build_celebration_data_section(data).rstrip())
     lines.append("")
 
     return "\n".join(lines)
@@ -201,7 +266,7 @@ def main() -> int:
     if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug):
         print(f"Error: invalid slug '{slug}'. Must match [a-z0-9][a-z0-9-]*", file=sys.stderr)
         return 1
-    outcome = data.brief_summary or data.plan_summary or "Completed."
+    outcome = _journal_outcome(data)
     # Sanitize outcome for README markdown table: collapse newlines, escape pipes
     outcome = re.sub(r"\s*\n\s*", " ", outcome).replace("|", "\\|")
     if len(outcome) > 120:
@@ -226,11 +291,12 @@ def main() -> int:
         journal_dir = repo_root / "docs" / "quest-journal"
         journal_dir.mkdir(parents=True, exist_ok=True)
         journal_file = journal_dir / f"{slug}_{completion_date.isoformat()}.md"
+        journal_rel_path = journal_file.relative_to(repo_root)
 
         if journal_file.exists():
             print(f"Journal entry already exists: {journal_file}")
         else:
-            entry = _generate_journal_entry(data, completion_date)
+            entry = build_journal_entry(data, completion_date, journal_rel_path)
             journal_file.write_text(entry)
             print(f"Journal entry created: {journal_file}")
 

--- a/scripts/quest_dashboard/loaders.py
+++ b/scripts/quest_dashboard/loaders.py
@@ -155,9 +155,12 @@ def _parse_journal_entry(journal_path: Path, repo_root: Path) -> JournalEntry:
     # Extract completed date
     completed_date = _extract_date(content, journal_path)
 
-    # Extract elevator pitch from Summary section
-    elevator_pitch = _extract_summary_pitch(content) or _extract_first_paragraph(
-        content
+    # Extract elevator pitch from Summary section first, then Outcome metadata,
+    # then the first real paragraph as a last resort.
+    elevator_pitch = (
+        _extract_summary_pitch(content)
+        or _extract_outcome_pitch(content)
+        or _extract_first_paragraph(content)
     )
 
     # Extract PR number
@@ -373,6 +376,55 @@ def _extract_summary_pitch(content: str) -> str | None:
     return _extract_first_paragraph(section)
 
 
+def _extract_outcome_pitch(content: str) -> str | None:
+    """Extract a normalized pitch from the journal Outcome metadata."""
+    match = re.search(
+        r"(?m)^\s*[-*]\s*Outcome:\s*`?(.+?)`?\s*$|^\s*\*\*Outcome:\s*\*\*\s*(.+?)$|^\s*\*\*Outcome\*\*\s*:\s*(.+?)$|^\s*Outcome:\s*`?(.+?)`?\s*$",
+        content,
+    )
+    if not match:
+        return None
+
+    lines = content.splitlines()
+    start_idx = None
+    first_line = ""
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        metadata_match = re.match(r"^[-*]\s+Outcome:\s*(.+)$", stripped)
+        if not metadata_match:
+            metadata_match = re.match(r"^\*\*Outcome:\s*\*\*\s*(.+)$", stripped)
+        if not metadata_match:
+            metadata_match = re.match(r"^\*\*Outcome\*\*\s*:\s*(.+)$", stripped)
+        if not metadata_match:
+            metadata_match = re.match(r"^Outcome:\s*(.+)$", stripped)
+        if metadata_match:
+            start_idx = idx
+            first_line = metadata_match.group(1).strip().strip("`")
+            break
+
+    if start_idx is None:
+        return None
+
+    outcome_lines = [first_line]
+    for line in lines[start_idx + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            break
+        if stripped.startswith("#"):
+            break
+        if re.match(r"^[-*]\s+[^:]+:\s+", stripped):
+            break
+        if re.match(r"^\*\*[^*]+:\s*\*\*", stripped) or re.match(r"^\*\*[^*]+\*\*\s*:", stripped):
+            break
+        if not stripped.startswith(">"):
+            break
+        outcome_lines.append(stripped)
+
+    cleaned = re.sub(r"(?m)^\s*>\s?", "", "\n".join(outcome_lines))
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
 def _extract_first_paragraph(content: str) -> str:
     """Extract the first non-empty paragraph from content.
 
@@ -516,7 +568,8 @@ def load_active_quests(quest_dir: Path) -> tuple[list[ActiveQuest], list[str]]:
 
         try:
             quest, quest_warnings = _parse_active_quest(state_path)
-            quests.append(quest)
+            if quest is not None:
+                quests.append(quest)
             warnings.extend(quest_warnings)
         except Exception as e:
             warnings.append(f"Failed to parse quest state {state_path}: {e}")
@@ -532,7 +585,7 @@ def load_active_quests(quest_dir: Path) -> tuple[list[ActiveQuest], list[str]]:
     return quests, warnings
 
 
-def _parse_active_quest(state_path: Path) -> tuple[ActiveQuest, list[str]]:
+def _parse_active_quest(state_path: Path) -> tuple[ActiveQuest | None, list[str]]:
     """Parse a single quest state.json and quest_brief.md into an ActiveQuest.
 
     Args:
@@ -554,6 +607,15 @@ def _parse_active_quest(state_path: Path) -> tuple[ActiveQuest, list[str]]:
     updated_at_str = state_data.get("updated_at")
     plan_iteration = state_data.get("plan_iteration")
     fix_iteration = state_data.get("fix_iteration")
+
+    # Completed quests should already be journaled/archived and should not show up
+    # in the active dashboard lane even if a stale .quest directory remains locally.
+    if str(raw_status).lower() in {"complete", "completed", "done"} or str(raw_phase).lower() in {
+        "complete",
+        "completed",
+        "done",
+    }:
+        return None, warnings
 
     # Normalize status and phase for display
     status = _normalize_display_label(raw_status)

--- a/scripts/quest_dashboard/loaders.py
+++ b/scripts/quest_dashboard/loaders.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from quest_celebrate.quest_data import (
     QUALITY_TIERS,
     extract_celebration_data_from_journal as _extract_celebration_data,
+    extract_metadata_value as _extract_metadata,
     friendly_model_name as _friendly_model_name,
 )
 
@@ -221,36 +222,6 @@ def _parse_journal_entry(journal_path: Path, repo_root: Path) -> JournalEntry:
         celebration_data=celebration_data,
     )
 
-
-def _extract_metadata(content: str, key: str) -> str | None:
-    """Extract metadata value from bold, list-item, or plain markdown patterns.
-
-    Matches both:
-    - **Key:** value  (colon is INSIDE the bold markers)
-    - **Key**: value  (colon is OUTSIDE - less common)
-    - - Key: value     (list-item format)
-    - Key: value       (plain format)
-
-    Args:
-        content: Markdown content
-        key: Metadata key (case-insensitive)
-
-    Returns:
-        Extracted value or None
-    """
-    patterns = [
-        rf"\*\*{re.escape(key)}:\s*\*\*\s*(.+?)(?:\n|$)",
-        rf"\*\*{re.escape(key)}\*\*\s*:\s*(.+?)(?:\n|$)",
-        rf"^\s*[-*]\s*{re.escape(key)}:\s*`?(.+?)`?\s*$",
-        rf"^\s*{re.escape(key)}:\s*`?(.+?)`?\s*$",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, content, re.IGNORECASE | re.MULTILINE)
-        if match:
-            return match.group(1).strip().strip("`")
-    return None
-
-
 def _extract_title(content: str) -> str | None:
     """Extract title from journal heading.
 
@@ -405,7 +376,7 @@ def _extract_summary_pitch(content: str) -> str | None:
 def _extract_first_paragraph(content: str) -> str:
     """Extract the first non-empty paragraph from content.
 
-    Skips headings, metadata lines (**Key:** value), and empty lines.
+    Skips headings, metadata lines (`**Key:** value` and `- Key: value`), and empty lines.
     Preserves paragraphs that start with bold text that is not a metadata key.
     """
     lines = content.split("\n")
@@ -424,6 +395,12 @@ def _extract_first_paragraph(content: str) -> str:
         if re.match(r"\*\*[^*]+:\s*\*\*", stripped) or re.match(
             r"\*\*[^*]+\*\*\s*:", stripped
         ):
+            if paragraph_lines:
+                break
+            continue
+
+        # Skip list-style metadata lines: - Key: value / * Key: value
+        if re.match(r"^[-*]\s+[^:]+:\s+", stripped):
             if paragraph_lines:
                 break
             continue
@@ -655,16 +632,22 @@ def _extract_brief_pitch(content: str) -> str | None:
     3. First paragraph of entire brief
     """
     # Try Original Prompt section
-    match = re.search(
-        r"^##\s+User Input \(Original Prompt\)\s*$(.+?)(?=^##|\Z)",
-        content,
-        re.MULTILINE | re.DOTALL,
-    )
-    if match:
-        section = match.group(1).strip()
-        pitch = _extract_first_paragraph(section)
-        if pitch:
-            return pitch
+    for pattern in (
+        r"^##\s+User Input(?:\s+\(Original Prompt\))?\s*$(.+?)(?=^##|\Z)",
+        r"^##\s+User Request\s*$(.+?)(?=^##|\Z)",
+        r"^##\s+Original User Input\s*$(.+?)(?=^##|\Z)",
+        r"^##\s+Original Request\s*$(.+?)(?=^##|\Z)",
+    ):
+        match = re.search(
+            pattern,
+            content,
+            re.IGNORECASE | re.MULTILINE | re.DOTALL,
+        )
+        if match:
+            section = match.group(1).strip()
+            pitch = _extract_first_paragraph(section)
+            if pitch:
+                return pitch
 
     # Try Requirements section
     match = re.search(

--- a/tests/unit/test_backfill_quest_journal.py
+++ b/tests/unit/test_backfill_quest_journal.py
@@ -1,0 +1,310 @@
+"""Unit tests for archive-backed quest journal backfill."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backfill_quest_journal import backfill_journal_entries
+
+
+def _write_archive_quest(
+    archive_dir: Path,
+    quest_id: str,
+    slug: str,
+    prompt_section: str = "## User Input (Original Prompt)",
+) -> None:
+    archive_dir.mkdir(parents=True)
+    (archive_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "quest_id": quest_id,
+                "slug": slug,
+                "status": "complete",
+                "phase": "complete",
+                "quest_mode": "solo",
+                "plan_iteration": 1,
+                "fix_iteration": 0,
+                "created_at": "2026-04-13T17:01:47Z",
+                "updated_at": "2026-04-13T17:25:04Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (archive_dir / "quest_brief.md").write_text(
+        "\n".join(
+            [
+                "# Quest Brief: Prompt Surface / Instruction Architecture Consolidation",
+                "",
+                prompt_section,
+                "",
+                "> Full original prompt recovered from the archive.",
+                "",
+                "## Router Classification",
+                "",
+                "```json",
+                '{"route": "solo"}',
+                "```",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    phase_01 = archive_dir / "phase_01_plan"
+    phase_01.mkdir()
+    (phase_01 / "plan.md").write_text(
+        "## Overview\n\nShipped a clearer proposal consolidation with preserved guardrails.\n",
+        encoding="utf-8",
+    )
+
+
+def _write_journal(journal_path: Path, quest_id: str) -> None:
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    journal_path.write_text(
+        "\n".join(
+            [
+                "# Quest Journal: Prompt Surface / Instruction Architecture Consolidation",
+                "",
+                f"- Quest ID: `{quest_id}`",
+                "- Completed: 2026-04-13",
+                "- Mode: solo",
+                "- Quality: Platinum",
+                "- Outcome: Old truncated quote",
+                "",
+                "## What Shipped",
+                "",
+                "Old body.",
+                "",
+                "## Celebration Data",
+                "",
+                "<!-- celebration-data-start -->",
+                "```json",
+                '{"quest_mode": "solo", "quality": {"tier": "Platinum", "grade": "P"}, "agents": [], "achievements": [], "metrics": [], "test_count": null, "tests_added": null, "files_changed": 1}',
+                "```",
+                "<!-- celebration-data-end -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_journal_with_old_brief_heading(journal_path: Path, quest_id: str) -> None:
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    journal_path.write_text(
+        "\n".join(
+            [
+                "# Quest Journal: Legacy Brief",
+                "",
+                f"- Quest ID: `{quest_id}`",
+                "- Completed: 2026-04-13",
+                "- Outcome: Preserve the rest of this document.",
+                "",
+                "## What Shipped",
+                "",
+                "Keep this handcrafted section.",
+                "",
+                "## This is where it all began...",
+                "",
+                "> Old truncated quote.",
+                "",
+                "## Iterations",
+                "",
+                "- Plan iterations: 1",
+                "- Fix iterations: 0",
+                "",
+                "## Next Steps",
+                "",
+                "- Keep this section too.",
+                "",
+                "## Celebration Data",
+                "",
+                "<!-- celebration-data-start -->",
+                "```json",
+                '{"quest_mode": "solo", "quality": {"tier": "Platinum", "grade": "P"}, "agents": [], "achievements": [], "metrics": [], "test_count": null, "tests_added": null, "files_changed": 1}',
+                "```",
+                "<!-- celebration-data-end -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_journal_with_richer_existing_brief(journal_path: Path, quest_id: str) -> None:
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    journal_path.write_text(
+        "\n".join(
+            [
+                "# Quest Journal: Rich Legacy Brief",
+                "",
+                f"- Quest ID: `{quest_id}`",
+                "- Completed: 2026-04-13",
+                "- Outcome: Preserve the deeper handcrafted context.",
+                "",
+                "## What Shipped",
+                "",
+                "Backfill should retain the richer reader-facing brief.",
+                "",
+                "## This is where it all began...",
+                "",
+                "What: Tighten validation before the launch scripts run.",
+                "",
+                "Why: Existing journal readers need the operational background, not just a short summary.",
+                "",
+                "Approach:",
+                "- validate inputs before invoking side effects",
+                "- fail early with actionable guidance",
+                "- keep the old rollout notes intact",
+                "",
+                "## Celebration Data",
+                "",
+                "<!-- celebration-data-start -->",
+                "```json",
+                '{"quest_mode": "solo", "quality": {"tier": "Platinum", "grade": "P"}, "agents": [], "achievements": [], "metrics": [], "test_count": null, "tests_added": null, "files_changed": 1}',
+                "```",
+                "<!-- celebration-data-end -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_backfill_patches_matching_journal(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "prompt-surface-consolidation_2026-04-13__1701"
+    journal_path = repo_root / "docs" / "quest-journal" / "prompt-surface-consolidation_2026-04-13.md"
+
+    _write_archive_quest(
+        archive_dir,
+        "prompt-surface-consolidation_2026-04-13__1701",
+        "prompt-surface-consolidation",
+    )
+    _write_journal(journal_path, "prompt-surface-consolidation_2026-04-13__1701")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == ["prompt-surface-consolidation_2026-04-13.md"]
+    updated = journal_path.read_text(encoding="utf-8")
+    assert "- Outcome: Old truncated quote" in updated
+    assert "Old body." in updated
+    assert "## Quest Brief" in updated
+    assert "Full original prompt recovered from the archive." in updated
+    assert "## Celebration" in updated
+    assert "`/celebrate docs/quest-journal/prompt-surface-consolidation_2026-04-13.md`" in updated
+
+
+def test_backfill_skips_unmatched_archive(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "missing-journal_2026-04-13__1701"
+    (repo_root / "docs" / "quest-journal").mkdir(parents=True)
+    _write_archive_quest(archive_dir, "missing-journal_2026-04-13__1701", "missing-journal")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == []
+    assert result["unchanged"] == []
+    assert any("no matching journal entry found" in warning for warning in result["skipped"])
+
+
+def test_backfill_handles_missing_archive_directory(tmp_path):
+    repo_root = tmp_path
+    (repo_root / ".quest").mkdir(parents=True)
+    (repo_root / "docs" / "quest-journal").mkdir(parents=True)
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result == {"patched": [], "unchanged": [], "skipped": []}
+
+
+def test_backfill_skips_ambiguous_slug_date_matches(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "ambiguous_2026-04-13__1701"
+    journal_dir = repo_root / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+    _write_archive_quest(archive_dir, "ambiguous_2026-04-13__1701", "ambiguous")
+    _write_journal(journal_dir / "ambiguous_2026-04-13-copy-a.md", "other-a_2026-04-13__1701")
+    _write_journal(journal_dir / "ambiguous_2026-04-13-copy-b.md", "other-b_2026-04-13__1701")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == []
+    assert any("ambiguous slug/date fallback" in warning for warning in result["skipped"])
+
+
+def test_backfill_skips_duplicate_quest_id_matches(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "duplicate_2026-04-13__1701"
+    journal_dir = repo_root / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+    _write_archive_quest(archive_dir, "duplicate_2026-04-13__1701", "duplicate")
+    _write_journal(journal_dir / "duplicate-a_2026-04-13.md", "duplicate_2026-04-13__1701")
+    _write_journal(journal_dir / "duplicate-b_2026-04-13.md", "duplicate_2026-04-13__1701")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == []
+    assert any("duplicate Quest ID match" in warning for warning in result["skipped"])
+
+
+def test_backfill_preserves_sections_after_legacy_brief_heading(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "legacy-brief_2026-04-13__1701"
+    journal_path = repo_root / "docs" / "quest-journal" / "legacy-brief_2026-04-13.md"
+
+    _write_archive_quest(archive_dir, "legacy-brief_2026-04-13__1701", "legacy-brief")
+    _write_journal_with_old_brief_heading(journal_path, "legacy-brief_2026-04-13__1701")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == ["legacy-brief_2026-04-13.md"]
+    updated = journal_path.read_text(encoding="utf-8")
+    assert "## Quest Brief" in updated
+    assert "## Iterations" in updated
+    assert "## Next Steps" in updated
+    assert "Keep this handcrafted section." in updated
+    assert "Keep this section too." in updated
+
+
+def test_backfill_preserves_richer_existing_brief_context(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "validate-and-launch_2026-04-13__1701"
+    journal_path = repo_root / "docs" / "quest-journal" / "validate-and-launch_2026-04-13.md"
+
+    _write_archive_quest(archive_dir, "validate-and-launch_2026-04-13__1701", "validate-and-launch")
+    _write_journal_with_richer_existing_brief(journal_path, "validate-and-launch_2026-04-13__1701")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == ["validate-and-launch_2026-04-13.md"]
+    updated = journal_path.read_text(encoding="utf-8")
+    assert "## Quest Brief" in updated
+    assert "What: Tighten validation before the launch scripts run." in updated
+    assert "Existing journal readers need the operational background" in updated
+    assert "### Archived Brief" in updated
+    assert "Full original prompt recovered from the archive." in updated
+
+    second = backfill_journal_entries(repo_root)
+    assert second["patched"] == []
+    updated_again = journal_path.read_text(encoding="utf-8")
+    assert updated_again.count("### Archived Brief") == 1
+
+
+def test_backfill_is_idempotent_on_rerun(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "prompt-surface-consolidation_2026-04-13__1701"
+    journal_path = repo_root / "docs" / "quest-journal" / "prompt-surface-consolidation_2026-04-13.md"
+
+    _write_archive_quest(
+        archive_dir,
+        "prompt-surface-consolidation_2026-04-13__1701",
+        "prompt-surface-consolidation",
+    )
+    _write_journal(journal_path, "prompt-surface-consolidation_2026-04-13__1701")
+
+    first = backfill_journal_entries(repo_root)
+    second = backfill_journal_entries(repo_root)
+
+    assert first["patched"] == ["prompt-surface-consolidation_2026-04-13.md"]
+    assert second["patched"] == []
+    assert second["unchanged"] == ["prompt-surface-consolidation_2026-04-13.md"]

--- a/tests/unit/test_backfill_quest_journal.py
+++ b/tests/unit/test_backfill_quest_journal.py
@@ -207,6 +207,26 @@ def test_backfill_skips_unmatched_archive(tmp_path):
     assert any("no matching journal entry found" in warning for warning in result["skipped"])
 
 
+def test_backfill_skips_slug_date_fallback_when_archive_date_is_unknown(tmp_path):
+    repo_root = tmp_path
+    archive_dir = repo_root / ".quest" / "archive" / "unknown-date_2026-04-13__1701"
+    journal_dir = repo_root / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+    _write_archive_quest(archive_dir, "unknown-date_2026-04-13__1701", "unknown-date")
+    _write_journal(journal_dir / "unknown-date_2026-04-13.md", "different-quest-id_2026-04-13__1701")
+
+    state_path = archive_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["created_at"] = "not-a-date"
+    state["updated_at"] = "still-not-a-date"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    result = backfill_journal_entries(repo_root)
+
+    assert result["patched"] == []
+    assert any("cannot use slug/date fallback" in warning for warning in result["skipped"])
+
+
 def test_backfill_handles_missing_archive_directory(tmp_path):
     repo_root = tmp_path
     (repo_root / ".quest").mkdir(parents=True)

--- a/tests/unit/test_quest_celebrate.py
+++ b/tests/unit/test_quest_celebrate.py
@@ -752,6 +752,53 @@ class TestQuestDataLoading:
 
         assert data.name == "My Test Feature"
         assert "great feature" in data.brief_summary.lower()
+        assert "Build a great feature." in data.brief_body
+        assert data.brief_source == "original_prompt"
+
+    def test_load_quest_data_reads_original_request_variant(self, tmp_path):
+        """Verifies legacy Original Request headings are treated as full prompt content."""
+        quest_dir = self._make_quest_dir(tmp_path)
+        (quest_dir / "quest_brief.md").write_text(
+            "# Quest Brief: My Test Feature\n\n"
+            "## Original Request\n\n"
+            "> Recover the original request in full.\n",
+            encoding="utf-8",
+        )
+
+        data = load_quest_data(quest_dir)
+
+        assert "Recover the original request in full." in data.brief_body
+        assert data.brief_source == "original_prompt"
+
+    def test_load_quest_data_reads_user_request_variant(self, tmp_path):
+        """Verifies User Request headings are treated as full prompt content."""
+        quest_dir = self._make_quest_dir(tmp_path)
+        (quest_dir / "quest_brief.md").write_text(
+            "# Quest Brief: My Test Feature\n\n"
+            "## User Request\n\n"
+            "Recover the user request in full.\n",
+            encoding="utf-8",
+        )
+
+        data = load_quest_data(quest_dir)
+
+        assert "Recover the user request in full." in data.brief_body
+        assert data.brief_source == "original_prompt"
+
+    def test_load_quest_data_reads_original_user_input_variant(self, tmp_path):
+        """Verifies Original User Input headings are treated as full prompt content."""
+        quest_dir = self._make_quest_dir(tmp_path)
+        (quest_dir / "quest_brief.md").write_text(
+            "# Quest Brief: My Test Feature\n\n"
+            "## Original User Input\n\n"
+            "Recover the original user input in full.\n",
+            encoding="utf-8",
+        )
+
+        data = load_quest_data(quest_dir)
+
+        assert "Recover the original user input in full." in data.brief_body
+        assert data.brief_source == "original_prompt"
 
     def test_load_quest_data_reads_plan_summary(self, tmp_path):
         """Verifies plan overview extracted."""

--- a/tests/unit/test_quest_complete.py
+++ b/tests/unit/test_quest_complete.py
@@ -1,0 +1,153 @@
+"""Unit tests for quest_complete journal rendering."""
+
+from datetime import date
+from pathlib import Path
+
+from quest_complete import build_journal_entry
+from quest_celebrate.quest_data import QuestData
+
+
+def test_generate_journal_entry_prefers_full_original_prompt():
+    data = QuestData(
+        quest_id="prompt-fix_2026-04-15__1200",
+        slug="prompt-fix",
+        name="Prompt Fix",
+        quest_mode="workflow",
+        brief_summary="Short summary",
+        brief_body="> Full original prompt line one.\n>\n> Full original prompt line two.",
+        brief_source="original_prompt",
+        plan_summary="Shipped the fix cleanly.",
+        quality_tier="Gold",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/prompt-fix_2026-04-15.md"),
+    )
+
+    assert "## Quest Brief" in entry
+    assert "Full original prompt line one." in entry
+    assert "Full original prompt line two." in entry
+    assert "Full original prompt was not recorded" not in entry
+    assert "- Outcome: Shipped the fix cleanly." in entry
+
+
+def test_generate_journal_entry_avoids_problem_statement_as_outcome():
+    data = QuestData(
+        quest_id="problem-first_2026-04-15__1200",
+        slug="problem-first",
+        name="Problem First",
+        brief_summary="Use the brief summary instead.",
+        brief_body="Use the brief summary instead.",
+        brief_source="brief_section",
+        plan_summary="**Problem:** This summary describes the bug, not the shipped result.",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/problem-first_2026-04-15.md"),
+    )
+
+    assert "- Outcome: Use the brief summary instead." in entry
+
+
+def test_generate_journal_entry_avoids_old_problem_statement_as_outcome():
+    data = QuestData(
+        quest_id="old-problem-style_2026-04-15__1200",
+        slug="old-problem-style",
+        name="Old Problem Style",
+        brief_summary="Use the brief summary instead.",
+        brief_body="Use the brief summary instead.",
+        brief_source="brief_section",
+        plan_summary="**Problem**: This summary describes the bug, not the shipped result.",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/old-problem-style_2026-04-15.md"),
+    )
+
+    assert "- Outcome: Use the brief summary instead." in entry
+
+
+def test_generate_journal_entry_avoids_problem_statement_without_brief_summary():
+    data = QuestData(
+        quest_id="problem-no-brief_2026-04-15__1200",
+        slug="problem-no-brief",
+        name="Problem No Brief",
+        plan_summary="**Problem:** This summary describes the bug, not the shipped result.",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/problem-no-brief_2026-04-15.md"),
+    )
+
+    assert "- Outcome: Completed successfully." in entry
+
+
+def test_generate_journal_entry_collapses_multiline_plan_summary_in_outcome():
+    data = QuestData(
+        quest_id="multiline-outcome_2026-04-15__1200",
+        slug="multiline-outcome",
+        name="Multiline Outcome",
+        brief_summary="Fallback summary",
+        brief_body="Fallback summary",
+        brief_source="brief_section",
+        plan_summary="> Primary shipped result\n>\n> with extra wrapped detail",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/multiline-outcome_2026-04-15.md"),
+    )
+
+    assert "- Outcome: Primary shipped result with extra wrapped detail" in entry
+    assert "- Outcome: >" not in entry
+
+
+def test_generate_journal_entry_adds_celebration_section_when_replayable():
+    data = QuestData(
+        quest_id="celebrate-me_2026-04-15__1200",
+        slug="celebrate-me",
+        name="Celebrate Me",
+        brief_summary="Replay this",
+        brief_body="Replay this",
+        brief_source="brief_section",
+        quality_tier="Platinum",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/celebrate-me_2026-04-15.md"),
+    )
+
+    assert "## Celebration" in entry
+    assert "[Jump to Celebration Data](#celebration-data)" in entry
+    assert "`/celebrate docs/quest-journal/celebrate-me_2026-04-15.md`" in entry
+
+
+def test_generate_journal_entry_falls_back_to_best_available_brief_context():
+    data = QuestData(
+        quest_id="legacy-brief_2026-04-15__1200",
+        slug="legacy-brief",
+        name="Legacy Brief",
+        brief_summary="Best available summary",
+        brief_body="Legacy brief details from the first recorded section.",
+        brief_source="brief_section",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 15),
+        Path("docs/quest-journal/legacy-brief_2026-04-15.md"),
+    )
+
+    assert "Legacy brief details from the first recorded section." in entry
+    assert "Full original prompt was not recorded for this quest." in entry

--- a/tests/unit/test_quest_dashboard_loaders.py
+++ b/tests/unit/test_quest_dashboard_loaders.py
@@ -118,6 +118,32 @@ More content.
     assert "first paragraph after the title" not in entry.elevator_pitch
 
 
+def test_journal_elevator_pitch_skips_list_item_metadata_without_summary(tmp_path):
+    """Fallback pitch extraction should ignore list-item metadata blocks."""
+    journal_dir = tmp_path / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+
+    journal_content = """# Quest Journal: Test Quest
+
+- Quest ID: `test-quest_2026-04-13__1701`
+- Completed: 2026-04-13
+- Outcome: Preserve the actual first paragraph.
+
+This is the real elevator pitch after metadata.
+
+## What Shipped
+
+More content.
+"""
+
+    journal_path = journal_dir / "test.md"
+    journal_path.write_text(journal_content, encoding="utf-8")
+
+    entry = _parse_journal_entry(journal_path, tmp_path)
+
+    assert entry.elevator_pitch == "This is the real elevator pitch after metadata."
+
+
 def test_journal_entry_detects_abandoned_status(tmp_path):
     """Test that abandoned status is correctly detected and normalized."""
     journal_dir = tmp_path / "docs" / "quest-journal"
@@ -233,6 +259,84 @@ Some requirements here.
         == "This is the elevator pitch from the original prompt section."
     )
     assert len(quest_warnings) == 0
+
+
+def test_active_quest_pitch_supports_original_request_variant(tmp_path):
+    """Active quest cards should support legacy Original Request sections."""
+    quest_dir = tmp_path / ".quest" / "legacy-request"
+    quest_dir.mkdir(parents=True)
+
+    state = {
+        "quest_id": "legacy-request",
+        "slug": "legacy-request",
+        "status": "in_progress",
+        "phase": "plan",
+        "updated_at": "2026-02-12T10:00:00Z",
+    }
+    (quest_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (quest_dir / "quest_brief.md").write_text(
+        "# Quest Brief: Legacy Request\n\n"
+        "## Original Request\n\n"
+        "Recover this prompt for active quest cards.\n",
+        encoding="utf-8",
+    )
+
+    quest, warnings = _parse_active_quest(quest_dir / "state.json")
+
+    assert quest.elevator_pitch == "Recover this prompt for active quest cards."
+    assert warnings == []
+
+
+def test_active_quest_pitch_supports_user_request_variant(tmp_path):
+    """Active quest cards should support legacy User Request sections."""
+    quest_dir = tmp_path / ".quest" / "legacy-user-request"
+    quest_dir.mkdir(parents=True)
+
+    state = {
+        "quest_id": "legacy-user-request",
+        "slug": "legacy-user-request",
+        "status": "in_progress",
+        "phase": "plan",
+        "updated_at": "2026-02-12T10:00:00Z",
+    }
+    (quest_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (quest_dir / "quest_brief.md").write_text(
+        "# Quest Brief: Legacy User Request\n\n"
+        "## User Request\n\n"
+        "Recover this prompt variant for active quest cards.\n",
+        encoding="utf-8",
+    )
+
+    quest, warnings = _parse_active_quest(quest_dir / "state.json")
+
+    assert quest.elevator_pitch == "Recover this prompt variant for active quest cards."
+    assert warnings == []
+
+
+def test_active_quest_pitch_supports_original_user_input_variant(tmp_path):
+    """Active quest cards should support legacy Original User Input sections."""
+    quest_dir = tmp_path / ".quest" / "legacy-original-user-input"
+    quest_dir.mkdir(parents=True)
+
+    state = {
+        "quest_id": "legacy-original-user-input",
+        "slug": "legacy-original-user-input",
+        "status": "in_progress",
+        "phase": "plan",
+        "updated_at": "2026-02-12T10:00:00Z",
+    }
+    (quest_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    (quest_dir / "quest_brief.md").write_text(
+        "# Quest Brief: Legacy Original User Input\n\n"
+        "## Original User Input\n\n"
+        "Recover this original user input for active quest cards.\n",
+        encoding="utf-8",
+    )
+
+    quest, warnings = _parse_active_quest(quest_dir / "state.json")
+
+    assert quest.elevator_pitch == "Recover this original user input for active quest cards."
+    assert warnings == []
 
 
 def test_malformed_state_json_produces_warning(tmp_path):

--- a/tests/unit/test_quest_dashboard_loaders.py
+++ b/tests/unit/test_quest_dashboard_loaders.py
@@ -9,6 +9,7 @@ from quest_dashboard.loaders import (
     _extract_celebration_data,
     _extract_iterations,
     _extract_metadata,
+    _extract_outcome_pitch,
     _extract_summary_pitch,
     _friendly_model_name,
     _normalize_status,
@@ -118,8 +119,8 @@ More content.
     assert "first paragraph after the title" not in entry.elevator_pitch
 
 
-def test_journal_elevator_pitch_skips_list_item_metadata_without_summary(tmp_path):
-    """Fallback pitch extraction should ignore list-item metadata blocks."""
+def test_journal_elevator_pitch_prefers_outcome_metadata_over_fallback_paragraph(tmp_path):
+    """Outcome metadata should win over later paragraph fallback when Summary is absent."""
     journal_dir = tmp_path / "docs" / "quest-journal"
     journal_dir.mkdir(parents=True)
 
@@ -141,7 +142,46 @@ More content.
 
     entry = _parse_journal_entry(journal_path, tmp_path)
 
-    assert entry.elevator_pitch == "This is the real elevator pitch after metadata."
+    assert entry.elevator_pitch == "Preserve the actual first paragraph."
+
+
+def test_journal_elevator_pitch_prefers_outcome_metadata_without_summary(tmp_path):
+    """Outcome metadata should beat file-list fallback when Summary is absent."""
+    journal_dir = tmp_path / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+
+    journal_content = """# Quest Journal: Test Quest
+
+- Quest ID: `test-quest_2026-04-13__1701`
+- Completed: 2026-04-13
+- Outcome: Dashboard quest detail pages now include the brief and celebration context.
+
+## Files Changed
+
+- `scripts/quest_complete.py`
+- `scripts/quest_dashboard/loaders.py`
+"""
+
+    journal_path = journal_dir / "test.md"
+    journal_path.write_text(journal_content, encoding="utf-8")
+
+    entry = _parse_journal_entry(journal_path, tmp_path)
+
+    assert (
+        entry.elevator_pitch
+        == "Dashboard quest detail pages now include the brief and celebration context."
+    )
+
+
+def test_extract_outcome_pitch_normalizes_blockquote_markers():
+    content = """- Outcome: > Consolidated overlapping proposals
+> into one canonical instruction architecture document.
+"""
+
+    assert (
+        _extract_outcome_pitch(content)
+        == "Consolidated overlapping proposals into one canonical instruction architecture document."
+    )
 
 
 def test_journal_entry_detects_abandoned_status(tmp_path):
@@ -377,6 +417,27 @@ def test_missing_quest_brief_produces_warning(tmp_path):
     assert quests[0].elevator_pitch == ""
     assert len(warnings) == 1
     assert "quest_brief.md" in warnings[0].lower() or "missing" in warnings[0].lower()
+
+
+def test_completed_active_quest_is_skipped_without_missing_brief_warning(tmp_path):
+    """Completed stale quest dirs should not appear in active results or warn."""
+    quest_dir = tmp_path / ".quest" / "completed-stale-quest"
+    quest_dir.mkdir(parents=True)
+
+    state = {
+        "quest_id": "completed-stale-quest",
+        "slug": "completed-stale-quest",
+        "status": "complete",
+        "phase": "complete",
+        "updated_at": "2026-02-12T10:00:00Z",
+    }
+    (quest_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+    # No quest_brief.md on purpose
+
+    quests, warnings = load_active_quests(tmp_path / ".quest")
+
+    assert quests == []
+    assert warnings == []
 
 
 def test_active_quests_sorted_by_phase_then_date(tmp_path):


### PR DESCRIPTION
## Summary
Fix the quest journal/detail pipeline so dashboard-linked quest pages actually explain what shipped, include celebration context, and can be repaired from archived quest artifacts.
- Forward journal generation now preserves richer brief context instead of collapsing to thin or misleading outcome text.
- Historical quest journals can now be backfilled safely without overwriting richer hand-written context.

## Changes
- **Behavior**:
  - Extend `scripts/quest_celebrate/quest_data.py` to recover richer brief content, including full prompt variants such as `User Request`, `Original User Input`, `User Input`, and `Original Request`.
  - Update `scripts/quest_complete.py` to render reader-facing `## Quest Brief` and `## Celebration` sections and to keep outcome metadata from falling back to old `Problem` statements.
  - Add `scripts/backfill_quest_journal.py` to patch existing journal pages from `.quest/archive/` while preserving richer existing brief sections and handling missing archive directories safely.
- **Dashboard**:
  - Broaden `scripts/quest_dashboard/loaders.py` brief parsing so active and completed quest cards understand the legacy prompt-heading variants.
  - Keep dashboard pitch extraction from using list-style metadata as the fallback summary.
- **Documentation**:
  - Backfill 21 historical files in `docs/quest-journal/` with quest brief and celebration context.
  - Add `docs/quest-journal/quest-dashboard-briefs_2026-04-16.md` and update `docs/quest-journal/README.md` with the generated completion entry.
- **Tests**:
  - Add `tests/unit/test_quest_complete.py` and `tests/unit/test_backfill_quest_journal.py`.
  - Expand `tests/unit/test_quest_celebrate.py` and `tests/unit/test_quest_dashboard_loaders.py` for heading variants, richer brief preservation, missing archive directories, and outcome fallback regressions.

## Validation
- [x] Run `python3 -m pytest tests/unit/test_quest_complete.py tests/unit/test_backfill_quest_journal.py tests/unit/test_quest_celebrate.py tests/unit/test_quest_dashboard_loaders.py tests/integration/test_build_quest_dashboard.py` from the repo root. Expected: all tests pass; current result is `145 passed`.
- [x] Run `python3 scripts/backfill_quest_journal.py --repo-root .` from the repo root. Expected: `21` journal files report `unchanged` on rerun and unmatched archive entries remain in `Skipped` without crashing.
- [x] Run `python3 scripts/quest_dashboard/build_quest_dashboard.py --output /tmp/quest-dashboard.html` from the repo root, then open `/tmp/quest-dashboard.html`. Expected: quest detail links resolve to journals that include usable brief context and celebration replay information, including `prompt-surface-consolidation_2026-04-13.md`, `feedback-intent-routing_2026-04-13.md`, and `ci-review-severity_2026-04-07.md`.
Watch for: the generated journal quality tier still comes from the existing celebration scoring logic, so reviewer focus should stay on brief/celebration correctness rather than the current tier label.

## Notes
- The visible celebration miss during this run was operator error, not a repo bug: the workflow already requires the `celebrate` skill to render directly to the user instead of using the Python fallback in interactive flows.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>
