### PR TITLE
Add Deep CI chunk fallback and harden arbiter backlog contract

### DIFF
--- a/.claude/hooks/enforce-allowlist.sh
+++ b/.claude/hooks/enforce-allowlist.sh
@@ -88,8 +88,13 @@ glob_to_regex() {
     if [[ "$char" == "*" ]]; then
       next="${pattern:i+1:1}"
       if [[ "$next" == "*" ]]; then
-        regex+=".*"
-        i=$((i + 1))
+        if [[ "${pattern:i+2:1}" == "/" ]]; then
+          regex+="(.*/)?"
+          i=$((i + 2))
+        else
+          regex+=".*"
+          i=$((i + 1))
+        fi
       else
         regex+="[^/]*"
       fi

--- a/.claude/hooks/enforce-allowlist.sh
+++ b/.claude/hooks/enforce-allowlist.sh
@@ -29,6 +29,28 @@ TOOL=$(echo "$INPUT" | jq -r '.tool // empty')
 PERMS=$(jq -r ".role_permissions.\"$ROLE\" // empty" "$ALLOWLIST")
 [[ -z "$PERMS" || "$PERMS" == "null" ]] && exit 0  # No permissions defined = allow
 
+normalize_repo_path() {
+  local file_path="$1"
+
+  python3 - "$REPO_ROOT" "$file_path" <<'PY'
+from pathlib import Path
+import sys
+
+repo_root = Path(sys.argv[1]).resolve()
+candidate = Path(sys.argv[2])
+if not candidate.is_absolute():
+    candidate = repo_root / candidate
+
+try:
+    resolved = candidate.resolve(strict=False)
+    relative = resolved.relative_to(repo_root)
+except (OSError, ValueError):
+    sys.exit(1)
+
+print(relative.as_posix())
+PY
+}
+
 # Check file write permissions for Write/Edit tools
 check_file_write() {
   local file_path="$1"
@@ -38,10 +60,7 @@ check_file_write() {
   allowed_patterns=$(echo "$PERMS" | jq -r '.file_write // [] | .[]')
   [[ -z "$allowed_patterns" ]] && return 1  # No patterns = deny
 
-  # Make path relative to repo root if absolute
-  if [[ "$file_path" == "$REPO_ROOT"* ]]; then
-    file_path="${file_path#$REPO_ROOT/}"
-  fi
+  file_path=$(normalize_repo_path "$file_path") || return 1
 
   # Check each pattern
   while IFS= read -r pattern; do

--- a/.claude/hooks/enforce-allowlist.sh
+++ b/.claude/hooks/enforce-allowlist.sh
@@ -47,10 +47,8 @@ check_file_write() {
   while IFS= read -r pattern; do
     [[ -z "$pattern" ]] && continue
 
-    # Convert glob pattern to regex for matching
-    # ** matches any path, * matches within a directory
-    local regex="^${pattern//\*\*/.*}$"
-    regex="${regex//\*/[^/]*}"
+    local regex
+    regex=$(glob_to_regex "$pattern")
 
     if [[ "$file_path" =~ $regex ]]; then
       return 0  # Match found, allow
@@ -58,6 +56,39 @@ check_file_write() {
   done <<< "$allowed_patterns"
 
   return 1  # No match, deny
+}
+
+glob_to_regex() {
+  local pattern="$1"
+  local regex="^"
+  local i char next
+
+  for ((i = 0; i < ${#pattern}; i++)); do
+    char="${pattern:i:1}"
+
+    if [[ "$char" == "*" ]]; then
+      next="${pattern:i+1:1}"
+      if [[ "$next" == "*" ]]; then
+        regex+=".*"
+        i=$((i + 1))
+      else
+        regex+="[^/]*"
+      fi
+      continue
+    fi
+
+    case "$char" in
+      [\\.\^\$\+\?\(\)\[\]\{\}\|])
+        regex+="\\$char"
+        ;;
+      *)
+        regex+="$char"
+        ;;
+    esac
+  done
+
+  regex+="$"
+  printf '%s\n' "$regex"
 }
 
 # Check bash command permissions

--- a/.github/codex-review-prompt.md
+++ b/.github/codex-review-prompt.md
@@ -81,9 +81,9 @@ The checked-out workspace is the trusted base branch, not the PR head. Use the d
 {PLACEHOLDER_PR_HEAD_FILES}
 </pr_head_files>
 
-## Deep CI Whole-File Logic Pass
+## Deep CI Whole-File / Chunked Logic Pass
 
-Normal diff review still applies to the full PR. In addition, inspect the selected full current PR-head file snapshots below for resulting whole-file behavior caused by the changed code.
+Normal diff review still applies to the full PR. In addition, inspect the selected Deep CI context below (full-file snapshots for smaller files, changed-line chunks for oversized files) for resulting behavior caused by the changed code.
 
 Focus only on behavior-affecting logic issues:
 - variable lifecycle and state initialization
@@ -93,7 +93,7 @@ Focus only on behavior-affecting logic issues:
 - persisted values that are consumed later
 - invariants introduced or broken by the diff
 
-Do not comment on markdown, prose, style, formatting, naming, pre-existing issues, or files that were not modified by this PR. Deep CI findings must still use the same JSON array schema and must still point to an exact RIGHT-side changed line from the diff. If a whole-file behavior concern cannot be tied to a changed line, omit it.
+Do not comment on markdown, prose, style, formatting, naming, pre-existing issues, or files that were not modified by this PR. Deep CI findings must still use the same JSON array schema and must still point to an exact RIGHT-side changed line from the diff. Chunked context is partial: do not infer findings that require omitted code unless the diff itself proves the issue. If a behavior concern cannot be tied to a changed line, omit it.
 
 <deep_ci_files>
 {PLACEHOLDER_DEEP_CI_FILES}

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -657,7 +657,12 @@ def render_deep_ci_context(snapshots, selected_files=None):
                 chunk_header,
                 (
                     "Changed RIGHT-side lines in this chunk: "
-                    + ", ".join(str(line) for line in chunk.get("changed_lines", []))
+                    + ", ".join(
+                        str(line)
+                        for line in chunk.get(
+                            "changed_lines_included", chunk.get("changed_lines", [])
+                        )
+                    )
                 ),
             ]
             omitted = chunk.get("changed_lines_omitted") or []

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -263,10 +263,11 @@ def build_line_windows(
     line_count,
     context_lines=DEEP_CI_CHUNK_CONTEXT_LINES,
     max_chunks=DEEP_CI_MAX_CHUNKS_PER_FILE,
+    include_omitted=False,
 ):
     """Expand and merge line windows around changed ranges with deterministic caps."""
     if not ranges or line_count < 1:
-        return []
+        return {"included": [], "omitted": []} if include_omitted else []
 
     expanded = []
     for start, end in ranges:
@@ -286,7 +287,7 @@ def build_line_windows(
         )
 
     if not expanded:
-        return []
+        return {"included": [], "omitted": []} if include_omitted else []
 
     expanded.sort(key=lambda item: (item["start_line"], item["end_line"]))
     merged = [expanded[0]]
@@ -303,6 +304,7 @@ def build_line_windows(
         else:
             merged.append(window)
 
+    omitted = []
     if len(merged) > max_chunks:
         ranked = sorted(
             merged,
@@ -312,7 +314,12 @@ def build_line_windows(
                 item["end_line"],
             ),
         )[:max_chunks]
+        ranked_ids = {id(item) for item in ranked}
+        omitted = [item for item in merged if id(item) not in ranked_ids]
         merged = sorted(ranked, key=lambda item: (item["start_line"], item["end_line"]))
+
+    if include_omitted:
+        return {"included": merged, "omitted": omitted}
 
     return merged
 
@@ -533,12 +540,18 @@ def fetch_deep_ci_files(
             )
             continue
 
-        windows = build_line_windows(
+        window_plan = build_line_windows(
             ranges,
             line_count,
             context_lines=context_lines,
             max_chunks=max_chunks_per_file,
+            include_omitted=True,
         )
+        windows = window_plan["included"]
+        chunk_cap_omitted_windows = [
+            {"start_line": window["start_line"], "end_line": window["end_line"]}
+            for window in window_plan["omitted"]
+        ]
         if not windows:
             snapshots.append(
                 _deep_ci_omitted_note(path, "no changed-line ranges found for oversized file")
@@ -602,6 +615,7 @@ def fetch_deep_ci_files(
                 "char_count": len(content),
                 "line_count": line_count,
                 "changed_line_ranges": ranges,
+                "chunk_cap_omitted_windows": chunk_cap_omitted_windows,
                 "total_cap_omitted_windows": total_cap_omitted_windows,
                 "omitted": False,
                 "reason": (
@@ -669,6 +683,16 @@ def render_deep_ci_context(snapshots, selected_files=None):
                 f"Total-cap omitted: {len(total_cap_omitted_windows)} changed-line "
                 f"window(s) ({omitted_ranges}) dropped because the Deep CI total "
                 f"character budget was exhausted"
+            )
+        chunk_cap_omitted_windows = snapshot.get("chunk_cap_omitted_windows") or []
+        if chunk_cap_omitted_windows:
+            omitted_ranges = ", ".join(
+                f"{w['start_line']}-{w['end_line']}" for w in chunk_cap_omitted_windows
+            )
+            file_lines.append(
+                f"Chunk-cap omitted: {len(chunk_cap_omitted_windows)} changed-line "
+                f"window(s) ({omitted_ranges}) dropped because the per-file chunk "
+                f"limit was reached"
             )
         for chunk in chunks:
             chunk_header = f"### {path} lines {chunk['start_line']}-{chunk['end_line']}"

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -35,6 +35,10 @@ DEEP_CI_MAX_CHANGES = 2000
 DEEP_CI_MAX_FILE_CHARS = 20000
 DEEP_CI_MAX_TOTAL_CHARS = 60000
 DEEP_CI_MAX_FILES = 3
+DEEP_CI_CHUNK_CONTEXT_LINES = 100
+DEEP_CI_MAX_CHUNKS_PER_FILE = 4
+DEEP_CI_MAX_CHUNK_CHARS = 12000
+DEEP_CI_MAX_FETCH_CHARS = 200000
 PROMPT_PLACEHOLDER_RE = re.compile(r"\{(PLACEHOLDER_[A-Z_]+)\}")
 
 
@@ -90,10 +94,7 @@ def _is_deleted_file(file_info):
 
 
 def _is_large_by_metadata(file_info, max_chars_per_file=DEEP_CI_MAX_FILE_CHARS):
-    size = file_info.get("size")
-    if isinstance(size, int) and size > max_chars_per_file:
-        return True
-
+    del max_chars_per_file  # metadata size no longer disqualifies chunk fallback candidates
     changes = file_info.get("changes")
     if isinstance(changes, int) and changes > DEEP_CI_MAX_CHANGES:
         return True
@@ -149,7 +150,12 @@ def select_deep_ci_files(changed_files, max_files=DEEP_CI_MAX_FILES):
 def _deep_ci_omitted_note(path, reason):
     return {
         "path": path,
+        "mode": "skipped",
         "content": "",
+        "chunks": [],
+        "char_count": 0,
+        "line_count": 0,
+        "changed_line_ranges": [],
         "omitted": True,
         "reason": reason,
     }
@@ -161,19 +167,267 @@ def markdown_code_fence(content):
     return "`" * max(3, longest + 1)
 
 
+def _merge_ranges(ranges):
+    if not ranges:
+        return []
+    sorted_ranges = sorted(ranges, key=lambda value: (value[0], value[1]))
+    merged = [sorted_ranges[0]]
+    for start, end in sorted_ranges[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end + 1:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def parse_changed_line_ranges(diff_text):
+    """Return path->right-side changed line ranges from a unified diff."""
+    if not isinstance(diff_text, str) or not diff_text.strip():
+        return {}
+
+    per_path = {}
+    current_path = None
+    current_line = None
+    pending_start = None
+    pending_end = None
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+    def flush_pending():
+        nonlocal pending_start, pending_end
+        if current_path is None or pending_start is None or pending_end is None:
+            pending_start = None
+            pending_end = None
+            return
+        per_path.setdefault(current_path, []).append((pending_start, pending_end))
+        pending_start = None
+        pending_end = None
+
+    for raw_line in diff_text.splitlines():
+        line = raw_line.rstrip("\n")
+
+        if current_line is None and line.startswith("+++ "):
+            flush_pending()
+            marker = line[4:]
+            if marker == "/dev/null":
+                current_path = None
+            elif marker.startswith("b/"):
+                current_path = marker[2:]
+            else:
+                current_path = marker
+            current_line = None
+            continue
+
+        if line.startswith("diff --git "):
+            flush_pending()
+            current_line = None
+            continue
+
+        hunk_match = hunk_re.match(line)
+        if hunk_match:
+            flush_pending()
+            current_line = int(hunk_match.group(1))
+            continue
+
+        if current_path is None or current_line is None:
+            continue
+
+        if line.startswith("+"):
+            if pending_start is None:
+                pending_start = current_line
+            pending_end = current_line
+            current_line += 1
+            continue
+
+        if line.startswith("-") and not line.startswith("---"):
+            flush_pending()
+            continue
+
+        if line.startswith(" "):
+            flush_pending()
+            current_line += 1
+            continue
+
+        if line.startswith("\\"):
+            continue
+
+        flush_pending()
+
+    flush_pending()
+
+    return {path: _merge_ranges(ranges) for path, ranges in per_path.items() if ranges}
+
+
+def build_line_windows(
+    ranges,
+    line_count,
+    context_lines=DEEP_CI_CHUNK_CONTEXT_LINES,
+    max_chunks=DEEP_CI_MAX_CHUNKS_PER_FILE,
+):
+    """Expand and merge line windows around changed ranges with deterministic caps."""
+    if not ranges or line_count < 1:
+        return []
+
+    expanded = []
+    for start, end in ranges:
+        if not isinstance(start, int) or not isinstance(end, int):
+            continue
+        if start < 1 or end < start:
+            continue
+        changed_start = max(1, min(start, line_count))
+        changed_end = max(changed_start, min(end, line_count))
+        expanded.append(
+            {
+                "start_line": max(1, changed_start - context_lines),
+                "end_line": min(line_count, changed_end + context_lines),
+                "changed_ranges": [(changed_start, changed_end)],
+                "changed_line_count": changed_end - changed_start + 1,
+            }
+        )
+
+    if not expanded:
+        return []
+
+    expanded.sort(key=lambda item: (item["start_line"], item["end_line"]))
+    merged = [expanded[0]]
+    for window in expanded[1:]:
+        current = merged[-1]
+        if window["start_line"] <= current["end_line"] + 1:
+            current["end_line"] = max(current["end_line"], window["end_line"])
+            current["changed_ranges"].extend(window["changed_ranges"])
+            current["changed_ranges"] = _merge_ranges(current["changed_ranges"])
+            current["changed_line_count"] = sum(
+                (range_end - range_start + 1)
+                for range_start, range_end in current["changed_ranges"]
+            )
+        else:
+            merged.append(window)
+
+    if len(merged) > max_chunks:
+        ranked = sorted(
+            merged,
+            key=lambda item: (
+                -item["changed_line_count"],
+                item["start_line"],
+                item["end_line"],
+            ),
+        )[:max_chunks]
+        merged = sorted(ranked, key=lambda item: (item["start_line"], item["end_line"]))
+
+    return merged
+
+
+def extract_line_chunk(content, start, end):
+    """Extract a one-based inclusive line range from content."""
+    lines = content.splitlines()
+    if not lines:
+        return ""
+    start_line = max(1, start)
+    end_line = min(len(lines), end)
+    if end_line < start_line:
+        return ""
+    return "\n".join(lines[start_line - 1 : end_line])
+
+
+def _text_len(lines):
+    if not lines:
+        return 0
+    return sum(len(line) for line in lines) + max(0, len(lines) - 1)
+
+
+def fit_chunk_to_char_cap(chunk, changed_lines, cap=DEEP_CI_MAX_CHUNK_CHARS):
+    """Trim a chunk to cap while preserving changed lines when possible."""
+    start_line = int(chunk.get("start_line", 1))
+    end_line = int(chunk.get("end_line", start_line))
+    content = chunk.get("content", "")
+    lines = content.splitlines()
+    if not lines:
+        return {
+            "start_line": start_line,
+            "end_line": end_line,
+            "content": "",
+            "changed_lines_included": [],
+            "changed_lines_omitted": sorted(changed_lines),
+        }
+
+    absolute_lines = list(range(start_line, start_line + len(lines)))
+    changed = sorted(line for line in changed_lines if line in set(absolute_lines))
+
+    if _text_len(lines) <= cap:
+        return {
+            "start_line": start_line,
+            "end_line": end_line,
+            "content": content,
+            "changed_lines_included": changed,
+            "changed_lines_omitted": [],
+        }
+
+    first_changed_idx = 0
+    last_changed_idx = len(lines) - 1
+    if changed:
+        first_changed_idx = max(0, changed[0] - start_line)
+        last_changed_idx = min(len(lines) - 1, changed[-1] - start_line)
+
+    keep_start = 0
+    keep_end = len(lines) - 1
+    while (
+        keep_start <= keep_end
+        and _text_len(lines[keep_start : keep_end + 1]) > cap
+        and (keep_start < first_changed_idx or keep_end > last_changed_idx)
+    ):
+        if keep_start < first_changed_idx:
+            keep_start += 1
+        if _text_len(lines[keep_start : keep_end + 1]) > cap and keep_end > last_changed_idx:
+            keep_end -= 1
+
+    kept_lines = lines[keep_start : keep_end + 1]
+    if _text_len(kept_lines) > cap:
+        keep_start = first_changed_idx
+        selected = []
+        current_len = 0
+        for candidate in lines[keep_start:]:
+            addition = len(candidate) + (1 if selected else 0)
+            if selected and current_len + addition > cap:
+                break
+            if not selected and addition > cap:
+                selected = [candidate[:cap]]
+                current_len = len(selected[0])
+                break
+            selected.append(candidate)
+            current_len += addition
+        kept_lines = selected
+        keep_end = keep_start + len(kept_lines) - 1
+
+    kept_content = "\n".join(kept_lines)
+    new_start = start_line + keep_start
+    new_end = start_line + keep_end if kept_lines else new_start - 1
+    included = [line for line in changed if new_start <= line <= new_end]
+    omitted = [line for line in changed if line not in included]
+    return {
+        "start_line": new_start,
+        "end_line": new_end,
+        "content": kept_content,
+        "changed_lines_included": included,
+        "changed_lines_omitted": omitted,
+    }
+
+
 def fetch_deep_ci_files(
     repo,
     head_sha,
     selected_files,
+    changed_line_ranges=None,
     max_chars_per_file=DEEP_CI_MAX_FILE_CHARS,
     max_total_chars=DEEP_CI_MAX_TOTAL_CHARS,
+    max_fetch_chars=DEEP_CI_MAX_FETCH_CHARS,
+    context_lines=DEEP_CI_CHUNK_CONTEXT_LINES,
+    max_chunks_per_file=DEEP_CI_MAX_CHUNKS_PER_FILE,
+    max_chunk_chars=DEEP_CI_MAX_CHUNK_CHARS,
 ):
-    """Fetch selected PR-head full files as read-only Deep CI snapshots.
-
-    Over-cap and unavailable files are omitted entirely from the whole-file pass.
-    """
+    """Fetch selected PR-head full/chunked files as read-only Deep CI snapshots."""
     snapshots = []
     total_chars = 0
+    changed_line_ranges = changed_line_ranges or {}
     for path in selected_files:
         encoded_path = quote(path, safe="/")
         cmd = [
@@ -191,25 +445,110 @@ def fetch_deep_ci_files(
             continue
 
         content = result.stdout
-        if len(content) > max_chars_per_file:
+        line_count = len(content.splitlines())
+        if len(content) > max_fetch_chars:
             snapshots.append(
                 _deep_ci_omitted_note(
                     path,
-                    f"current file size exceeds {max_chars_per_file} chars",
-                )
-            )
-            continue
-        if total_chars + len(content) > max_total_chars:
-            snapshots.append(
-                _deep_ci_omitted_note(
-                    path,
-                    f"Deep CI total content cap exceeds {max_total_chars} chars",
+                    f"file exceeds Deep CI hard fetch cap of {max_fetch_chars} chars",
                 )
             )
             continue
 
-        total_chars += len(content)
-        snapshots.append({"path": path, "content": content, "omitted": False, "reason": ""})
+        if len(content) <= max_chars_per_file:
+            if total_chars + len(content) > max_total_chars:
+                snapshots.append(_deep_ci_omitted_note(path, "total-cap-exhausted"))
+                continue
+            total_chars += len(content)
+            snapshots.append(
+                {
+                    "path": path,
+                    "mode": "full",
+                    "content": content,
+                    "chunks": [],
+                    "char_count": len(content),
+                    "line_count": line_count,
+                    "changed_line_ranges": changed_line_ranges.get(path, []),
+                    "omitted": False,
+                    "reason": "",
+                }
+            )
+            continue
+
+        ranges = changed_line_ranges.get(path, [])
+        if not ranges:
+            snapshots.append(
+                _deep_ci_omitted_note(path, "no changed-line ranges found for oversized file")
+            )
+            continue
+
+        windows = build_line_windows(
+            ranges,
+            line_count,
+            context_lines=context_lines,
+            max_chunks=max_chunks_per_file,
+        )
+        if not windows:
+            snapshots.append(
+                _deep_ci_omitted_note(path, "no changed-line ranges found for oversized file")
+            )
+            continue
+
+        chunks = []
+        for window in windows:
+            start_line = window["start_line"]
+            end_line = window["end_line"]
+            changed_lines = []
+            for range_start, range_end in window["changed_ranges"]:
+                changed_lines.extend(range(range_start, range_end + 1))
+            changed_lines = sorted(set(changed_lines))
+            raw_chunk = {
+                "start_line": start_line,
+                "end_line": end_line,
+                "content": extract_line_chunk(content, start_line, end_line),
+            }
+            fitted_chunk = fit_chunk_to_char_cap(
+                raw_chunk,
+                changed_lines,
+                cap=max_chunk_chars,
+            )
+            chunk_content = fitted_chunk["content"]
+            if not chunk_content:
+                continue
+            chunk_chars = len(chunk_content)
+            if total_chars + chunk_chars > max_total_chars:
+                break
+            total_chars += chunk_chars
+            chunks.append(
+                {
+                    "start_line": fitted_chunk["start_line"],
+                    "end_line": fitted_chunk["end_line"],
+                    "content": chunk_content,
+                    "changed_lines": changed_lines,
+                    "changed_lines_included": fitted_chunk["changed_lines_included"],
+                    "changed_lines_omitted": fitted_chunk["changed_lines_omitted"],
+                }
+            )
+
+        if not chunks:
+            snapshots.append(_deep_ci_omitted_note(path, "total-cap-exhausted"))
+            continue
+
+        snapshots.append(
+            {
+                "path": path,
+                "mode": "chunked",
+                "content": "",
+                "chunks": chunks,
+                "char_count": len(content),
+                "line_count": line_count,
+                "changed_line_ranges": ranges,
+                "omitted": False,
+                "reason": (
+                    f"full file exceeded {max_chars_per_file} chars; only changed-line windows are included"
+                ),
+            }
+        )
 
     return snapshots
 
@@ -217,26 +556,73 @@ def fetch_deep_ci_files(
 def render_deep_ci_context(snapshots, selected_files=None):
     """Render Deep CI snapshots and omission notes as prompt markdown."""
     if not snapshots:
-        return "No eligible changed code files selected for Deep CI whole-file review.\n"
+        return "No eligible changed code files selected for Deep CI context review.\n"
 
     rendered = []
     selected_count = len(selected_files or snapshots)
     rendered.append(
-        f"Selected {selected_count} changed code file(s) for bounded Deep CI whole-file review."
+        f"Selected {selected_count} changed code file(s) for bounded Deep CI context review."
     )
     for snapshot in snapshots:
         path = snapshot["path"]
-        if snapshot.get("omitted"):
+        mode = snapshot.get("mode", "skipped")
+        if mode == "skipped":
             rendered.append(
-                "## "
-                + path
-                + "\n"
-                + f"Skipped Deep CI whole-file review for {path} because {snapshot['reason']}."
+                f"## {path}\n"
+                "Mode: skipped\n"
+                f"Skipped Deep CI review for {path} because {snapshot['reason']}."
             )
             continue
-        content = snapshot["content"].rstrip()
-        fence = markdown_code_fence(content)
-        rendered.append(f"## {path}\n{fence}\n{content}\n{fence}")
+        if mode == "full":
+            content = snapshot["content"].rstrip()
+            fence = markdown_code_fence(content)
+            rendered.append(
+                "\n".join(
+                    [
+                        f"## {path}",
+                        "Mode: full-file",
+                        f"Size: {snapshot.get('char_count', len(snapshot['content']))} chars, {snapshot.get('line_count', 0)} lines",
+                        fence,
+                        content,
+                        fence,
+                    ]
+                )
+            )
+            continue
+
+        chunks = snapshot.get("chunks", [])
+        ranges = ", ".join(f"{chunk['start_line']}-{chunk['end_line']}" for chunk in chunks)
+        file_lines = [
+            f"## {path}",
+            "Mode: chunked-large-file",
+            f"Size: {snapshot.get('char_count', 0)} chars, {snapshot.get('line_count', 0)} lines",
+            f"Included chunks: {len(chunks)}",
+            f"Included line ranges: {ranges}",
+            f"Omitted: {snapshot.get('reason', '')}",
+        ]
+        for chunk in chunks:
+            chunk_header = f"### {path} lines {chunk['start_line']}-{chunk['end_line']}"
+            chunk_lines = [
+                chunk_header,
+                (
+                    "Changed RIGHT-side lines in this chunk: "
+                    + ", ".join(str(line) for line in chunk.get("changed_lines", []))
+                ),
+            ]
+            omitted = chunk.get("changed_lines_omitted") or []
+            if omitted:
+                chunk_lines.append(
+                    "changed_lines_included: "
+                    + ", ".join(str(line) for line in chunk.get("changed_lines_included", []))
+                )
+                chunk_lines.append(
+                    "changed_lines_omitted: " + ", ".join(str(line) for line in omitted)
+                )
+            content = chunk.get("content", "").rstrip()
+            fence = markdown_code_fence(content)
+            chunk_lines.extend([fence, content, fence])
+            file_lines.append("\n".join(chunk_lines))
+        rendered.append("\n\n".join(file_lines))
 
     return "\n\n".join(rendered).strip() + "\n"
 
@@ -312,7 +698,14 @@ def gather_context():
 
     changed_file_metadata = load_changed_file_metadata()
     selected_deep_ci_files = select_deep_ci_files(changed_file_metadata)
-    deep_ci_snapshots = fetch_deep_ci_files(repo, head_sha, selected_deep_ci_files)
+    diff_text = _read_text_if_exists("/tmp/pr.diff")
+    changed_line_ranges = parse_changed_line_ranges(diff_text)
+    deep_ci_snapshots = fetch_deep_ci_files(
+        repo,
+        head_sha,
+        selected_deep_ci_files,
+        changed_line_ranges=changed_line_ranges,
+    )
     deep_ci_context = render_deep_ci_context(deep_ci_snapshots, selected_deep_ci_files)
     Path('/tmp/deep_ci_files.md').write_text(deep_ci_context, encoding='utf-8')
 

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -546,7 +546,8 @@ def fetch_deep_ci_files(
             continue
 
         chunks = []
-        for window in windows:
+        total_cap_omitted_windows = []
+        for idx, window in enumerate(windows):
             start_line = window["start_line"]
             end_line = window["end_line"]
             changed_lines = []
@@ -568,6 +569,13 @@ def fetch_deep_ci_files(
                 continue
             chunk_chars = len(chunk_content)
             if total_chars + chunk_chars > max_total_chars:
+                # Total cap reached mid-file: record every remaining planned
+                # window (including this one) so rendering can surface the
+                # dropped ranges explicitly rather than silently truncating.
+                total_cap_omitted_windows = [
+                    {"start_line": w["start_line"], "end_line": w["end_line"]}
+                    for w in windows[idx:]
+                ]
                 break
             total_chars += chunk_chars
             chunks.append(
@@ -594,6 +602,7 @@ def fetch_deep_ci_files(
                 "char_count": len(content),
                 "line_count": line_count,
                 "changed_line_ranges": ranges,
+                "total_cap_omitted_windows": total_cap_omitted_windows,
                 "omitted": False,
                 "reason": (
                     f"full file exceeded {max_chars_per_file} chars; only changed-line windows are included"
@@ -651,6 +660,16 @@ def render_deep_ci_context(snapshots, selected_files=None):
             f"Included line ranges: {ranges}",
             f"Omitted: {snapshot.get('reason', '')}",
         ]
+        total_cap_omitted_windows = snapshot.get("total_cap_omitted_windows") or []
+        if total_cap_omitted_windows:
+            omitted_ranges = ", ".join(
+                f"{w['start_line']}-{w['end_line']}" for w in total_cap_omitted_windows
+            )
+            file_lines.append(
+                f"Total-cap omitted: {len(total_cap_omitted_windows)} changed-line "
+                f"window(s) ({omitted_ranges}) dropped because the Deep CI total "
+                f"character budget was exhausted"
+            )
         for chunk in chunks:
             chunk_header = f"### {path} lines {chunk['start_line']}-{chunk['end_line']}"
             chunk_lines = [

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -412,6 +412,29 @@ def fit_chunk_to_char_cap(chunk, changed_lines, cap=DEEP_CI_MAX_CHUNK_CHARS):
     }
 
 
+def _metadata_size_exceeds_hard_cap(file_info, max_fetch_chars):
+    """Return True when PR file metadata reports a size exceeding the hard cap.
+
+    Treat any missing or non-integer size field as "unknown size, proceed to
+    fetch" so the post-fetch safeguard remains the backstop. GitHub's PR
+    files endpoint does not guarantee a byte-size field, so we check a small
+    allowlist of plausible keys that callers may populate (``size``,
+    ``byteSize``, ``char_count``). The function never disqualifies a file
+    based on line-count proxies like ``changes`` -- those are covered by
+    ``_is_large_by_metadata`` during candidate selection, not the hard-cap
+    pre-fetch guard.
+    """
+    if not isinstance(file_info, dict):
+        return False
+    for field in ("size", "byteSize", "char_count"):
+        value = file_info.get(field)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value > max_fetch_chars:
+            return True
+    return False
+
+
 def fetch_deep_ci_files(
     repo,
     head_sha,
@@ -423,12 +446,37 @@ def fetch_deep_ci_files(
     context_lines=DEEP_CI_CHUNK_CONTEXT_LINES,
     max_chunks_per_file=DEEP_CI_MAX_CHUNKS_PER_FILE,
     max_chunk_chars=DEEP_CI_MAX_CHUNK_CHARS,
+    file_metadata=None,
 ):
     """Fetch selected PR-head full/chunked files as read-only Deep CI snapshots."""
     snapshots = []
     total_chars = 0
     changed_line_ranges = changed_line_ranges or {}
+    metadata_by_path = {}
+    if isinstance(file_metadata, dict):
+        metadata_by_path = file_metadata
+    elif isinstance(file_metadata, list):
+        for entry in file_metadata:
+            info = _normalize_path_info(entry)
+            path = info.get("path")
+            if path:
+                metadata_by_path[path] = info
+
     for path in selected_files:
+        metadata = metadata_by_path.get(path) or {}
+        # Pre-fetch guard: if PR metadata already tells us the file exceeds
+        # the hard fetch cap, skip the gh api call entirely. This preserves
+        # the F1 visibility behavior (rendered as Mode: skipped with a
+        # hard-cap reason) without pulling the full body first.
+        if _metadata_size_exceeds_hard_cap(metadata, max_fetch_chars):
+            snapshots.append(
+                _deep_ci_omitted_note(
+                    path,
+                    f"file exceeds Deep CI hard fetch cap of {max_fetch_chars} chars",
+                )
+            )
+            continue
+
         encoded_path = quote(path, safe="/")
         cmd = [
             "gh",
@@ -446,6 +494,9 @@ def fetch_deep_ci_files(
 
         content = result.stdout
         line_count = len(content.splitlines())
+        # Backstop: if metadata lacked a size field (or the size was under
+        # the cap but the real file exceeds it), skip with the same reason
+        # string as the pre-fetch path so downstream rendering is uniform.
         if len(content) > max_fetch_chars:
             snapshots.append(
                 _deep_ci_omitted_note(
@@ -705,6 +756,7 @@ def gather_context():
         head_sha,
         selected_deep_ci_files,
         changed_line_ranges=changed_line_ranges,
+        file_metadata=changed_file_metadata,
     )
     deep_ci_context = render_deep_ci_context(deep_ci_snapshots, selected_deep_ci_files)
     Path('/tmp/deep_ci_files.md').write_text(deep_ci_context, encoding='utf-8')

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -101,9 +101,10 @@ scripts/quest_complete.py
 scripts/quest_preflight.sh
 scripts/quest_state.py
 tests/integration/test-enforce-allowlist.sh
-tests/unit/test_allowlist_matcher.py
-tests/unit/test_review_intelligence.py
-tests/unit/test_codex_skill_wrappers.py
+tests/test-quest-preflight.sh
+tests/test-quest-runtime.sh
+tests/test-validate-handoff-contracts.sh
+tests/test-validate-quest-state.sh
 
 [user-customized]
 # These files preserve local customizations; AGENTS.md updates in place only when

--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -223,8 +223,8 @@ Rules:
   - Codex / OpenAI → `noreply@openai.com`
   - OpenCode → `noreply@opencode.ai`
 - Resolve `<human author identity>` from local git config when available:
-  - Prefer `git config user.name` + `git config user.email` and format as `Name <email>`
-  - If only a GitHub username can be inferred from git config or the remote URL, use that username
+  - Prefer a GitHub username when it can be inferred from the remote URL or GitHub CLI context
+  - Otherwise use `git config user.name`
   - If no human identity can be verified, use `the repository author`
 - The `in collaboration with` line is always present and always last.
 

--- a/.skills/quest/agents/arbiter.md
+++ b/.skills/quest/agents/arbiter.md
@@ -35,8 +35,8 @@ The Arbiter exists to **prevent spin** and enforce engineering pragmatism. It fi
    - `iterate` — plan needs changes. Provide a focused, prioritized list of issues for the Planner.
    - `approve` — plan is good enough. Proceed to Builder.
 6. Write the verdict to `.quest/<id>/phase_01_plan/arbiter_verdict.md.next`
-7. Synthesize canonical findings from both review markdown artifacts and write:
-   - `.quest/<id>/phase_01_plan/review_findings.json` (or the orchestrator-provided `.next` scratch path for atomic publish)
+7. Synthesize canonical findings from both review markdown artifacts and write the scratch artifact:
+   - `.quest/<id>/phase_01_plan/review_findings.json.next`
    - If no actionable findings exist, write an empty array (`[]`) instead of skipping the file
 
 Canonical findings schema (required fields per finding):

--- a/.skills/quest/agents/arbiter.md
+++ b/.skills/quest/agents/arbiter.md
@@ -34,7 +34,7 @@ The Arbiter exists to **prevent spin** and enforce engineering pragmatism. It fi
 5. Produce a **synthesized verdict** with one of:
    - `iterate` — plan needs changes. Provide a focused, prioritized list of issues for the Planner.
    - `approve` — plan is good enough. Proceed to Builder.
-6. Write the verdict to `.quest/<id>/phase_01_plan/arbiter_verdict.md`
+6. Write the verdict to `.quest/<id>/phase_01_plan/arbiter_verdict.md.next`
 7. Synthesize canonical findings from both review markdown artifacts and write:
    - `.quest/<id>/phase_01_plan/review_findings.json` (or the orchestrator-provided `.next` scratch path for atomic publish)
    - If no actionable findings exist, write an empty array (`[]`) instead of skipping the file
@@ -108,7 +108,7 @@ A plan is NOT ready when:
 {
   "status": "complete | needs_human | blocked",
   "artifacts": [
-    ".quest/<id>/phase_01_plan/arbiter_verdict.md",
+    ".quest/<id>/phase_01_plan/arbiter_verdict.md.next",
     ".quest/<id>/phase_01_plan/review_findings.json.next"
   ],
   "next": "planner | builder",
@@ -120,7 +120,7 @@ A plan is NOT ready when:
 ```text
 ---HANDOFF---
 STATUS: complete | needs_human | blocked
-ARTIFACTS: .quest/<id>/phase_01_plan/arbiter_verdict.md, .quest/<id>/phase_01_plan/review_findings.json.next
+ARTIFACTS: .quest/<id>/phase_01_plan/arbiter_verdict.md.next, .quest/<id>/phase_01_plan/review_findings.json.next
 NEXT: planner | builder
 SUMMARY: Iteration <N>: <approve|iterate> — <reason>
 ```

--- a/.skills/quest/agents/arbiter.md
+++ b/.skills/quest/agents/arbiter.md
@@ -1,7 +1,7 @@
 # Arbiter Agent
 
 ## Role
-Gatekeeper for plan quality and canonical review decisions. Receives both plan-review artifacts, synthesizes their feedback, filters out noise, decides whether the plan is ready for implementation, and emits canonical findings/backlog artifacts.
+Gatekeeper for plan quality and canonical review decisions. Receives both plan-review artifacts, synthesizes their feedback, filters out noise, decides whether the plan is ready for implementation, and emits canonical findings artifacts.
 
 ## Tool
 Claude runtime. Use native `Task(subagent_type="arbiter")` when the orchestrator supports Claude tasks; in Codex-led Quest runs, use `python3 scripts/quest_claude_runner.py` as the orchestration entrypoint. `scripts/quest_claude_bridge.py` remains the transport layer behind that runner.
@@ -36,10 +36,43 @@ The Arbiter exists to **prevent spin** and enforce engineering pragmatism. It fi
    - `approve` — plan is good enough. Proceed to Builder.
 6. Write the verdict to `.quest/<id>/phase_01_plan/arbiter_verdict.md`
 7. Synthesize canonical findings from both review markdown artifacts and write:
-   - `.quest/<id>/phase_01_plan/review_findings.json`
+   - `.quest/<id>/phase_01_plan/review_findings.json` (or the orchestrator-provided `.next` scratch path for atomic publish)
    - If no actionable findings exist, write an empty array (`[]`) instead of skipping the file
-8. Build a canonical decision backlog and write:
-   - `.quest/<id>/phase_01_plan/review_backlog.json`
+
+Canonical findings schema (required fields per finding):
+`finding_id, source, kind, severity, confidence, path, line, summary, why_it_matters, evidence, action, needs_test, write_scope, related_acceptance_criteria`
+
+Allowed enum values:
+- `severity`: `critical`, `high`, `medium`, `low`, `info`
+- `confidence`: `high`, `medium`, `low`
+
+Minimal valid finding example:
+```json
+[
+  {
+    "finding_id": "arb-it2-b3",
+    "source": "arbiter",
+    "kind": "regression-risk",
+    "severity": "medium",
+    "confidence": "high",
+    "path": "scripts/quest_review_intelligence.py",
+    "line": 95,
+    "summary": "build-backlog requires an explicit --phase selector.",
+    "why_it_matters": "Without explicit phase policy, review-phase decisions can regress.",
+    "evidence": [
+      "Current build-backlog invocation omits phase context."
+    ],
+    "action": "Add --phase {plan,review} and pass --phase plan from workflow Step 3.",
+    "needs_test": true,
+    "write_scope": [
+      "scripts/quest_review_intelligence.py",
+      "scripts/quest_runtime/review_intelligence.py",
+      "tests/unit/test_review_intelligence.py"
+    ],
+    "related_acceptance_criteria": ["B2", "B5"]
+  }
+]
+```
 
 ## Decision Criteria for "Good Enough"
 A plan is ready when:
@@ -76,8 +109,7 @@ A plan is NOT ready when:
   "status": "complete | needs_human | blocked",
   "artifacts": [
     ".quest/<id>/phase_01_plan/arbiter_verdict.md",
-    ".quest/<id>/phase_01_plan/review_findings.json",
-    ".quest/<id>/phase_01_plan/review_backlog.json"
+    ".quest/<id>/phase_01_plan/review_findings.json.next"
   ],
   "next": "planner | builder",
   "summary": "Iteration <N>: <approve|iterate> — <reason>"
@@ -88,7 +120,7 @@ A plan is NOT ready when:
 ```text
 ---HANDOFF---
 STATUS: complete | needs_human | blocked
-ARTIFACTS: .quest/<id>/phase_01_plan/arbiter_verdict.md, .quest/<id>/phase_01_plan/review_findings.json, .quest/<id>/phase_01_plan/review_backlog.json
+ARTIFACTS: .quest/<id>/phase_01_plan/arbiter_verdict.md, .quest/<id>/phase_01_plan/review_findings.json.next
 NEXT: planner | builder
 SUMMARY: Iteration <N>: <approve|iterate> — <reason>
 ```

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -525,8 +525,8 @@ gates.max_plan_iterations (default: 4)
    - If arbiter handoff says `next: builder` and findings validation passed:
      - Build backlog from validated findings:
        - `python3 scripts/quest_review_intelligence.py build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next`
-     - Optional guard:
-       - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next`
+     - Validate the plan-phase backlog before publish:
+       - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan`
      - On build-backlog or validate-backlog failure: STOP route, do not transition, preserve canonical artifacts, leave `.next` files for inspection.
      - Publish atomically only after both files validate:
        - `os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")`

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -128,7 +128,7 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 5. **Artifact preparation (before every role invocation):**
    Before invoking any role, the orchestrator MUST:
    1. Resolve artifact paths: `expected_artifacts_for_role(quest_dir, phase, agent)`
-   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates role-output files while preserving canonical state files that the runtime marks preserve-on-prepare.
+   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates role-output scratch files.
    3. Include in the role prompt:
       ```
       Artifact files have been prepared for you. Overwrite these files directly:
@@ -300,7 +300,7 @@ gates.max_plan_iterations (default: 4)
 
 **Loop:**
 
-0. **Clear stale handoff and scratch files:** If `plan_iteration >= 1` (i.e., any refinement pass after the first), delete any existing `handoff*.json` files in `.quest/<id>/phase_01_plan/` to prevent stale data from a previous iteration being read. Also delete stale arbiter scratch files (`review_findings.json.next`, `review_backlog.json.next`) before each arbiter attempt. Do **not** truncate last-known-good canonical files (`arbiter_verdict.md`, `review_findings.json`, `review_backlog.json`) during cleanup.
+0. **Clear stale handoff and scratch files:** If `plan_iteration >= 1` (i.e., any refinement pass after the first), delete any existing `handoff*.json` files in `.quest/<id>/phase_01_plan/` to prevent stale data from a previous iteration being read. Also delete stale arbiter scratch files (`arbiter_verdict.md.next`, `review_findings.json.next`, `review_backlog.json.next`) before each arbiter attempt. Do **not** truncate last-known-good canonical files (`arbiter_verdict.md`, `review_findings.json`, `review_backlog.json`) during cleanup.
 
 1. **Update state:** `plan_iteration += 1`, `status: in_progress`, `last_role: planner_agent`
 
@@ -481,11 +481,11 @@ gates.max_plan_iterations (default: 4)
      - `.quest/<id>/phase_01_plan/review_findings.json.next`
      - `.quest/<id>/phase_01_plan/review_backlog.json.next`
    - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare:
-     - `arbiter_verdict.md`
+     - `arbiter_verdict.md.next`
      - `review_findings.json.next`
      - `handoff_arbiter.json`
      in `.quest/<id>/phase_01_plan/`.
-     Existing `arbiter_verdict.md` is preserved during pre-run preparation.
+     Canonical `arbiter_verdict.md` is not prepared or truncated; publish `arbiter_verdict.md.next` only after validation succeeds.
    - Use a short prompt with path references only:
      ```
      You are the Arbiter Agent.
@@ -498,7 +498,7 @@ gates.max_plan_iterations (default: 4)
      Review B: .quest/<id>/phase_01_plan/review_plan-reviewer-b.md
 
      Artifact files have been prepared for you. Overwrite these files directly:
-     - .quest/<id>/phase_01_plan/arbiter_verdict.md
+     - .quest/<id>/phase_01_plan/arbiter_verdict.md.next
      - .quest/<id>/phase_01_plan/review_findings.json.next
      - .quest/<id>/phase_01_plan/handoff_arbiter.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
@@ -519,8 +519,10 @@ gates.max_plan_iterations (default: 4)
        - Surface validator output in orchestrator logs/user message.
        - Keep canonical artifacts untouched; keep `.next` files for debugging.
    - If arbiter handoff says `next: planner`:
-     - Skip `build-backlog` and skip atomic publish.
-     - Clean `.next` scratch files.
+     - Skip `build-backlog` and skip review findings/backlog publish.
+     - Publish the validated verdict scratch artifact:
+       - `os.replace(".quest/<id>/phase_01_plan/arbiter_verdict.md.next", ".quest/<id>/phase_01_plan/arbiter_verdict.md")`
+     - Clean `review_findings.json.next` / `review_backlog.json.next` scratch files.
      - Preserve canonical `review_findings.json` / `review_backlog.json`.
      - Return control to planner refinement loop.
    - If arbiter handoff says `next: builder` and findings validation passed:
@@ -529,7 +531,8 @@ gates.max_plan_iterations (default: 4)
      - Validate the plan-phase backlog before publish:
        - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults`
      - On build-backlog or validate-backlog failure: STOP route, do not transition, preserve canonical artifacts, leave `.next` files for inspection.
-     - Publish atomically only after both files validate:
+     - Publish atomically only after validation succeeds:
+       - `os.replace(".quest/<id>/phase_01_plan/arbiter_verdict.md.next", ".quest/<id>/phase_01_plan/arbiter_verdict.md")`
        - `os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")`
        - `os.replace(".quest/<id>/phase_01_plan/review_backlog.json.next", ".quest/<id>/phase_01_plan/review_backlog.json")`
      - On publish failure: STOP route, log full error, do not transition, and leave `.next` files in place.

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -128,7 +128,7 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 5. **Artifact preparation (before every role invocation):**
    Before invoking any role, the orchestrator MUST:
    1. Resolve artifact paths: `expected_artifacts_for_role(quest_dir, phase, agent)`
-   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates role-output scratch files.
+   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates every resolved role-output path. Canonical files that must survive failed attempts MUST NOT be returned by `expected_artifacts_for_role`; use scratch paths and publish after validation instead.
    3. Include in the role prompt:
       ```
       Artifact files have been prepared for you. Overwrite these files directly:

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -128,7 +128,7 @@ After any subagent completes, the orchestrator reads the agent's `handoff.json` 
 5. **Artifact preparation (before every role invocation):**
    Before invoking any role, the orchestrator MUST:
    1. Resolve artifact paths: `expected_artifacts_for_role(quest_dir, phase, agent)`
-   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates files
+   2. Prepare files: `prepare_artifact_files(paths)` — creates parent directories and truncates role-output files while preserving canonical state files that the runtime marks preserve-on-prepare.
    3. Include in the role prompt:
       ```
       Artifact files have been prepared for you. Overwrite these files directly:
@@ -485,6 +485,7 @@ gates.max_plan_iterations (default: 4)
      - `review_findings.json.next`
      - `handoff_arbiter.json`
      in `.quest/<id>/phase_01_plan/`.
+     Existing `arbiter_verdict.md` is preserved during pre-run preparation.
    - Use a short prompt with path references only:
      ```
      You are the Arbiter Agent.
@@ -526,7 +527,7 @@ gates.max_plan_iterations (default: 4)
      - Build backlog from validated findings:
        - `python3 scripts/quest_review_intelligence.py build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next`
      - Validate the plan-phase backlog before publish:
-       - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan`
+       - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults`
      - On build-backlog or validate-backlog failure: STOP route, do not transition, preserve canonical artifacts, leave `.next` files for inspection.
      - Publish atomically only after both files validate:
        - `os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")`
@@ -535,7 +536,7 @@ gates.max_plan_iterations (default: 4)
 
 6. **Check verdict and transition guard:**
    - If `NEXT: builder`:
-     - **Workflow mode only:** Transition only after successful `validate-findings` + `build-backlog --phase plan` (+ optional `validate-backlog`) + atomic publish. In solo mode the arbiter is skipped (see item 5 above), and so is the validate/build/publish pipeline — transition directly without those prerequisites.
+     - **Workflow mode only:** Transition only after successful `validate-findings` + `build-backlog --phase plan` + `validate-backlog --expected-phase plan --strict-plan-defaults` + atomic publish. In solo mode the arbiter is skipped (see item 5 above), and so is the validate/build/publish pipeline — transition directly without those prerequisites.
      - Then transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition plan_reviewed --status complete --last-verdict approve --expect-phase plan` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to **Step 3.5** (Interactive Presentation). Do not attempt the `presenting` transition while state still says `phase: plan`.
    - If `NEXT: planner` → Check iteration count
      - If `plan_iteration >= max_plan_iterations`: Warn user, ask to proceed anyway or review manually

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -535,7 +535,7 @@ gates.max_plan_iterations (default: 4)
 
 6. **Check verdict and transition guard:**
    - If `NEXT: builder`:
-     - Transition only after successful `validate-findings` + `build-backlog --phase plan` (+ optional `validate-backlog`) + atomic publish.
+     - **Workflow mode only:** Transition only after successful `validate-findings` + `build-backlog --phase plan` (+ optional `validate-backlog`) + atomic publish. In solo mode the arbiter is skipped (see item 5 above), and so is the validate/build/publish pipeline — transition directly without those prerequisites.
      - Then transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition plan_reviewed --status complete --last-verdict approve --expect-phase plan` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to **Step 3.5** (Interactive Presentation). Do not attempt the `presenting` transition while state still says `phase: plan`.
    - If `NEXT: planner` → Check iteration count
      - If `plan_iteration >= max_plan_iterations`: Warn user, ask to proceed anyway or review manually

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -300,7 +300,7 @@ gates.max_plan_iterations (default: 4)
 
 **Loop:**
 
-0. **Clear stale handoff files:** If `plan_iteration >= 1` (i.e., any refinement pass after the first), delete any existing `handoff*.json` files in `.quest/<id>/phase_01_plan/` to prevent stale data from a previous iteration being read.
+0. **Clear stale handoff and scratch files:** If `plan_iteration >= 1` (i.e., any refinement pass after the first), delete any existing `handoff*.json` files in `.quest/<id>/phase_01_plan/` to prevent stale data from a previous iteration being read. Also delete stale arbiter scratch files (`review_findings.json.next`, `review_backlog.json.next`) before each arbiter attempt. Do **not** truncate last-known-good canonical files (`arbiter_verdict.md`, `review_findings.json`, `review_backlog.json`) during cleanup.
 
 1. **Update state:** `plan_iteration += 1`, `status: in_progress`, `last_role: planner_agent`
 
@@ -472,13 +472,17 @@ gates.max_plan_iterations (default: 4)
    - Read `.quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json`
    - If `next: "arbiter"` → remap to `next: "builder"` (approved in solo mode)
    - If `next: "planner"` → plan needs revision (no remapping)
+   - Do not require `review_backlog.json` for the solo transition path.
    - Log: `Plan review: arbiter=skipped (solo mode, using reviewer-a verdict)` to `.quest/<id>/logs/parallelism.log`
 
    **If `quest_mode == "workflow"` (default):** Read `models.arbiter` from allowlist. Invoke Arbiter through the corresponding runtime:
+   - Contract-hardening rollout order (required when implementing this behavior): land workflow + helper CLI (`build-backlog --phase`) + runtime `.next` artifact wiring first; trim arbiter output contract second. This prevents transient mismatches during migration.
+   - Before each arbiter attempt, remove stale scratch artifacts:
+     - `.quest/<id>/phase_01_plan/review_findings.json.next`
+     - `.quest/<id>/phase_01_plan/review_backlog.json.next`
    - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare:
      - `arbiter_verdict.md`
-     - `review_findings.json`
-     - `review_backlog.json`
+     - `review_findings.json.next`
      - `handoff_arbiter.json`
      in `.quest/<id>/phase_01_plan/`.
    - Use a short prompt with path references only:
@@ -494,8 +498,7 @@ gates.max_plan_iterations (default: 4)
 
      Artifact files have been prepared for you. Overwrite these files directly:
      - .quest/<id>/phase_01_plan/arbiter_verdict.md
-     - .quest/<id>/phase_01_plan/review_findings.json
-     - .quest/<id>/phase_01_plan/review_backlog.json
+     - .quest/<id>/phase_01_plan/review_findings.json.next
      - .quest/<id>/phase_01_plan/handoff_arbiter.json
      Do not create Quest artifacts via shell redirection, heredocs, or echo.
      End with: ---HANDOFF--- STATUS/ARTIFACTS/NEXT/SUMMARY
@@ -503,18 +506,41 @@ gates.max_plan_iterations (default: 4)
      ```
    - Wait for the selected runtime to complete
    - Read `.quest/<id>/phase_01_plan/handoff_arbiter.json`
-   - Ensure `.quest/<id>/phase_01_plan/review_findings.json` always exists (empty array is valid)
-   - Route based on `next` field ("builder" = approved, "planner" = iterate)
    - Apply deterministic precedence from **Handoff File Polling** for native Claude task vs bridge execution
    - Fallback: if handoff.json missing or unparsable after that precedence, parse text handoff from response
+   - Immediately validate findings:
+     - `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next`
+   - If findings validation fails:
+     - Retry arbiter exactly once with the validator stderr/stdout embedded in the retry prompt.
+     - Re-run `validate-findings` on the second attempt.
+     - If validation still fails, STOP route:
+       - Do **not** call `quest_state.py --transition plan_reviewed`.
+       - Surface validator output in orchestrator logs/user message.
+       - Keep canonical artifacts untouched; keep `.next` files for debugging.
+   - If arbiter handoff says `next: planner`:
+     - Skip `build-backlog` and skip atomic publish.
+     - Clean `.next` scratch files.
+     - Preserve canonical `review_findings.json` / `review_backlog.json`.
+     - Return control to planner refinement loop.
+   - If arbiter handoff says `next: builder` and findings validation passed:
+     - Build backlog from validated findings:
+       - `python3 scripts/quest_review_intelligence.py build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next`
+     - Optional guard:
+       - `python3 scripts/quest_review_intelligence.py validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next`
+     - On build-backlog or validate-backlog failure: STOP route, do not transition, preserve canonical artifacts, leave `.next` files for inspection.
+     - Publish atomically only after both files validate:
+       - `os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")`
+       - `os.replace(".quest/<id>/phase_01_plan/review_backlog.json.next", ".quest/<id>/phase_01_plan/review_backlog.json")`
+     - On publish failure: STOP route, log full error, do not transition, and leave `.next` files in place.
 
-6. **Check verdict:**
+6. **Check verdict and transition guard:**
    - If `NEXT: builder`:
-     - Plan approved! Transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition plan_reviewed --status complete --last-verdict approve --expect-phase plan` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to **Step 3.5** (Interactive Presentation). Do not attempt the `presenting` transition while state still says `phase: plan`.
+     - Transition only after successful `validate-findings` + `build-backlog --phase plan` (+ optional `validate-backlog`) + atomic publish.
+     - Then transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition plan_reviewed --status complete --last-verdict approve --expect-phase plan` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to **Step 3.5** (Interactive Presentation). Do not attempt the `presenting` transition while state still says `phase: plan`.
    - If `NEXT: planner` → Check iteration count
      - If `plan_iteration >= max_plan_iterations`: Warn user, ask to proceed anyway or review manually
      - If `auto_approve_phases.plan_refinement` is false: Ask user to approve refinement
-     - Otherwise: Loop back to step 0 (stale handoff cleanup)
+     - Otherwise: Loop back to step 0 (stale handoff/scratch cleanup)
 
 ### Step 3.5: Interactive Plan Presentation (MANDATORY HUMAN GATE)
 

--- a/ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
+++ b/ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
@@ -1,0 +1,378 @@
+---
+title: Review-Skill Ergonomics and Team-Preference Memory
+purpose: Tighten Quest's review skills with concrete prompt-engineering and workflow changes, and add a lightweight file-based memory for team preferences that survives across quests.
+audience:
+  - quest-developers
+  - quest-users
+scope: Review-adjacent skills (code-reviewer, ci-code-reviewer, plan-reviewer, pr-shepherd, fixer), plus a new pre-commit review entry point and a new team-preference store.
+status: proposed
+owner: kjell
+date: 2026-04-22
+---
+
+## Problem
+
+Quest's review pipeline is structurally strong (plan review, dual code review, arbiter, fix loop with defer taxonomy) but several ergonomic and memory gaps reduce day-to-day quality:
+
+1. **No pre-commit review entry point.** We review plans and PRs, but there is nothing between "I finished coding" and "I push a PR". Developers either skip review or wait for a PR cycle.
+2. **Polling windows are loosely specified.** `pr-shepherd` says "wait ~180s if pending" — an LLM given latitude drifts. Sometimes it retries forever, sometimes gives up after one try.
+3. **LLM-default chattiness is unconstrained.** Review outputs frequently include padding ("Great work on X, one small nit..."), restated findings as top-level PR comments, and unsolicited justification replies. Each skill re-derives anti-chat rules locally; nothing is shared.
+4. **Parallel sub-agent usage for independent findings is aspirational, not prescribed.** `pr-shepherd` batches fixes but does not mandate parallel sub-agents for disjoint findings, leading to sequential execution even when the findings are independent.
+5. **Review output references findings by title, not by number.** When a user says "fix the 2nd and 4th ones", the agent has to re-derive ordering. Numbered lists eliminate this.
+6. **No activation announcement.** When several review-adjacent skills could plausibly fire, the user sometimes cannot tell which skill is running.
+7. **Team preferences evaporate at the end of the conversation.** When a reviewer consistently marks "silent error-swallowing in `except:` blocks" as a blocker, or when a user says "we always prefer functional composition over class hierarchies here", nothing persists. The same correction happens on the next quest. `deferred_findings.jsonl` does not solve this — it tracks *unresolved findings on touched files*, not *patterns the team tends to apply*.
+8. **Fix-loop iterations leave no audit trail.** Between arbiter verdict → fixer → re-review → fixer, there are no commits. A multi-iteration fix loop squashes into one terminal commit (if any). If iteration 3 breaks something that iteration 2 didn't, there is no commit to bisect to and no way to re-review "what the arbiter actually saw in iteration 2". The git history hides the loop's structure completely.
+9. **`pr-shepherd` is badly named.** The name is metaphorical, not descriptive. New users encountering `/pr-shepherd` or reading `.skills/pr-shepherd/SKILL.md` do not immediately know that this is the "check-the-PR, respond-to-comments, iterate-until-green" skill. The verb in the actual behavior is "check" — fetch comments, evaluate CI, triage, fix, resolve.
+10. **Quest-specific skills are not namespaced.** Skills like `pr-shepherd`, `plan-reviewer`, `code-reviewer`, `fixer`, `arbiter`, `implementer` live alongside completely portable skills (e.g., `gpt`, `celebrate`, `git-commit-assistant`) and alongside skills that come from other installed plugins. There is no visual cue that a skill is part of the Quest orchestration contract vs. a standalone utility. Skill-name collisions with other plugins are also possible — several of Quest's skill names (`run-review`, `check-pr-comments`) are generic enough that a third-party plugin could ship the same name.
+
+## Proposal
+
+Ten changes, grouped by effort. Items 1–4 are same-day changes. Items 5–6 are a week of focused work. Item 7 is the strategic bet. Items 8 and 10 are evaluation items — flagged for decision, not yet for implementation. Item 9 is a concrete rename with a well-bounded blast radius.
+
+### 1. Hard polling budgets across all poll-equipped skills  (XS)
+
+Replace prose like "wait a bit if pending" or "poll until the check completes" with explicit, numeric budgets in each affected skill:
+
+- `pr-shepherd` CI wait: **30 seconds × 30 retries (15-minute cap)**.
+- `ci-code-reviewer` existing-comment fetch: **10 seconds × 10 retries (100-second cap)** or single-shot, whichever matches the real API shape.
+- Any future local-review skill (see item 5): **15 seconds × 20 retries (5-minute cap)**.
+
+Write them as explicit `interval_seconds × max_retries` pairs in the SKILL.md body. Audit every skill for soft-language polling and convert.
+
+### 2. Canonical review anti-pattern list  (S)
+
+Create `.skills/review-anti-patterns.md` and reference it from every review-adjacent SKILL.md (`code-reviewer`, `ci-code-reviewer`, `plan-reviewer`, `pr-shepherd`, `fixer`). Contents, in rule + rationale form:
+
+- **Do not add reply comments justifying a finding.** The finding is in the review; commentary belongs in the SHA-level summary, not on each thread.
+- **Do not restate inline findings as top-level PR comments.** Inline-first is already our rule; this enforces it.
+- **Do not ask "which issues to fix" when the severity is unambiguous.** Blockers and Must-fix items are always fixed. Ask only for Should-fix / Nit selection.
+- **Do not introduce requirements the plan or PR description did not ask for.** "While you're here…" is scope creep.
+- **Do not pad the review with empty PASS sections** when nothing notable was found. Clean output is: PR-description line + summary + APPROVE.
+- **Bias toward action on iteration 3+.** Only blockers justify another round. Defer the rest via `review-decisions`.
+
+Each referencing skill includes one line: "See `.skills/review-anti-patterns.md` for the shared rule set."
+
+### 3. Announced skill activation as a global rule  (XS)
+
+Add one line to `BOOTSTRAP.md` and to each review-adjacent SKILL.md opener:
+
+> "At activation, announce the skill name and the scope it will operate on in one line. Example: `[code-reviewer] reviewing PR #97 against plan-2026-04-20.md`."
+
+This eliminates the "which skill is running right now" confusion when multiple could trigger.
+
+### 4. Numbered findings in review output  (XS)
+
+Change the output format in `code-reviewer`, `ci-code-reviewer`, and `plan-reviewer` so every finding is prefixed with a stable number within the current review:
+
+```
+[1] Must fix — src/foo.py:42 — null deref when config is missing
+[2] Should fix — src/bar.py:18 — redundant re-entry in retry loop
+[3] Nit — docs/README.md:10 — typo
+```
+
+Downstream effects:
+- User can say "fix 1 and 2" and the fixer maps unambiguously.
+- `review-backlog.json` can carry the review-local index alongside `finding_id`.
+- `pr-shepherd` batch reports become auditable by index.
+
+### 5. Parallel sub-agent directive for independent findings  (S)
+
+Add a reusable block to `pr-shepherd` (Step 4.4) and `fixer`:
+
+> "When multiple findings are independent — disjoint files, no shared invariants, no ordering dependency — dispatch them to parallel sub-agents in a single tool-call round. Each sub-agent must independently validate the finding before fixing. No two sub-agents may edit the same file. Merge results before commit."
+
+Include a short worked example in `delegation/workflow.md` showing when parallelism is and isn't safe (e.g., two findings in the same module with a shared type change must be sequential).
+
+### 6. Pre-commit review skill  (S–M)
+
+New skill: `.skills/pre-commit-review/SKILL.md`. Invocation targets the **working-tree diff**, not a PR URL:
+
+- Inputs: `git diff` (staged + unstaged combined by default; configurable).
+- Reuses `code-reviewer`'s severity model and `.skills/review-anti-patterns.md` rules.
+- Outputs a numbered finding list (see item 4) with a "fix selected / fix all Must / skip" prompt.
+- Stops when the user says "commit" or "skip"; never pushes.
+- Also exposed as an explicit slash command `/pre-commit-review` so users can invoke without relying on auto-trigger.
+
+### 7. Team-preference memory (soft-preference framed)  (M–L)
+
+**The bet.** Build a lightweight, file-based memory for team preferences that any review skill loads at start and applies with hedge language — never as rigid rules.
+
+#### Storage
+
+New file: `.quest/memory/team_preferences.jsonl`, append-only. One JSON object per line:
+
+```json
+{
+  "id": "tp_2026-04-22_001",
+  "created_at": "2026-04-22T11:00:00Z",
+  "source": "user_correction | arbiter_dismissed | reviewer_repeat",
+  "confidence": "high | medium | low",
+  "pattern": "We prefer functional composition over class hierarchies in src/pipeline/",
+  "example_finding_id": "f_2026-04-20_abc",
+  "path_glob": "src/pipeline/**",
+  "superseded_by": null
+}
+```
+
+#### Capture (three narrow sources — no speculative population)
+
+- **Explicit user command**: `/remember "we prefer immutable structs for config objects"` saves `source: user_correction`, `confidence: high`.
+- **Arbiter dismissal pattern**: when the arbiter dismisses the same class of finding three times in a row across iterations, it appends `source: arbiter_dismissed`, `confidence: medium` with a proposed pattern the user must confirm on the next review.
+- **Repeated reviewer verdict**: when two reviewers in the same quest independently flag the same class of issue, the arbiter appends `source: reviewer_repeat`, `confidence: medium`.
+
+Never auto-promote. Never store a preference without a linked originating finding or explicit user command.
+
+#### Read (consumed by every review skill)
+
+`plan-reviewer`, `code-reviewer`, and `ci-code-reviewer` read `team_preferences.jsonl` at start and filter by `path_glob` against files in scope. They render the matching entries into context with hedge language:
+
+> "The team tends to prefer X in this area (high confidence, from 3 prior reviewer verdicts). Weigh but don't enforce."
+
+Explicit rendering rules — each SKILL.md body must include:
+
+- **"Render preferences as tendencies, not rules. Never open a review with a preference-only blocker."**
+- **"If a preference contradicts the current plan's stated direction, note it as context, not as a finding."**
+
+#### Prune
+
+Quarterly (or on-demand via `/prune-preferences`), an explicit command walks `team_preferences.jsonl` and marks entries `superseded_by` another entry or prompts the user to retire low-confidence entries with no recent reinforcement.
+
+#### Why soft preferences
+
+The worst failure mode of any institutional-memory system is turning one grumpy review into eternal gospel. The hedge-language render + confidence scoring + explicit user-promote gate are the anti-dogmatism wiring. Every design decision here should ask "does this make the preference more or less likely to be treated as absolute" and favor less.
+
+### 8. Evaluate fix-loop commit checkpointing  (evaluation — no code yet)
+
+**The open design question.** Today the fix loop — arbiter decides → fixer applies → code-reviewer re-runs → arbiter decides again — runs with no git checkpointing between iterations. All edits land in the working tree and only get committed when the user (or `git-commit-assistant`) says so at the end. Everything gets squashed into one "address review feedback" commit, which is clean for squash-merge workflows but has real downsides:
+
+- **Lost audit trail.** The exact state the arbiter reviewed in iteration 2 is gone by the time iteration 3 runs. If a later regression traces back to "we broke it in the iteration-2 fix", there is no commit to bisect to.
+- **No safe rollback point.** If iteration 3's fix turns out worse than iteration 2's, the user has to reconstruct iteration 2 manually from agent transcripts.
+- **The arbiter's verdict is coupled to a moving tree.** Re-running a review against "what the arbiter saw" is impossible without committed snapshots.
+
+Evaluate whether to add one of the following checkpointing modes and pick one as default (likely Mode B), with the others available via flag.
+
+#### Mode A — pre-fix snapshot
+
+Commit **after the arbiter emits its verdict, before the fixer runs**. Commit message: `checkpoint: quest-<id> iter-N reviewed state`. The fixer then applies changes. At iteration N+1, another pre-fix snapshot is committed before the next fix.
+
+- **Pros**: captures exactly the tree the arbiter reviewed; enables "re-review the same state" verification; isolates fixer changes cleanly into the next commit.
+- **Cons**: commits a tree the team may not want to ship (known-imperfect); requires the author's own pre-fix changes to have already been committed, otherwise the snapshot captures unrelated staged/unstaged work.
+
+#### Mode B — post-fix iteration commit
+
+Commit **after the fixer finishes each iteration**, not before. Commit message: `fix: quest-<id> iter-N address review feedback`.
+
+- **Pros**: each fix is isolated and auditable via `git log`; bisect-friendly; matches the pattern already used by successful review-loop tools; post-fix state is always a deliberate candidate for keeping.
+- **Cons**: noisy on squash-merge conventions (mitigation: the commits get squashed at merge anyway, so history cost is bounded to the branch).
+
+#### Mode C — ephemeral checkpoint tags
+
+No commits in the main stream. After each arbiter verdict (or each fix), create a git tag like `quest/<id>/iter-N-reviewed` or `quest/<id>/iter-N-fixed` pointing at the current working-tree state via a temporary detached-HEAD commit on a shadow ref.
+
+- **Pros**: zero pollution of the branch history; full audit trail available when needed.
+- **Cons**: more moving parts; requires the user to know tags exist; cleanup policy needed (auto-delete tags on quest archive?).
+
+#### Mode D — status quo
+
+Keep no checkpoints. Accept the audit-trail loss as the cost of clean history.
+
+#### Evaluation criteria (to decide in a follow-up discussion, not in this idea doc)
+
+1. **What is our merge strategy on the repos that use Quest?** If squash-merge is universal, Mode B's noise cost is zero. If merge-commit is used, Mode C starts looking attractive.
+2. **Do we ever want to bisect a fix-loop regression?** If yes, Mode B or C is required. Mode A would also work but commits less-desirable intermediate states.
+3. **Does the arbiter need to be able to re-review a prior iteration's tree?** If yes, Mode A is the only option that guarantees it. If no (the arbiter always reviews "current state"), Modes B/C are sufficient.
+4. **What does `pr-shepherd` do today?** It already commits fix batches during the PR comment-response loop. If Mode B matches that pattern, we unify the model across intra-quest fix loops and post-PR fix loops — worth checking whether the commit-message prefix should match (`fix: address review feedback (iteration N)` vs the intra-quest variant).
+5. **Can the user opt out?** A `--no-iteration-commits` flag (or an allowlist gate) must exist for users who genuinely want a single terminal commit. Default-on, opt-out.
+
+#### Interaction with existing gates
+
+`gates.require_approval_before_commit: true` in `.ai/allowlist.json` currently requires human approval before any commit. A fix-loop checkpointing mode would need either (a) a scoped exception that auto-approves checkpoint commits only, or (b) a one-time per-quest approval covering the full loop. Option (b) is preferable — the user approves the loop's commit cadence once, at quest start, and the rest runs unattended.
+
+Keep this item as **evaluation-only** until a decision is reached. Do not implement a mode as part of items 1–7.
+
+### 9. Rename `pr-shepherd` → `check-pr`  (S)
+
+The current name is a metaphor. "Shepherding" describes the behavior poetically but not accurately. A user seeing `/pr-shepherd` for the first time cannot reliably predict what it does. The actual verb is **check** — fetch comments, evaluate CI status, triage findings, fix batches, resolve threads, iterate until clean. "Check the PR" reads correctly.
+
+#### Concrete rename scope
+
+- Directory: `.skills/pr-shepherd/` → `.skills/check-pr/`
+- Skill identity: `name: pr-shepherd` → `name: check-pr` in the SKILL.md frontmatter.
+- Slash command: `/pr-shepherd` → `/check-pr` (and keep `/pr-shepherd` as an alias for a deprecation window if other users already reference it).
+- Catalog entry: `.skills/SKILLS.md` section header + all prose references.
+- Installer: `scripts/quest_installer.sh` copies whole skill directories today, so it picks up the new name automatically — but audit any hardcoded skill-name lists (manifest validation, checksum registry, `.quest-manifest`, `.quest-checksums`) that might enumerate `pr-shepherd` explicitly.
+- Downstream references to update:
+  - `.skills/SKILLS.md`
+  - `.claude/skills/pr-shepherd/SKILL.md` (mirror copy — rename directory)
+  - `.agents/skills/pr-shepherd/SKILL.md` (mirror copy — rename directory)
+  - `tests/unit/test_codex_skill_wrappers.py`
+  - `docs/guides/quest_setup.md`
+  - `docs/quest-journal/*.md` (several) — update if the journal entries are still authoritative references; leave historical entries alone.
+  - Any CLAUDE.md / AGENTS.md mentions.
+  - Cross-references inside other skill bodies (e.g., `git-commit-assistant`, `review-decisions`, workflow docs).
+- Manifest / checksum artifacts: `.quest-manifest`, `.quest-checksums`, `manifest.json` may need regeneration after the rename. Run the manifest validator (`scripts/quest_validate-manifest.sh`) as the final step of the rename and fix any fallout before committing.
+
+#### Deprecation path
+
+Ship the rename in one atomic PR. Keep a redirect stub at `.skills/pr-shepherd/SKILL.md` for one release that points users to `.skills/check-pr/SKILL.md` and documents the rename in its frontmatter description. Remove the stub in the following release.
+
+#### Why this is worth doing now
+
+It's a rare chance to fix a confusing name before we add the `/pre-commit-review` skill (item 6) and evaluate a `/check-pr-local` variant (item 7). Two "check"-named review skills reading identically is more discoverable than `pre-commit-review` + `pr-shepherd`.
+
+### 10. Namespace Quest-specific skills with a `quest` prefix  (discussion — decision required before acting)
+
+**The discussion.** Skills shipped by Quest are mixed in with standalone utility skills in the same `.skills/` catalog. There is no way to tell, at a glance, that `plan-reviewer` is part of the Quest orchestration contract (meaning: rename it and the whole pipeline breaks) while `git-commit-assistant` is a standalone utility (meaning: rename it and only that skill's invocations break). The risk is low today, but it grows as Quest is installed alongside more third-party plugins and as Quest's own skill set grows.
+
+Decide whether to prefix all orchestration-contract skills with a stable `quest` marker, and pick one of the following naming conventions.
+
+#### Option A — colon namespace: `quest:plan-reviewer`
+
+- Reads cleanly, matches MCP convention (`mcp__codex-cli__codex`).
+- Colon may not be a legal directory-name component on Windows (NTFS forbids `:` in filenames). Would require storing skills under a sanitized directory (`quest_plan-reviewer/`) and exposing the `quest:plan-reviewer` identity in frontmatter only.
+- User-facing slash commands become `/quest:plan-reviewer`, which is clear but longer to type.
+
+#### Option B — underscore prefix: `quest_plan-reviewer` or `quest_plan_reviewer`
+
+- File-system-safe everywhere.
+- Visually clear but less idiomatic for slash commands.
+- Some skill names become awkwardly long (`quest_ci-code-reviewer`, `quest_check-pr`).
+
+#### Option C — hyphen prefix: `quest-plan-reviewer`
+
+- File-system-safe, matches existing hyphen-separated style.
+- Reads as one long token rather than two (less obvious namespace boundary).
+- Slash command: `/quest-plan-reviewer`. OK but verbose.
+
+#### Option D — prefix only what is orchestration-critical, leave utilities alone
+
+Apply the prefix only to skills that are load-bearing to the pipeline (`plan-maker`, `plan-reviewer`, `code-reviewer`, `ci-code-reviewer`, `check-pr` (from item 9), `fixer`, `arbiter`, `implementer`, `review-decisions`, the quest-agent itself). Keep portable skills unprefixed (`gpt`, `celebrate`, `git-commit-assistant`, `pr-assistant`, `pre-commit-review` from item 6).
+
+- **Pros**: preserves portability of utility skills — a user of just `git-commit-assistant` should not have to know Quest exists.
+- **Cons**: the boundary between "Quest-contract" and "utility" is fuzzy and will need to be documented explicitly to stay honest.
+
+#### Option E — status quo
+
+Accept that skill names are unnamespaced and rely on catalog documentation plus good skill-name hygiene to avoid collisions.
+
+#### Prerequisite research — platform support for prefixed skill names
+
+Before any of the options below can be chosen, confirm what each target client actually accepts as a skill identifier. The Quest pipeline runs on both Claude Code and Codex, and skill-name conventions may differ.
+
+- **Claude Code**: confirmed supported. Skill names with hyphens are accepted today; colon-namespaced identifiers (`quest:check-pr`) work at the frontmatter-identity level though the on-disk directory name must be filesystem-legal (typically `quest-check-pr/` with the colon form only in the `name:` field).
+- **Codex CLI**: unknown. Research required before committing to any option. Specifically:
+  - Does Codex accept hyphen-prefixed skill names (`quest-check-pr`) in the `name:` field without transformation?
+  - Does Codex accept colon-namespaced identifiers (`quest:check-pr`)?
+  - Does Codex's skill-loader care about directory name vs. frontmatter `name:` when the two diverge (e.g., `quest-check-pr/` on disk with `name: quest:check-pr` in frontmatter)?
+  - Are slash commands invoked with the same identifier as the skill, or do they have their own naming rules?
+  - Does `mcp__codex-cli__codex` (the bridge Quest uses) preserve the prefix in sub-agent hand-offs, or does it strip/rewrite it?
+
+If Codex does not accept one of the forms, that option is off the table — do not choose it for aesthetic reasons alone. The pipeline must function identically across both runtimes.
+
+Output of this research: a one-page finding that maps each of Options A–E to "works on Claude, works on Codex, works on both" and lists any per-runtime caveats. Attach it to this idea doc before the decision meeting.
+
+#### Decision criteria
+
+1. **Collision risk today.** Is any other plugin we (or downstream users) install likely to ship a skill with the same name as one of ours? Run a quick survey of marketplace plugins before deciding.
+2. **Install-location collision risk.** When Quest is installed into a repo that already has a `.skills/` directory from another plugin, do our names overwrite theirs today? If yes, prefixing is more urgent.
+3. **Slash-command ergonomics.** Measure how often Quest skills are invoked by `/command` vs. auto-trigger. Frequent typing pressure argues against long prefixes.
+4. **Cross-repo portability.** If a user takes `.skills/git-commit-assistant/` and drops it into another repo, should it work without any Quest context? If yes, that skill must stay unprefixed — argues for Option D.
+5. **Migration cost.** Renaming all Quest orchestration skills touches many files and every stored quest's metadata (model map keys in `.ai/allowlist.json`, role names in `agents/*.md`, manifest entries). Estimate the blast radius before committing.
+
+#### Recommendation (for discussion)
+
+Start with **Option D**: prefix only orchestration-critical skills, use hyphen style (`quest-plan-reviewer`, `quest-arbiter`, `quest-fixer`, etc.), and leave portable utilities unprefixed. Combine with item 9's rename so `pr-shepherd` lands as `quest-check-pr`, not `check-pr`. If we later decide Option A (colon) is worth the cross-platform cost, the migration from hyphen to colon is mechanical.
+
+Keep this item as **discussion-only** until a decision is made. If the decision is "yes, prefix", the rename from item 9 should be folded into the prefix rollout rather than shipped separately — doing the rename twice (once to `check-pr`, once to `quest-check-pr`) is avoidable pain.
+
+## Dual-Mode Sanity Check
+
+### Inside-repo use (Quest developed here)
+- Items 1–5 are prompt edits inside existing SKILL.md files. Minimal risk.
+- Item 6 (pre-commit review) is a new skill plus a thin Python wrapper. Local-only; no external calls beyond the existing model dispatch.
+- Item 7 (team-preference memory) writes only to `.quest/memory/team_preferences.jsonl`. No new infra. The append-only JSONL format matches the existing `deferred_findings.jsonl` pattern.
+
+### Outside-in use (Quest invoked from another repo)
+- Items 1–5 propagate with the skill files. No repo-state dependency.
+- Item 6: `pre-commit-review` requires `git` and a working tree. When `vcs_available == false`, the skill must refuse with a clear message and exit non-zero, not silently succeed.
+- Item 7: `.quest/memory/` is repo-local, same scoping as `.quest/<id>/`. If a target repo has no `.quest/` root yet, the skill creates `memory/` on first write. No global / cross-repo state.
+
+### Conflicts and Required Adaptations
+- `code-reviewer` / `ci-code-reviewer` already have severity models and anti-creep rules scattered in their bodies. Items 2 and 4 require moving some of that text into the shared anti-pattern file and the numbered-output template. Keep the existing per-skill rules only if they are genuinely skill-specific (e.g., `ci-code-reviewer`'s PR-description validation, which is CI-only).
+- `pr-shepherd` Step 4.4 already describes the intelligence pipeline (`normalize-pr-intake` → `build-backlog` → `select-batch-validation` → `build-fix-batches` → `classify-pr-stop`). Item 5 extends this with an explicit parallelism rule for disjoint findings; it does not replace the batching pipeline.
+- `review-decisions/SKILL.md` defines the canonical decision set (`fix_now / verify_first / defer / drop / needs_human_decision`). Item 7's `team_preferences.jsonl` is a separate artifact and must not be consumed as if it were a backlog — the decision taxonomy stays unchanged.
+- `.ai/allowlist.json` must grant reviewer roles read access to `.quest/memory/team_preferences.jsonl` and grant `arbiter` + a new `/remember` command path write access. No other role should write.
+
+## Actionable Steps
+
+### Same-day batch
+1. Create `.skills/review-anti-patterns.md` with the six rules from item 2. Reference it from `code-reviewer`, `ci-code-reviewer`, `plan-reviewer`, `pr-shepherd`, `fixer` — one line each.
+2. Add hard polling budgets (item 1) to `pr-shepherd` (CI poll) and `ci-code-reviewer` (existing-comment fetch). Grep for "wait", "poll", "until complete" to catch remaining soft windows.
+3. Add the activation-announcement line (item 3) to `BOOTSTRAP.md` and each review SKILL.md opener.
+4. Change `code-reviewer`, `ci-code-reviewer`, and `plan-reviewer` output format to number findings (item 4). Update any downstream consumers that parse review output (check `scripts/quest_review_intelligence.py` and the `review-backlog.json` shape for needed additions — store the review-local index alongside `finding_id`).
+
+### Week-level batch
+5. Add the parallel sub-agent directive (item 5) to `pr-shepherd` Step 4.4 and `fixer`. Add a worked example to `delegation/workflow.md`.
+6. Build the `pre-commit-review` skill (item 6):
+   - `.skills/pre-commit-review/SKILL.md` with numbered output, severity model, and a "fix / skip / commit" terminal prompt.
+   - A `/pre-commit-review` slash command entry.
+   - Update `.skills/SKILLS.md` catalog.
+
+### Strategic batch
+7. Implement team-preference memory (item 7):
+   - Add `.quest/memory/` directory convention and add it to `.gitignore` so `team_preferences.jsonl` is local-only for the initial rollout. Revisit committed-vs-ignored once the format has stabilized.
+   - Add `/remember` command and its save path.
+   - Extend `arbiter` to write `arbiter_dismissed` / `reviewer_repeat` entries on pattern triggers.
+   - Extend `plan-reviewer`, `code-reviewer`, `ci-code-reviewer` to read matching entries at start and render them with the mandated hedge language.
+   - Add `/prune-preferences` command.
+   - Update `.ai/allowlist.json` to allow reads for reviewer roles and writes for `arbiter` + `/remember` paths only.
+
+### Evaluation (no code yet)
+8. Decide on fix-loop commit checkpointing (item 8):
+   - Survey merge strategies on the repos Quest operates against (squash vs. merge-commit).
+   - Confirm whether the arbiter ever needs to re-review a prior iteration's tree state.
+   - Compare the four modes (A–D) against criteria 1–5. Pick one as default; flag others as opt-in.
+   - Sketch the allowlist-gate change (one-time per-quest approval covering checkpoint commits).
+   - Return to this doc with a decision and, only then, add concrete implementation steps.
+
+10. Decide on the `quest` prefix for orchestration-critical skills (item 10):
+    - **First: platform support research.** Confirm which naming options actually work on Codex (Claude is already known to support them). Answer the specific questions in the "Prerequisite research" subsection of item 10. Produce a one-page finding mapping each Option A–E to "works on Claude / works on Codex / works on both". This must be done before any naming decision — options unsupported on Codex are not real options.
+    - Survey existing plugins for skill-name collision risk.
+    - Pick one of Options A–E, constrained by the research result. Recommended starting point (if supported on both runtimes): Option D with hyphen style.
+    - If the decision is "yes, prefix", fold item 9's rename into this rollout so `pr-shepherd` lands as `quest-check-pr` in one step.
+    - If the decision is "no, status quo", proceed with item 9 as specified.
+    - Enumerate all touch points before starting: `.ai/allowlist.json` role names, `.skills/quest/agents/*.md`, model map keys, workflow references, test fixtures, docs.
+
+### Rename (do after item 10's decision)
+9. Execute the `pr-shepherd` → `check-pr` rename (or `quest-check-pr` if item 10 decides to prefix):
+    - Rename directory and mirror copies (`.claude/skills/`, `.agents/skills/`).
+    - Update `name:` in SKILL.md frontmatter.
+    - Update catalog entry in `.skills/SKILLS.md`.
+    - Update slash command registration and keep the old name as an alias for one release.
+    - Update all references grep'd from `.md`, `.py`, `.sh`, `.json`, `.yml` files in the repo (excluding historical journal and archived `ideas/` entries).
+    - Regenerate `.quest-manifest` and `.quest-checksums`; run `scripts/quest_validate-manifest.sh`.
+    - Single atomic PR; do not interleave with other behavior changes.
+
+## Non-Goals
+
+- **No automatic rule promotion.** Preferences never become blocking rules without explicit user action.
+- **No behavior change to existing review severity model.** Blocker / Must fix / Should fix / Nit stays as-is. Preferences are rendered as context, not as findings.
+- **No backwards-compatibility shim for the numbered-output format.** Downstream consumers that parse review text are updated in the same batch as item 4.
+- **No replacement for `deferred_findings.jsonl`.** Deferred findings (path-keyed, unresolved) and team preferences (pattern-keyed, persistent) are separate stores with separate lifecycles.
+
+## Open Questions
+
+- Should `.quest/memory/team_preferences.jsonl` be committed to the repo (team-shared) or gitignored (local-only)? **Decision for now: gitignored (local-only).** The file lives under `.quest/memory/` and is excluded from version control on initial rollout. Revisit once the format has stabilized and the noise profile is understood; team-sharing is the more valuable end state but only after the content has proven worth sharing. `/prune-preferences` still applies to the local file.
+- Activation announcement: always on. Small, low-signal-cost, and consistent across interactive and CI contexts. No env-var suppression, no mode toggle — every skill announces its name and scope on activation, every time.
+- Should `pre-commit-review` refuse to run if the tree is clean? Or should it fall back to last-commit review? Recommendation: refuse with a clear message; let the user explicitly pass a ref if they want a commit-scoped review instead.
+
+## Cross-References
+
+- `.skills/code-reviewer/SKILL.md`, `.skills/ci-code-reviewer/SKILL.md`, `.skills/plan-reviewer/SKILL.md`
+- `.skills/pr-shepherd/SKILL.md`
+- `.skills/review-decisions/SKILL.md`
+- `.skills/quest/delegation/workflow.md` (Step 4.4 review-intelligence pipeline)
+- `.skills/quest/agents/arbiter.md` (dismissal-pattern capture)
+- `.ai/allowlist.json` (reviewer read / arbiter write paths)
+- `.quest/backlog/deferred_findings.jsonl` (analogous file-based memory, different lifecycle)
+- `ideas/2026-04-13-quest-memory-architecture.md` (prior memory-architecture thinking — sanity-check against existing proposals before implementing)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ Build and utility scripts for the Quest repository.
 | `quest_runtime/` | Python package with Quest orchestration helpers (state updates, Claude bridge runner, handoff polling). |
 | `quest_runtime/review_intelligence.py` | Canonical review-finding schema validation, dedupe/merge helpers, decision backlog policy, deferred JSONL append, and planner backlog scan matching. |
 | `quest_runtime/pr_review_cycle.py` | PR-cycle helpers for canonical intake normalization, actionable batch construction, validation-step selection, loop-stop classification, and cap retagging. |
-| `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running the standard Quest validation and test suite. |
+| `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running Quest validators plus the shipped smoke-test surface. |
 | `quest_claude_bridge.py` | Thin transport bridge from the current host into Claude CLI for Codex-led Claude-designated Quest roles. |
 | `quest_preflight.sh` | Checks second-model readiness before quest routing. Codex-led Claude probes now retain a recent successful host probe under `.quest/cache/` so later quest starts can reuse it. |
 | `quest_claude_probe.py` | Probes the Claude bridge by requiring a real artifact write and `handoff.json` under the quest logs directory. |
@@ -66,7 +66,7 @@ python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state failing
 # Debug: select targeted validation steps for a single finding (single-finding preview)
 python3 scripts/quest_select_tests.py --finding /tmp/finding.json --repo-inventory /tmp/repo_inventory.json --output /tmp/validation_steps.json
 
-# Run the standard Quest validations and test suite
+# Run the installed Quest validations and smoke tests
 quest-checks
 
 # Validate quest configuration

--- a/scripts/check_quest_checksum_drift.py
+++ b/scripts/check_quest_checksum_drift.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Check Quest-managed files against .quest-checksums.
+
+This is a repo-local maintenance helper. It is intentionally not part of the
+Quest installer manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check Quest-managed files against .quest-checksums.",
+    )
+    parser.add_argument(
+        "repo",
+        nargs="?",
+        default=".",
+        help="Repository root to check (default: current directory).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.repo).resolve()
+    checksums = root / ".quest-checksums"
+
+    if not checksums.exists():
+        print(f"missing .quest-checksums: {checksums}")
+        return 2
+
+    drift: list[tuple[str, str]] = []
+    for raw in checksums.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            expected, relpath = raw.split("  ", 1)
+        except ValueError:
+            drift.append((raw, "malformed entry"))
+            continue
+
+        path = root / relpath
+        if not path.exists():
+            drift.append((relpath, "missing file"))
+            continue
+
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != expected:
+            drift.append((relpath, actual))
+
+    if drift:
+        print("DRIFT")
+        for relpath, detail in drift:
+            print(f"{relpath}\t{detail}")
+        return 1
+
+    print("OK: no checksum drift")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_quest_checksum_drift.py
+++ b/scripts/check_quest_checksum_drift.py
@@ -25,6 +25,15 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def resolve_repo_managed_path(root: Path, relpath: str) -> Path | None:
+    try:
+        candidate = (root / relpath).resolve(strict=False)
+        candidate.relative_to(root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return candidate
+
+
 def main() -> int:
     args = parse_args()
     root = Path(args.repo).resolve()
@@ -45,7 +54,10 @@ def main() -> int:
             drift.append((raw, "malformed entry"))
             continue
 
-        path = root / relpath
+        path = resolve_repo_managed_path(root, relpath)
+        if path is None:
+            drift.append((relpath, "unsafe path"))
+            continue
         if not path.exists():
             drift.append((relpath, "missing file"))
             continue

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -65,6 +65,17 @@ def command_basename(command_tokens: list[str]) -> str:
     return Path(command_tokens[0]).name
 
 
+def executable_token_matches(command_token: str, entry_token: str) -> bool:
+    if command_token == entry_token:
+        return True
+    if "/" in entry_token:
+        return False
+    command_path = Path(command_token)
+    if command_path.is_absolute():
+        return command_path.name == entry_token
+    return False
+
+
 def contains_blocked_find_action(command_tokens: list[str]) -> bool:
     if command_basename(command_tokens) != "find":
         return False
@@ -95,7 +106,9 @@ def token_prefix_matches(command_tokens: list[str], entry: str) -> bool:
         return False
     if len(command_tokens) < len(entry_tokens):
         return False
-    return command_tokens[: len(entry_tokens)] == entry_tokens
+    if not executable_token_matches(command_tokens[0], entry_tokens[0]):
+        return False
+    return command_tokens[1 : len(entry_tokens)] == entry_tokens[1:]
 
 
 def is_bash_command_allowed(command: str, allowed_entries: list[str]) -> tuple[bool, str]:

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import shlex
 import sys
+from pathlib import Path
 
 BLOCKED_METACHARACTERS = (
     "&&",
@@ -58,14 +59,20 @@ def shell_tokens(command: str) -> list[str] | None:
         return None
 
 
+def command_basename(command_tokens: list[str]) -> str:
+    if not command_tokens:
+        return ""
+    return Path(command_tokens[0]).name
+
+
 def contains_blocked_find_action(command_tokens: list[str]) -> bool:
-    if not command_tokens or command_tokens[0] != "find":
+    if command_basename(command_tokens) != "find":
         return False
     return any(token in BLOCKED_FIND_ACTIONS for token in command_tokens[1:])
 
 
 def contains_blocked_rg_flag(command_tokens: list[str]) -> bool:
-    if not command_tokens or command_tokens[0] != "rg":
+    if command_basename(command_tokens) != "rg":
         return False
     return any(
         token in BLOCKED_RG_FLAGS

--- a/scripts/quest_checks/cli.py
+++ b/scripts/quest_checks/cli.py
@@ -1,9 +1,8 @@
-"""Run the standard Quest validation and test commands."""
+"""Run the installed Quest validation and smoke-test commands."""
 
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -11,7 +10,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 COMMANDS: list[tuple[str, list[str]]] = [
     ("validate quest config", ["bash", "scripts/quest_validate-quest-config.sh"]),
     ("validate manifest", ["bash", "scripts/quest_validate-manifest.sh"]),
-    ("python tests", [sys.executable, "-m", "pytest"]),
+    (
+        "allowlist integration tests",
+        ["bash", "tests/integration/test-enforce-allowlist.sh"],
+    ),
     ("quest preflight shell tests", ["bash", "tests/test-quest-preflight.sh"]),
     ("quest runtime shell tests", ["bash", "tests/test-quest-runtime.sh"]),
     (
@@ -29,3 +31,7 @@ def main() -> int:
         if completed.returncode != 0:
             return completed.returncode
     return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -5,9 +5,41 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import time
+from pathlib import Path
 
 from quest_runtime.artifacts import expected_artifacts_for_role
 from quest_runtime.claude_runner import resolve_path, run_claude_role
+
+
+_TELEMETRY_ENV = "QUEST_RUNNER_TELEMETRY_LOG"
+
+
+def _append_telemetry(event: dict) -> None:
+    """Append a single JSON line to the runner telemetry log if env var is set.
+
+    This is an opt-in seam used by tests to observe the actual runner-produced
+    sequence of attempts (plus external events like ``publish`` when the caller
+    chooses to append them). Production runs are unaffected unless
+    ``QUEST_RUNNER_TELEMETRY_LOG`` is exported, in which case the file simply
+    accumulates invocation records. Failures to write telemetry must never
+    affect the runner outcome.
+    """
+
+    log_path = os.environ.get(_TELEMETRY_ENV)
+    if not log_path:
+        return
+    try:
+        path = Path(log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = dict(event)
+        record.setdefault("ts", time.time())
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+    except OSError:
+        # Telemetry is best-effort; never fail the runner because of it.
+        return
 
 
 def parse_args() -> argparse.Namespace:
@@ -32,6 +64,14 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    _append_telemetry(
+        {
+            "event": "attempt_start",
+            "agent": args.agent,
+            "phase": args.phase,
+            "iter": args.iter,
+        }
+    )
     try:
         artifact_paths = expected_artifacts_for_role(
             quest_dir=args.quest_dir,
@@ -47,6 +87,17 @@ def main() -> int:
             "stderr": str(exc),
             "stdout": "",
         }
+        _append_telemetry(
+            {
+                "event": "attempt_end",
+                "agent": args.agent,
+                "phase": args.phase,
+                "iter": args.iter,
+                "result_kind": "invocation_error",
+                "handoff_state": "missing",
+                "exit_code": 1,
+            }
+        )
         print(json.dumps(payload, ensure_ascii=True))
         return 1
     result = run_claude_role(
@@ -73,6 +124,17 @@ def main() -> int:
         "stderr": result.stderr.strip(),
         "stdout": result.stdout.strip(),
     }
+    _append_telemetry(
+        {
+            "event": "attempt_end",
+            "agent": args.agent,
+            "phase": args.phase,
+            "iter": args.iter,
+            "result_kind": result.result_kind,
+            "handoff_state": result.handoff_state,
+            "exit_code": result.exit_code,
+        }
+    )
     print(json.dumps(payload, ensure_ascii=True))
     return 0 if result.exit_code == 0 else result.exit_code
 

--- a/scripts/quest_claude_runner.py
+++ b/scripts/quest_claude_runner.py
@@ -37,8 +37,11 @@ def _append_telemetry(event: dict) -> None:
         record.setdefault("ts", time.time())
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, ensure_ascii=True) + "\n")
-    except OSError:
+    except Exception:
         # Telemetry is best-effort; never fail the runner because of it.
+        # Broad except is intentional — the docstring contract is that
+        # telemetry must never affect runner outcome, which includes
+        # TypeError from json.dumps on unexpected payloads.
         return
 
 

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -312,7 +312,14 @@ def main() -> int:
 
     # Load quest data
     data = load_quest_data(quest_dir)
-    completion_date = date.fromisoformat(args.date) if args.date else _today()
+    try:
+        completion_date = date.fromisoformat(args.date) if args.date else _today()
+    except ValueError:
+        print(
+            f"Error: invalid date '{args.date}'. Expected YYYY-MM-DD.",
+            file=sys.stderr,
+        )
+        return 1
 
     # Determine slug and outcome
     slug = data.slug or state.get("slug", quest_dir.name.split("_")[0])

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -133,6 +133,16 @@ OLD_SCRIPT_NAMES=(
   "scripts/validate-quest-state.sh"
 )
 
+LEGACY_SOURCE_ONLY_TESTS=(
+  "tests/unit/test_allowlist_matcher.py"
+  "tests/unit/test_codex_skill_wrappers.py"
+  "tests/unit/test_quest_checks_cli.py"
+  "tests/unit/test_quest_complete.py"
+  "tests/unit/test_quest_manifest.py"
+  "tests/unit/test_quest_state.py"
+  "tests/unit/test_review_intelligence.py"
+)
+
 CHECKSUM_MANAGED_USER_CUSTOMIZED=(
   "AGENTS.md"
 )
@@ -736,6 +746,53 @@ cleanup_removed_managed_files() {
 
     rm -f "$filepath"
     log_success "Removed stale Quest-managed file: $filepath"
+  done
+}
+
+cleanup_legacy_source_only_tests() {
+  local filepath
+  local stored_checksum
+  local current_checksum
+  local upstream_checksum
+  local temp_file
+
+  for filepath in "${LEGACY_SOURCE_ONLY_TESTS[@]}"; do
+    remove_updated_checksum "$filepath"
+    if [ ! -e "$filepath" ]; then
+      continue
+    fi
+
+    current_checksum=$(get_file_checksum "$filepath")
+
+    if stored_checksum=$(get_stored_checksum "$filepath" 2>/dev/null); then
+      if [ "$current_checksum" != "$stored_checksum" ]; then
+        log_warn "Leaving modified legacy Quest source-only test in place for manual cleanup: $filepath"
+        continue
+      fi
+    else
+      temp_file=".quest-temp.$$"
+      if ! fetch_file_to_temp "$filepath" "$temp_file" 2>/dev/null; then
+        rm -f "$temp_file"
+        log_warn "Leaving unmanaged Quest-like test in place: $filepath"
+        continue
+      fi
+
+      upstream_checksum=$(get_file_checksum "$temp_file")
+      rm -f "$temp_file"
+
+      if [ "$current_checksum" != "$upstream_checksum" ]; then
+        log_warn "Leaving locally modified legacy Quest source-only test in place for manual cleanup: $filepath"
+        continue
+      fi
+    fi
+
+    if $DRY_RUN; then
+      log_action "Remove legacy Quest source-only test: $filepath"
+      continue
+    fi
+
+    rm -f "$filepath"
+    log_success "Removed legacy Quest source-only test: $filepath"
   done
 }
 
@@ -1797,6 +1854,7 @@ run_install() {
   migrate_legacy_validation_hook
   cleanup_renamed_scripts
   cleanup_removed_managed_files
+  cleanup_legacy_source_only_tests
 
   # Set executable bits
   set_executable_bits

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -684,6 +684,61 @@ cleanup_updated_sidecar() {
   log_info "Removed stale update sidecar: $updated_path"
 }
 
+is_current_manifest_file() {
+  local target="$1"
+  local filepath
+
+  for filepath in "${COPY_AS_IS[@]}" "${USER_CUSTOMIZED[@]}" "${MERGE_CAREFULLY[@]}"; do
+    if [ "$filepath" = "$target" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+cleanup_removed_managed_files() {
+  local filepath
+  local stored_checksum
+  local current_checksum
+
+  for filepath in "${LOCAL_CHECKSUM_FILES[@]}"; do
+    if is_current_manifest_file "$filepath"; then
+      continue
+    fi
+
+    remove_updated_checksum "$filepath"
+
+    if [ ! -e "$filepath" ]; then
+      if $DRY_RUN; then
+        log_action "Prune stale Quest checksum entry: $filepath"
+      else
+        log_info "Pruned stale Quest checksum entry: $filepath"
+      fi
+      continue
+    fi
+
+    stored_checksum=$(get_stored_checksum "$filepath" || true)
+    if [ -z "$stored_checksum" ]; then
+      log_warn "Leaving existing non-Quest file in place: $filepath"
+      continue
+    fi
+
+    current_checksum=$(get_file_checksum "$filepath")
+    if [ "$current_checksum" != "$stored_checksum" ]; then
+      log_warn "Leaving modified stale Quest-managed file in place for manual cleanup: $filepath"
+      continue
+    fi
+
+    if $DRY_RUN; then
+      log_action "Remove stale Quest-managed file: $filepath"
+      continue
+    fi
+
+    rm -f "$filepath"
+    log_success "Removed stale Quest-managed file: $filepath"
+  done
+}
+
 ###############################################################################
 # Version Functions
 ###############################################################################
@@ -1741,6 +1796,7 @@ run_install() {
   install_merge_carefully
   migrate_legacy_validation_hook
   cleanup_renamed_scripts
+  cleanup_removed_managed_files
 
   # Set executable bits
   set_executable_bits

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -480,6 +480,29 @@ get_content_checksum() {
   $cmd | cut -d' ' -f1
 }
 
+is_safe_repo_relative_path() {
+  local target="$1"
+  local component
+  local path_parts=()
+
+  case "$target" in
+    ""|/*|*$'\n'*|*$'\r'*)
+      return 1
+      ;;
+  esac
+
+  IFS='/' read -r -a path_parts <<< "$target"
+  for component in "${path_parts[@]}"; do
+    case "$component" in
+      ""|"."|"..")
+        return 1
+        ;;
+    esac
+  done
+
+  return 0
+}
+
 # Load checksums from .quest-checksums file
 load_local_checksums() {
   LOCAL_CHECKSUM_FILES=()
@@ -500,6 +523,11 @@ load_local_checksums() {
       # Validate checksum format (SHA256 = 64 hex chars) and filepath is non-empty
       if [ ${#checksum} -ne 64 ] || [ -z "$filepath" ]; then
         log_warn "Malformed checksum entry, skipping: $line"
+        continue
+      fi
+
+      if ! is_safe_repo_relative_path "$filepath"; then
+        log_warn "Unsafe checksum path outside repository, skipping: $filepath"
         continue
       fi
 
@@ -708,6 +736,12 @@ cleanup_removed_managed_files() {
   local current_checksum
 
   for filepath in "${LOCAL_CHECKSUM_FILES[@]}"; do
+    if ! is_safe_repo_relative_path "$filepath"; then
+      remove_updated_checksum "$filepath"
+      log_warn "Skipping unsafe checksum path outside repository: $filepath"
+      continue
+    fi
+
     if is_current_manifest_file "$filepath"; then
       continue
     fi

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -133,13 +133,9 @@ OLD_SCRIPT_NAMES=(
   "scripts/validate-quest-state.sh"
 )
 
-LEGACY_SOURCE_ONLY_TESTS=(
+LEGACY_INSTALLED_SOURCE_ONLY_TESTS=(
   "tests/unit/test_allowlist_matcher.py"
   "tests/unit/test_codex_skill_wrappers.py"
-  "tests/unit/test_quest_checks_cli.py"
-  "tests/unit/test_quest_complete.py"
-  "tests/unit/test_quest_manifest.py"
-  "tests/unit/test_quest_state.py"
   "tests/unit/test_review_intelligence.py"
 )
 
@@ -756,7 +752,7 @@ cleanup_legacy_source_only_tests() {
   local upstream_checksum
   local temp_file
 
-  for filepath in "${LEGACY_SOURCE_ONLY_TESTS[@]}"; do
+  for filepath in "${LEGACY_INSTALLED_SOURCE_ONLY_TESTS[@]}"; do
     remove_updated_checksum "$filepath"
     if [ ! -e "$filepath" ]; then
       continue

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -216,10 +216,6 @@ def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
         }
 
         retagged = retag_backlog_at_cap(payload)
-        _write_json(backlog_path, retagged)
-        if args.retag_output:
-            _write_json(Path(args.retag_output), retagged)
-
         deferred_items = [
             item
             for item in retagged.get("items", [])
@@ -245,6 +241,13 @@ def _cmd_classify_pr_stop(args: argparse.Namespace) -> int:
                 deferred_items,
                 lineage,
             )
+
+        # Append deferred history first; append_deferred_findings is idempotent
+        # per (deferred_by_quest, finding_id), so a retry after a later write
+        # failure will not duplicate backlog lineage.
+        _write_json(backlog_path, retagged)
+        if args.retag_output:
+            _write_json(Path(args.retag_output), retagged)
 
     payload = dict(classification)
     payload["deferred_count"] = deferred_count

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -119,7 +119,8 @@ def _cmd_validate_backlog(args: argparse.Namespace) -> int:
             ]
     if getattr(args, "strict_plan_defaults", False):
         errors = list(errors) + validate_plan_phase_defaults(payload)
-    item_count = len(payload.get("items", [])) if isinstance(payload, dict) else 0
+    items = payload.get("items") if isinstance(payload, dict) else None
+    item_count = len(items) if isinstance(items, list) else 0
     print(json.dumps({"ok": not errors, "count": item_count, "errors": errors}, indent=2, sort_keys=True))
     return 1 if errors else 0
 

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -109,6 +109,13 @@ def _cmd_build_backlog(args: argparse.Namespace) -> int:
 def _cmd_validate_backlog(args: argparse.Namespace) -> int:
     payload = _load_json(Path(args.input))
     errors = validate_review_backlog(payload)
+    expected_phase = getattr(args, "expected_phase", None)
+    if expected_phase:
+        actual_phase = payload.get("phase") if isinstance(payload, dict) else None
+        if actual_phase != expected_phase:
+            errors = list(errors) + [
+                f"expected phase='{expected_phase}' but backlog has phase='{actual_phase}'"
+            ]
     item_count = len(payload.get("items", [])) if isinstance(payload, dict) else 0
     print(json.dumps({"ok": not errors, "count": item_count, "errors": errors}, indent=2, sort_keys=True))
     return 1 if errors else 0
@@ -310,6 +317,15 @@ def parse_args() -> argparse.Namespace:
         help="Validate canonical review backlog JSON",
     )
     validate_backlog.add_argument("--input", required=True, help="Path to review backlog JSON file")
+    validate_backlog.add_argument(
+        "--expected-phase",
+        choices=["plan", "review"],
+        default=None,
+        help=(
+            "When set, also verify backlog['phase'] matches this value. "
+            "A missing phase key or mismatch is reported as an error."
+        ),
+    )
     validate_backlog.set_defaults(func=_cmd_validate_backlog)
 
     select_validation = subparsers.add_parser(

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -22,6 +22,7 @@ from quest_runtime.review_intelligence import (
     merge_and_dedupe,
     scan_deferred_backlog,
     utc_now_iso,
+    validate_review_backlog,
     validate_findings,
 )
 
@@ -95,10 +96,22 @@ def _cmd_merge_findings(args: argparse.Namespace) -> int:
 def _cmd_build_backlog(args: argparse.Namespace) -> int:
     payload = _load_json(Path(args.findings))
     findings = _extract_findings(payload)
-    backlog = build_review_backlog(findings, at_loop_cap=args.at_loop_cap)
+    backlog = build_review_backlog(
+        findings,
+        at_loop_cap=args.at_loop_cap,
+        phase=args.phase,
+    )
     _write_json(Path(args.output), backlog)
     print(json.dumps({"ok": True, "count": len(backlog["items"]), "output": args.output}, sort_keys=True))
     return 0
+
+
+def _cmd_validate_backlog(args: argparse.Namespace) -> int:
+    payload = _load_json(Path(args.input))
+    errors = validate_review_backlog(payload)
+    item_count = len(payload.get("items", [])) if isinstance(payload, dict) else 0
+    print(json.dumps({"ok": not errors, "count": item_count, "errors": errors}, indent=2, sort_keys=True))
+    return 1 if errors else 0
 
 
 def _cmd_normalize_pr_intake(args: argparse.Namespace) -> int:
@@ -283,8 +296,21 @@ def parse_args() -> argparse.Namespace:
     backlog = subparsers.add_parser("build-backlog", help="Build review backlog from findings")
     backlog.add_argument("--findings", required=True, help="Input findings JSON file")
     backlog.add_argument("--output", required=True, help="Path to backlog output JSON")
+    backlog.add_argument(
+        "--phase",
+        default="review",
+        choices=["plan", "review"],
+        help="Backlog decision policy phase (default: review)",
+    )
     backlog.add_argument("--at-loop-cap", action="store_true", help="Apply loop-cap decision policy")
     backlog.set_defaults(func=_cmd_build_backlog)
+
+    validate_backlog = subparsers.add_parser(
+        "validate-backlog",
+        help="Validate canonical review backlog JSON",
+    )
+    validate_backlog.add_argument("--input", required=True, help="Path to review backlog JSON file")
+    validate_backlog.set_defaults(func=_cmd_validate_backlog)
 
     select_validation = subparsers.add_parser(
         "select-batch-validation",

--- a/scripts/quest_review_intelligence.py
+++ b/scripts/quest_review_intelligence.py
@@ -22,6 +22,7 @@ from quest_runtime.review_intelligence import (
     merge_and_dedupe,
     scan_deferred_backlog,
     utc_now_iso,
+    validate_plan_phase_defaults,
     validate_review_backlog,
     validate_findings,
 )
@@ -116,6 +117,8 @@ def _cmd_validate_backlog(args: argparse.Namespace) -> int:
             errors = list(errors) + [
                 f"expected phase='{expected_phase}' but backlog has phase='{actual_phase}'"
             ]
+    if getattr(args, "strict_plan_defaults", False):
+        errors = list(errors) + validate_plan_phase_defaults(payload)
     item_count = len(payload.get("items", [])) if isinstance(payload, dict) else 0
     print(json.dumps({"ok": not errors, "count": item_count, "errors": errors}, indent=2, sort_keys=True))
     return 1 if errors else 0
@@ -324,6 +327,14 @@ def parse_args() -> argparse.Namespace:
         help=(
             "When set, also verify backlog['phase'] matches this value. "
             "A missing phase key or mismatch is reported as an error."
+        ),
+    )
+    validate_backlog.add_argument(
+        "--strict-plan-defaults",
+        action="store_true",
+        help=(
+            "Also verify every item matches canonical build-backlog --phase "
+            "plan defaults for decision, owner, and batch."
         ),
     )
     validate_backlog.set_defaults(func=_cmd_validate_backlog)

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -48,6 +48,8 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
     ),
 }
 
+PREPARE_PRESERVE_EXISTING_NAMES = frozenset({"arbiter_verdict.md"})
+
 SOLO_DISABLED_AGENTS = frozenset({"plan-reviewer-b", "code-reviewer-b", "arbiter"})
 
 ROLE_PHASE_ALIASES: dict[str, frozenset[str]] = {
@@ -104,7 +106,13 @@ def prepare_artifact_files(paths: list[Path]) -> list[Path]:
     for path in paths:
         resolved = Path(path).resolve()
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        resolved.write_text("", encoding="utf-8")
+        # Arbiter verdict is canonical state; retries must not wipe it before
+        # the new attempt has produced replacement scratch artifacts.
+        should_preserve_existing = (
+            resolved.name in PREPARE_PRESERVE_EXISTING_NAMES and resolved.exists()
+        )
+        if not should_preserve_existing:
+            resolved.write_text("", encoding="utf-8")
         prepared.append(resolved)
     return prepared
 

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -18,8 +18,7 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
         "phase_01_plan",
         (
             "arbiter_verdict.md",
-            "review_findings.json",
-            "review_backlog.json",
+            "review_findings.json.next",
             "handoff_arbiter.json",
         ),
     ),

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -17,7 +17,7 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
     "arbiter": (
         "phase_01_plan",
         (
-            "arbiter_verdict.md",
+            "arbiter_verdict.md.next",
             "review_findings.json.next",
             "handoff_arbiter.json",
         ),
@@ -47,8 +47,6 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
         ("review_fix_feedback_discussion.md", "handoff_fixer.json"),
     ),
 }
-
-PREPARE_PRESERVE_EXISTING_NAMES = frozenset({"arbiter_verdict.md"})
 
 SOLO_DISABLED_AGENTS = frozenset({"plan-reviewer-b", "code-reviewer-b", "arbiter"})
 
@@ -106,13 +104,7 @@ def prepare_artifact_files(paths: list[Path]) -> list[Path]:
     for path in paths:
         resolved = Path(path).resolve()
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        # Arbiter verdict is canonical state; retries must not wipe it before
-        # the new attempt has produced replacement scratch artifacts.
-        should_preserve_existing = (
-            resolved.name in PREPARE_PRESERVE_EXISTING_NAMES and resolved.exists()
-        )
-        if not should_preserve_existing:
-            resolved.write_text("", encoding="utf-8")
+        resolved.write_text("", encoding="utf-8")
         prepared.append(resolved)
     return prepared
 

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -488,7 +488,11 @@ def append_deferred_findings(
     findings: list[dict[str, Any]],
     lineage: dict[str, Any],
 ) -> int:
-    """Append deferred findings with lineage to an append-only JSONL backlog."""
+    """Append deferred findings with lineage to an append-only JSONL backlog.
+
+    Appends are idempotent per ``(deferred_by_quest, finding_id)`` so a retry
+    after a later backlog-write failure does not duplicate deferred history.
+    """
 
     required_lineage = (
         "deferred_by_quest",
@@ -507,13 +511,37 @@ def append_deferred_findings(
     target = Path(jsonl_path)
     target.parent.mkdir(parents=True, exist_ok=True)
 
+    existing_keys: set[tuple[str, str]] = set()
+    if target.exists():
+        for raw_line in target.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            finding_id = str(record.get("finding_id") or "").strip()
+            deferred_by_quest = str(record.get("deferred_by_quest") or "").strip()
+            if finding_id and deferred_by_quest:
+                existing_keys.add((deferred_by_quest, finding_id))
+
     written = 0
     with target.open("a", encoding="utf-8") as handle:
         for finding in findings:
             record = copy.deepcopy(finding)
             for field in required_lineage:
                 record[field] = lineage[field]
+            record_key = (
+                str(record["deferred_by_quest"]).strip(),
+                str(record["finding_id"]).strip(),
+            )
+            if record_key in existing_keys:
+                continue
             handle.write(json.dumps(record, sort_keys=True) + "\n")
+            existing_keys.add(record_key)
             written += 1
     return written
 

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -389,6 +389,18 @@ def validate_review_backlog(backlog: Any) -> list[str]:
         return ["backlog JSON object must contain an 'items' list"]
 
     errors: list[str] = []
+
+    # Baseline phase enforcement: the top-level 'phase' field must be present
+    # and one of the allowed values. --expected-phase is the stricter equality
+    # check layered on top; this is the catch-all for typos/corruption/missing.
+    phase = backlog.get("phase")
+    if "phase" not in backlog:
+        errors.append("backlog must include a top-level 'phase' field")
+    elif not isinstance(phase, str) or phase not in ("plan", "review"):
+        errors.append(
+            f"backlog 'phase' must be one of 'plan' or 'review', got {phase!r}"
+        )
+
     required_decision_fields = (
         "decision",
         "decision_confidence",

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -396,9 +396,10 @@ def validate_review_backlog(backlog: Any) -> list[str]:
     phase = backlog.get("phase")
     if "phase" not in backlog:
         errors.append("backlog must include a top-level 'phase' field")
-    elif not isinstance(phase, str) or phase not in ("plan", "review"):
+    elif not isinstance(phase, str) or phase not in ALLOWED_BACKLOG_PHASES:
         errors.append(
-            f"backlog 'phase' must be one of 'plan' or 'review', got {phase!r}"
+            "backlog 'phase' must be one of "
+            f"{', '.join(ALLOWED_BACKLOG_PHASES)}, got {phase!r}"
         )
 
     required_decision_fields = (

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -449,6 +449,40 @@ def validate_review_backlog(backlog: Any) -> list[str]:
     return errors
 
 
+def validate_plan_phase_defaults(backlog: Any) -> list[str]:
+    """Validate plan-phase backlog items match canonical builder defaults."""
+
+    if not isinstance(backlog, dict):
+        return ["backlog must be a JSON object"]
+
+    errors: list[str] = []
+    phase = backlog.get("phase")
+    if phase != "plan":
+        errors.append(f"strict plan defaults require phase='plan', got {phase!r}")
+
+    items = backlog.get("items")
+    if not isinstance(items, list):
+        return errors + ["backlog JSON object must contain an 'items' list"]
+
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        try:
+            expected = _plan_phase_decision(item)
+        except ValueError:
+            # validate_review_backlog reports the malformed finding fields.
+            continue
+        for field in ("decision", "owner", "batch"):
+            actual = item.get(field)
+            if actual != expected[field]:
+                errors.append(
+                    f"[{index}] plan-phase field '{field}' must be "
+                    f"{expected[field]!r}, got {actual!r}"
+                )
+
+    return errors
+
+
 def append_deferred_findings(
     jsonl_path: Path,
     findings: list[dict[str, Any]],

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -38,6 +38,7 @@ ALLOWED_DECISIONS = (
 
 _SEVERITY_RANK = {name: index for index, name in enumerate(ALLOWED_SEVERITIES)}
 _CONFIDENCE_RANK = {name: index for index, name in enumerate(ALLOWED_CONFIDENCE)}
+ALLOWED_BACKLOG_PHASES = ("plan", "review")
 
 
 def utc_now_iso() -> str:
@@ -231,6 +232,36 @@ def _batch_from_finding(finding: dict[str, Any]) -> str:
     return "misc"
 
 
+def _slugify(value: str, *, fallback: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or fallback
+
+
+def _path_group_from_finding(finding: dict[str, Any]) -> str:
+    candidate = ""
+    write_scope = finding.get("write_scope")
+    if isinstance(write_scope, list):
+        scopes = sorted(item for item in write_scope if isinstance(item, str) and item.strip())
+        if scopes:
+            candidate = scopes[0]
+    if not candidate:
+        path = finding.get("path")
+        if isinstance(path, str):
+            candidate = path
+
+    normalized = candidate.strip()
+    if not normalized:
+        return "root"
+    normalized = normalized.strip("/")
+    if "/" not in normalized:
+        return "root"
+
+    first_segment = normalized.split("/", 1)[0]
+    if first_segment in {"", ".", ".."}:
+        return "root"
+    return _slugify(first_segment, fallback="root")
+
+
 def select_decision(finding: dict[str, Any], *, at_loop_cap: bool) -> dict[str, Any]:
     """Select a deterministic backlog decision for one finding."""
 
@@ -287,19 +318,50 @@ def select_decision(finding: dict[str, Any], *, at_loop_cap: bool) -> dict[str, 
     }
 
 
+def _plan_phase_decision(finding: dict[str, Any]) -> dict[str, Any]:
+    """Return deterministic plan-phase backlog defaults."""
+
+    errors = validate_finding(finding)
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    kind = _slugify(str(finding.get("kind") or "finding"), fallback="finding")
+    path_group = _path_group_from_finding(finding)
+    needs_validation: list[str] = []
+    if finding["needs_test"]:
+        needs_validation.append("unit_test")
+    needs_validation.extend(["typecheck", "lint"])
+
+    return {
+        "decision": "fix_now",
+        "decision_confidence": finding["confidence"],
+        "reason": "Plan-phase canonical default: builder implements this finding now.",
+        "needs_validation": needs_validation,
+        "owner": "builder",
+        "batch": f"{kind}-{path_group}",
+    }
+
+
 def build_review_backlog(
     findings: list[dict[str, Any]],
     *,
     at_loop_cap: bool,
+    phase: str = "review",
 ) -> dict[str, Any]:
     """Build canonical review backlog entries from findings."""
+
+    if phase not in ALLOWED_BACKLOG_PHASES:
+        raise ValueError(f"phase must be one of: {', '.join(ALLOWED_BACKLOG_PHASES)}")
 
     merged = merge_and_dedupe([findings])
     items: list[dict[str, Any]] = []
     counts = {decision: 0 for decision in ALLOWED_DECISIONS}
 
     for finding in merged:
-        decision_data = select_decision(finding, at_loop_cap=at_loop_cap)
+        if phase == "plan":
+            decision_data = _plan_phase_decision(finding)
+        else:
+            decision_data = select_decision(finding, at_loop_cap=at_loop_cap)
         item = copy.deepcopy(finding)
         item.update(decision_data)
         items.append(item)
@@ -309,10 +371,69 @@ def build_review_backlog(
         "version": 1,
         "generated_at": utc_now_iso(),
         "at_loop_cap": at_loop_cap,
+        "phase": phase,
         "allowed_decisions": list(ALLOWED_DECISIONS),
         "counts": counts,
         "items": items,
     }
+
+
+def validate_review_backlog(backlog: Any) -> list[str]:
+    """Validate canonical backlog object shape and decision fields."""
+
+    if not isinstance(backlog, dict):
+        return ["backlog must be a JSON object"]
+
+    items = backlog.get("items")
+    if not isinstance(items, list):
+        return ["backlog JSON object must contain an 'items' list"]
+
+    errors: list[str] = []
+    required_decision_fields = (
+        "decision",
+        "decision_confidence",
+        "reason",
+        "needs_validation",
+        "owner",
+        "batch",
+    )
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"[{index}] backlog item must be an object")
+            continue
+
+        for error in validate_finding(item):
+            errors.append(f"[{index}] {error}")
+
+        for field in required_decision_fields:
+            if field not in item:
+                errors.append(f"[{index}] missing required field '{field}'")
+
+        decision = item.get("decision")
+        if decision not in ALLOWED_DECISIONS:
+            errors.append(f"[{index}] field 'decision' has invalid value")
+
+        decision_confidence = item.get("decision_confidence")
+        if decision_confidence not in ALLOWED_CONFIDENCE:
+            errors.append(f"[{index}] field 'decision_confidence' has invalid value")
+
+        reason = item.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(f"[{index}] field 'reason' must be a non-empty string")
+
+        owner = item.get("owner")
+        if not isinstance(owner, str) or not owner.strip():
+            errors.append(f"[{index}] field 'owner' must be a non-empty string")
+
+        batch = item.get("batch")
+        if not isinstance(batch, str) or not batch.strip():
+            errors.append(f"[{index}] field 'batch' must be a non-empty string")
+
+        needs_validation = item.get("needs_validation")
+        if not _is_string_list(needs_validation):
+            errors.append(f"[{index}] field 'needs_validation' must be a list[str]")
+
+    return errors
 
 
 def append_deferred_findings(

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Validates that .quest-manifest includes all Quest files
-# Fails if any tracked files are missing from the manifest
+# Validates that .quest-manifest includes all installer-managed Quest files
+# Fails if shipped Quest files are missing from the manifest
 #
 
 set -e
@@ -33,7 +33,7 @@ get_manifest_files() {
 MANIFEST_FILES=$(get_manifest_files | sort)
 
 # Define which directories/patterns should be in the manifest
-# These are the Quest framework files that the installer manages
+# These are the Quest framework files that the installer ships
 EXPECTED_PATTERNS=(
   ".ai/*.md"
   ".ai/*.json"
@@ -52,9 +52,15 @@ EXPECTED_PATTERNS=(
   "scripts/quest_claude_bridge.py"
   "scripts/quest_claude_probe.py"
   "scripts/quest_claude_runner.py"
+  "scripts/quest_backfill_journal.py"
+  "scripts/quest_complete.py"
+  "scripts/quest_preflight.sh"
   "scripts/quest_review_intelligence.py"
   "scripts/quest_select_tests.py"
   "scripts/quest_startup_branch.py"
+  "scripts/quest_state.py"
+  "scripts/quest_celebrate/*.py"
+  "scripts/quest_celebrate/*.sh"
   "scripts/quest_validate-handoff-contracts.sh"
   "scripts/quest_validate-manifest.sh"
   "scripts/quest_validate-quest-config.sh"
@@ -62,7 +68,10 @@ EXPECTED_PATTERNS=(
   "scripts/quest_checks/*.py"
   "scripts/quest_runtime/*.py"
   "tests/integration/test-enforce-allowlist.sh"
-  "tests/unit/test_allowlist_matcher.py"
+  "tests/test-quest-preflight.sh"
+  "tests/test-quest-runtime.sh"
+  "tests/test-validate-handoff-contracts.sh"
+  "tests/test-validate-quest-state.sh"
 )
 
 # Find all files matching our patterns

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -406,7 +406,7 @@ validate_plan_phase_backlog() {
 
     def path_group:
       (if (.write_scope | type) == "array" then
-        ([.write_scope[] | select(type == "string") | trim_string | select(. != "")] | sort | first // "")
+        ([.write_scope[] | select(type == "string") | select((. | trim_string) != "")] | sort | first // "")
       else
         ""
       end) as $candidate

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -368,6 +368,50 @@ $item_errors"
   pass "Semantic check: review backlog is valid ($backlog_file)"
 }
 
+validate_plan_phase_backlog() {
+  # Plan-phase approval requires:
+  #   1. backlog["phase"] == "plan" (asserted via the CLI validator)
+  #   2. every backlog item's decision is actionable by the builder
+  #      (fix_now or verify_first). defer/drop/needs_human_decision are
+  #      non-compliant at plan approval -- a forgotten --phase plan flag
+  #      would otherwise silently produce verify_first/drop review-phase
+  #      decisions and let the plan fall through without fix_now tagging.
+  local backlog_file="$1"
+  local validator="$REPO_ROOT/scripts/quest_review_intelligence.py"
+
+  if [ ! -f "$validator" ]; then
+    fail "Semantic check: review backlog validator not found at $validator"
+    return 1
+  fi
+
+  local phase_output
+  phase_output=$(python3 "$validator" validate-backlog --input "$backlog_file" --expected-phase plan 2>&1)
+  local phase_rc=$?
+  if [ "$phase_rc" -ne 0 ]; then
+    fail "Semantic check: plan-phase backlog check failed ($backlog_file): $phase_output"
+    return 1
+  fi
+
+  local bad_decisions
+  bad_decisions=$(jq -r '
+    [
+      (.items // []) | to_entries[] |
+      select((.value.decision // "") as $d |
+        ($d != "fix_now") and ($d != "verify_first")
+      ) |
+      "[" + (.key | tostring) + "] non-actionable decision: " + (.value.decision // "missing")
+    ] | .[]
+  ' "$backlog_file" 2>/dev/null)
+
+  if [ -n "$bad_decisions" ]; then
+    fail "Semantic check: plan-phase backlog has non-actionable items (must all be fix_now or verify_first): $bad_decisions"
+    return 1
+  fi
+
+  pass "Semantic check: plan-phase backlog is fully actionable ($backlog_file)"
+  return 0
+}
+
 read_required_reviewer_handoff() {
   local handoff_file="$1"
   local next_value=""
@@ -466,7 +510,9 @@ validate_semantic_content() {
         local findings_file="$quest_dir/phase_01_plan/review_findings.json"
         local backlog_file="$quest_dir/phase_01_plan/review_backlog.json"
         validate_review_findings_schema "$findings_file"
-        validate_review_backlog_schema "$backlog_file"
+        if validate_review_backlog_schema "$backlog_file"; then
+          validate_plan_phase_backlog "$backlog_file"
+        fi
       fi
       ;;
     "presentation_complete->building")

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -611,6 +611,7 @@ validate_iteration_bounds() {
 
 # Main entry point
 main() {
+  local used_flag_syntax=false
   # Handle --help
   case "${1:-}" in
     --help|-h)
@@ -618,15 +619,57 @@ main() {
       ;;
   esac
 
+  local quest_dir=""
+  local target_phase=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --quest-dir)
+        used_flag_syntax=true
+        shift
+        if [ $# -eq 0 ]; then
+          echo "Error: --quest-dir requires a value" >&2
+          exit 2
+        fi
+        quest_dir="$1"
+        ;;
+      --target|--target-phase)
+        used_flag_syntax=true
+        shift
+        if [ $# -eq 0 ]; then
+          echo "Error: --target requires a value" >&2
+          exit 2
+        fi
+        target_phase="$1"
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*)
+        echo "Error: Unknown option: $1" >&2
+        exit 2
+        ;;
+      *)
+        if [ -z "$quest_dir" ]; then
+          quest_dir="$1"
+        elif [ -z "$target_phase" ]; then
+          target_phase="$1"
+        else
+          echo "Error: Unexpected argument: $1" >&2
+          exit 2
+        fi
+        ;;
+    esac
+    shift
+  done
+
   # Usage check
-  if [ $# -lt 2 ]; then
+  if [ -z "$quest_dir" ] || [ -z "$target_phase" ]; then
     echo "Usage: $SCRIPT_NAME <quest-dir> <target-phase>" >&2
     echo "Run '$SCRIPT_NAME --help' for details." >&2
     exit 2
   fi
-
-  local quest_dir="$1"
-  local target_phase="$2"
 
   if [ ! -d "$quest_dir" ]; then
     echo "Error: Quest directory not found: $quest_dir" >&2
@@ -660,9 +703,24 @@ main() {
     exit 1
   fi
 
-  validate_transition "$CURRENT_PHASE" "$target_phase"
-  validate_artifacts "$quest_dir" "$CURRENT_PHASE" "$target_phase"
-  validate_semantic_content "$quest_dir" "$CURRENT_PHASE" "$target_phase"
+  local checkpoint_plan_reviewed=false
+  if [ "$used_flag_syntax" = true ] && [ "$target_phase" = "plan_reviewed" ]; then
+    case "$CURRENT_PHASE" in
+      plan_reviewed|presenting|presentation_complete|building|reviewing|fixing|complete)
+        checkpoint_plan_reviewed=true
+        ;;
+    esac
+  fi
+
+  if [ "$checkpoint_plan_reviewed" = true ]; then
+    pass "Checkpoint validation mode: re-validating plan_reviewed artifacts from current phase $CURRENT_PHASE"
+    validate_artifacts "$quest_dir" "plan" "plan_reviewed"
+    validate_semantic_content "$quest_dir" "plan" "plan_reviewed"
+  else
+    validate_transition "$CURRENT_PHASE" "$target_phase"
+    validate_artifacts "$quest_dir" "$CURRENT_PHASE" "$target_phase"
+    validate_semantic_content "$quest_dir" "$CURRENT_PHASE" "$target_phase"
+  fi
   validate_iteration_bounds "$target_phase" "$PLAN_ITERATION" "$FIX_ITERATION"
 
   # Log this validation run

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -371,11 +371,11 @@ $item_errors"
 validate_plan_phase_backlog() {
   # Plan-phase approval requires:
   #   1. backlog["phase"] == "plan" (asserted via the CLI validator)
-  #   2. every backlog item's decision is actionable by the builder
-  #      (fix_now or verify_first). defer/drop/needs_human_decision are
-  #      non-compliant at plan approval -- a forgotten --phase plan flag
-  #      would otherwise silently produce verify_first/drop review-phase
-  #      decisions and let the plan fall through without fix_now tagging.
+  #   2. every backlog item matches the canonical plan-phase defaults
+  #      produced by build-backlog --phase plan: decision=fix_now,
+  #      owner=builder, and batch=<slugified kind>-<path group>. A drifted
+  #      producer can otherwise emit review-style semantics under phase="plan"
+  #      and still pass schema checks.
   local backlog_file="$1"
   local validator="$REPO_ROOT/scripts/quest_review_intelligence.py"
 
@@ -392,23 +392,73 @@ validate_plan_phase_backlog() {
     return 1
   fi
 
-  local bad_decisions
-  bad_decisions=$(jq -r '
+  local plan_default_errors
+  plan_default_errors=$(jq -r '
+    def trim_string:
+      gsub("^\\s+|\\s+$"; "");
+
+    def slugify($fallback):
+      ascii_downcase
+      | gsub("[^a-z0-9]+"; "-")
+      | gsub("^-+"; "")
+      | gsub("-+$"; "") as $slug
+      | if $slug == "" then $fallback else $slug end;
+
+    def path_group:
+      (if (.write_scope | type) == "array" then
+        ([.write_scope[] | select(type == "string") | trim_string | select(. != "")] | sort | first // "")
+      else
+        ""
+      end) as $candidate
+      | (if $candidate == "" and (.path | type) == "string" then .path else $candidate end)
+      | trim_string
+      | gsub("^/+"; "")
+      | gsub("/+$"; "") as $normalized
+      | if ($normalized == "") or (($normalized | contains("/")) | not) then
+        "root"
+      else
+        ($normalized | split("/")[0]) as $first
+        | if ($first == "" or $first == "." or $first == "..") then
+          "root"
+        else
+          ($first | slugify("root"))
+        end
+      end;
+
+    def expected_batch:
+      ((.kind // "finding") | tostring | slugify("finding")) + "-" + path_group;
+
     [
       (.items // []) | to_entries[] |
-      select((.value.decision // "") as $d |
-        ($d != "fix_now") and ($d != "verify_first")
-      ) |
-      "[" + (.key | tostring) + "] non-actionable decision: " + (.value.decision // "missing")
+      (.value as $item |
+        [
+          (if ($item.decision // "") != "fix_now" then
+            "decision=" + ($item.decision // "missing") + " (expected fix_now)"
+          else empty end),
+          (if ($item.owner // "") != "builder" then
+            "owner=" + ($item.owner // "missing") + " (expected builder)"
+          else empty end),
+          (if ($item.batch // "") != ($item | expected_batch) then
+            "batch=" + ($item.batch // "missing") + " (expected " + ($item | expected_batch) + ")"
+          else empty end)
+        ] as $errors |
+        select($errors | length > 0) |
+        "[" + (.key | tostring) + "] " + ($errors | join(", "))
+      )
     ] | .[]
-  ' "$backlog_file" 2>/dev/null)
-
-  if [ -n "$bad_decisions" ]; then
-    fail "Semantic check: plan-phase backlog has non-actionable items (must all be fix_now or verify_first): $bad_decisions"
+  ' "$backlog_file" 2>&1)
+  local plan_default_rc=$?
+  if [ "$plan_default_rc" -ne 0 ]; then
+    fail "Semantic check: plan-phase backlog canonical default check failed ($backlog_file): $plan_default_errors"
     return 1
   fi
 
-  pass "Semantic check: plan-phase backlog is fully actionable ($backlog_file)"
+  if [ -n "$plan_default_errors" ]; then
+    fail "Semantic check: plan-phase backlog must use canonical plan defaults: $plan_default_errors"
+    return 1
+  fi
+
+  pass "Semantic check: plan-phase backlog matches canonical plan defaults ($backlog_file)"
   return 0
 }
 

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -385,76 +385,10 @@ validate_plan_phase_backlog() {
   fi
 
   local phase_output
-  phase_output=$(python3 "$validator" validate-backlog --input "$backlog_file" --expected-phase plan 2>&1)
+  phase_output=$(python3 "$validator" validate-backlog --input "$backlog_file" --expected-phase plan --strict-plan-defaults 2>&1)
   local phase_rc=$?
   if [ "$phase_rc" -ne 0 ]; then
     fail "Semantic check: plan-phase backlog check failed ($backlog_file): $phase_output"
-    return 1
-  fi
-
-  local plan_default_errors
-  plan_default_errors=$(jq -r '
-    def trim_string:
-      gsub("^\\s+|\\s+$"; "");
-
-    def slugify($fallback):
-      ascii_downcase
-      | gsub("[^a-z0-9]+"; "-")
-      | gsub("^-+"; "")
-      | gsub("-+$"; "") as $slug
-      | if $slug == "" then $fallback else $slug end;
-
-    def path_group:
-      (if (.write_scope | type) == "array" then
-        ([.write_scope[] | select(type == "string") | select((. | trim_string) != "")] | sort | first // "")
-      else
-        ""
-      end) as $candidate
-      | (if $candidate == "" and (.path | type) == "string" then .path else $candidate end)
-      | trim_string
-      | gsub("^/+"; "")
-      | gsub("/+$"; "") as $normalized
-      | if ($normalized == "") or (($normalized | contains("/")) | not) then
-        "root"
-      else
-        ($normalized | split("/")[0]) as $first
-        | if ($first == "" or $first == "." or $first == "..") then
-          "root"
-        else
-          ($first | slugify("root"))
-        end
-      end;
-
-    def expected_batch:
-      ((.kind // "finding") | tostring | slugify("finding")) + "-" + path_group;
-
-    [
-      (.items // []) | to_entries[] |
-      (.value as $item |
-        [
-          (if ($item.decision // "") != "fix_now" then
-            "decision=" + ($item.decision // "missing") + " (expected fix_now)"
-          else empty end),
-          (if ($item.owner // "") != "builder" then
-            "owner=" + ($item.owner // "missing") + " (expected builder)"
-          else empty end),
-          (if ($item.batch // "") != ($item | expected_batch) then
-            "batch=" + ($item.batch // "missing") + " (expected " + ($item | expected_batch) + ")"
-          else empty end)
-        ] as $errors |
-        select($errors | length > 0) |
-        "[" + (.key | tostring) + "] " + ($errors | join(", "))
-      )
-    ] | .[]
-  ' "$backlog_file" 2>&1)
-  local plan_default_rc=$?
-  if [ "$plan_default_rc" -ne 0 ]; then
-    fail "Semantic check: plan-phase backlog canonical default check failed ($backlog_file): $plan_default_errors"
-    return 1
-  fi
-
-  if [ -n "$plan_default_errors" ]; then
-    fail "Semantic check: plan-phase backlog must use canonical plan defaults: $plan_default_errors"
     return 1
   fi
 

--- a/tests/integration/test-enforce-allowlist.sh
+++ b/tests/integration/test-enforce-allowlist.sh
@@ -6,6 +6,7 @@ set -uo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 HOOK_SCRIPT="$REPO_ROOT/.claude/hooks/enforce-allowlist.sh"
+ALLOWLIST_FILE="$REPO_ROOT/.ai/allowlist.json"
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -39,6 +40,23 @@ run_hook_for_write() {
   printf '%s' "$payload" | "$HOOK_SCRIPT" "$role"
 }
 
+set_builder_file_write_patterns() {
+  local patterns_json="$1"
+  python3 - "$ALLOWLIST_FILE" "$patterns_json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+patterns = json.loads(sys.argv[2])
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+data["role_permissions"]["builder_agent"]["file_write"] = patterns
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+}
+
 test_bridge_allows_manifest_validation_command() {
   local output rc
   output=$(run_hook_for_command "builder_agent" "bash scripts/quest_validate-manifest.sh" 2>&1)
@@ -67,6 +85,31 @@ test_file_write_allows_nested_docs_output() {
   output=$(run_hook_for_write "builder_agent" "$REPO_ROOT/docs/dashboard/index.html" 2>&1)
   rc=$?
   [ "$rc" -eq 0 ] && [ -z "$output" ]
+}
+
+test_file_write_allows_root_markdown_for_double_star_slash_pattern() {
+  local backup output_root output_nested rc_root rc_nested
+  backup=$(mktemp) || return 1
+  cp "$ALLOWLIST_FILE" "$backup" || {
+    rm -f "$backup"
+    return 1
+  }
+  trap 'mv "$backup" "$ALLOWLIST_FILE"' RETURN
+
+  set_builder_file_write_patterns '["**/*.md"]' || return 1
+
+  output_root=$(run_hook_for_write "builder_agent" "$REPO_ROOT/README.md" 2>&1)
+  rc_root=$?
+  output_nested=$(run_hook_for_write "builder_agent" "$REPO_ROOT/docs/guides/quest_setup.md" 2>&1)
+  rc_nested=$?
+
+  trap - RETURN
+  mv "$backup" "$ALLOWLIST_FILE" || return 1
+
+  [ "$rc_root" -eq 0 ] &&
+    [ -z "$output_root" ] &&
+    [ "$rc_nested" -eq 0 ] &&
+    [ -z "$output_nested" ]
 }
 
 test_file_write_allows_role_scoped_quest_path() {
@@ -103,6 +146,7 @@ run_test test_bridge_allows_manifest_validation_command
 run_test test_bridge_rejects_compound_bypass
 run_test test_file_write_allows_nested_double_star_path
 run_test test_file_write_allows_nested_docs_output
+run_test test_file_write_allows_root_markdown_for_double_star_slash_pattern
 run_test test_file_write_allows_role_scoped_quest_path
 run_test test_file_write_rejects_traversal_out_of_allowed_root
 run_test test_file_write_rejects_unlisted_dashboard_source_path

--- a/tests/integration/test-enforce-allowlist.sh
+++ b/tests/integration/test-enforce-allowlist.sh
@@ -31,6 +31,14 @@ run_hook_for_command() {
   printf '%s' "$payload" | "$HOOK_SCRIPT" "$role"
 }
 
+run_hook_for_write() {
+  local role="$1"
+  local file_path="$2"
+  local payload
+  payload=$(jq -cn --arg path "$file_path" '{tool:"Write",input:{file_path:$path}}')
+  printf '%s' "$payload" | "$HOOK_SCRIPT" "$role"
+}
+
 test_bridge_allows_manifest_validation_command() {
   local output rc
   output=$(run_hook_for_command "builder_agent" "bash scripts/quest_validate-manifest.sh" 2>&1)
@@ -47,6 +55,29 @@ test_bridge_rejects_compound_bypass() {
     echo "$output" | grep -q "blocked_metacharacter"
 }
 
+test_file_write_allows_nested_double_star_path() {
+  local output rc
+  output=$(run_hook_for_write "builder_agent" "$REPO_ROOT/scripts/quest_dashboard/render.py" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ]
+}
+
+test_file_write_allows_nested_docs_output() {
+  local output rc
+  output=$(run_hook_for_write "builder_agent" "$REPO_ROOT/docs/dashboard/index.html" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ]
+}
+
+test_file_write_rejects_unlisted_dashboard_source_path() {
+  local output rc
+  output=$(run_hook_for_write "builder_agent" "$REPO_ROOT/dashboard/src/App.tsx" 2>&1)
+  rc=$?
+  [ "$rc" -eq 2 ] &&
+    echo "$output" | grep -q "BLOCKED:" &&
+    echo "$output" | grep -q "dashboard/src/App.tsx"
+}
+
 if [ ! -x "$HOOK_SCRIPT" ]; then
   echo "[SKIP] Hook script is missing or not executable: $HOOK_SCRIPT"
   exit 0
@@ -54,6 +85,9 @@ fi
 
 run_test test_bridge_allows_manifest_validation_command
 run_test test_bridge_rejects_compound_bypass
+run_test test_file_write_allows_nested_double_star_path
+run_test test_file_write_allows_nested_docs_output
+run_test test_file_write_rejects_unlisted_dashboard_source_path
 
 echo ""
 echo "Tests run: $TESTS_RUN"

--- a/tests/integration/test-enforce-allowlist.sh
+++ b/tests/integration/test-enforce-allowlist.sh
@@ -69,6 +69,22 @@ test_file_write_allows_nested_docs_output() {
   [ "$rc" -eq 0 ] && [ -z "$output" ]
 }
 
+test_file_write_allows_role_scoped_quest_path() {
+  local output rc
+  output=$(run_hook_for_write "arbiter_agent" "$REPO_ROOT/.quest/state.json" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ]
+}
+
+test_file_write_rejects_traversal_out_of_allowed_root() {
+  local output rc
+  output=$(run_hook_for_write "arbiter_agent" "$REPO_ROOT/.quest/../scripts/quest_state.py" 2>&1)
+  rc=$?
+  [ "$rc" -eq 2 ] &&
+    echo "$output" | grep -q "BLOCKED:" &&
+    echo "$output" | grep -q ".quest/../scripts/quest_state.py"
+}
+
 test_file_write_rejects_unlisted_dashboard_source_path() {
   local output rc
   output=$(run_hook_for_write "builder_agent" "$REPO_ROOT/dashboard/src/App.tsx" 2>&1)
@@ -87,6 +103,8 @@ run_test test_bridge_allows_manifest_validation_command
 run_test test_bridge_rejects_compound_bypass
 run_test test_file_write_allows_nested_double_star_path
 run_test test_file_write_allows_nested_docs_output
+run_test test_file_write_allows_role_scoped_quest_path
+run_test test_file_write_rejects_traversal_out_of_allowed_root
 run_test test_file_write_rejects_unlisted_dashboard_source_path
 
 echo ""

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -763,6 +763,90 @@ test_installer_preserves_modified_removed_managed_files_for_manual_cleanup() {
   return $rc
 }
 
+test_installer_prunes_untracked_legacy_source_only_test_matching_upstream() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p tests/unit
+    printf 'quest source-only test\n' > tests/unit/test_quest_complete.py
+    printf 'quest source-only test\n' > "$tmpdir/upstream_test_quest_complete.py"
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=()
+    LOCAL_CHECKSUM_VALUES=()
+    init_updated_checksums
+
+    fetch_file_to_temp() {
+      if [ "$1" = "tests/unit/test_quest_complete.py" ]; then
+        cp "$tmpdir/upstream_test_quest_complete.py" "$2"
+        return 0
+      fi
+      return 1
+    }
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_legacy_source_only_tests
+
+    [ ! -e tests/unit/test_quest_complete.py ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_preserves_modified_untracked_legacy_source_only_test() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p tests/unit
+    printf 'locally modified quest source-only test\n' > tests/unit/test_quest_complete.py
+    printf 'quest source-only test\n' > "$tmpdir/upstream_test_quest_complete.py"
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=()
+    LOCAL_CHECKSUM_VALUES=()
+    init_updated_checksums
+
+    fetch_file_to_temp() {
+      if [ "$1" = "tests/unit/test_quest_complete.py" ]; then
+        cp "$tmpdir/upstream_test_quest_complete.py" "$2"
+        return 0
+      fi
+      return 1
+    }
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_legacy_source_only_tests
+
+    [ -e tests/unit/test_quest_complete.py ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 test_manifest_lists_prefixed_scripts() {
   grep -q '^scripts/quest_claude_bridge.py$' "$MANIFEST_FILE" &&
     grep -q '^scripts/quest_validate-handoff-contracts.sh$' "$MANIFEST_FILE" &&
@@ -1377,6 +1461,8 @@ run_test test_installer_records_checksum_for_new_agents_file
 run_test test_installer_preserves_customized_agents_file_with_sidecar
 run_test test_installer_prunes_pristine_removed_managed_files
 run_test test_installer_preserves_modified_removed_managed_files_for_manual_cleanup
+run_test test_installer_prunes_untracked_legacy_source_only_test_matching_upstream
+run_test test_installer_preserves_modified_untracked_legacy_source_only_test
 run_test test_manifest_lists_prefixed_scripts
 run_test test_manifest_lists_installed_quest_smoke_tests
 run_test test_manifest_excludes_source_only_unit_tests

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -763,15 +763,15 @@ test_installer_preserves_modified_removed_managed_files_for_manual_cleanup() {
   return $rc
 }
 
-test_installer_prunes_untracked_legacy_source_only_test_matching_upstream() {
+test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream() {
   local tmpdir
   tmpdir=$(mktemp -d)
 
   (
     cd "$tmpdir" || exit 1
     mkdir -p tests/unit
-    printf 'quest source-only test\n' > tests/unit/test_quest_complete.py
-    printf 'quest source-only test\n' > "$tmpdir/upstream_test_quest_complete.py"
+    printf 'quest installed source-only test\n' > tests/unit/test_allowlist_matcher.py
+    printf 'quest installed source-only test\n' > "$tmpdir/upstream_test_allowlist_matcher.py"
     load_installer_functions
 
     DRY_RUN=false
@@ -784,8 +784,8 @@ test_installer_prunes_untracked_legacy_source_only_test_matching_upstream() {
     init_updated_checksums
 
     fetch_file_to_temp() {
-      if [ "$1" = "tests/unit/test_quest_complete.py" ]; then
-        cp "$tmpdir/upstream_test_quest_complete.py" "$2"
+      if [ "$1" = "tests/unit/test_allowlist_matcher.py" ]; then
+        cp "$tmpdir/upstream_test_allowlist_matcher.py" "$2"
         return 0
       fi
       return 1
@@ -798,22 +798,22 @@ test_installer_prunes_untracked_legacy_source_only_test_matching_upstream() {
 
     cleanup_legacy_source_only_tests
 
-    [ ! -e tests/unit/test_quest_complete.py ]
+    [ ! -e tests/unit/test_allowlist_matcher.py ]
   )
   local rc=$?
   rm -rf "$tmpdir"
   return $rc
 }
 
-test_installer_preserves_modified_untracked_legacy_source_only_test() {
+test_installer_preserves_modified_untracked_legacy_installed_source_only_test() {
   local tmpdir
   tmpdir=$(mktemp -d)
 
   (
     cd "$tmpdir" || exit 1
     mkdir -p tests/unit
-    printf 'locally modified quest source-only test\n' > tests/unit/test_quest_complete.py
-    printf 'quest source-only test\n' > "$tmpdir/upstream_test_quest_complete.py"
+    printf 'locally modified quest source-only test\n' > tests/unit/test_allowlist_matcher.py
+    printf 'quest installed source-only test\n' > "$tmpdir/upstream_test_allowlist_matcher.py"
     load_installer_functions
 
     DRY_RUN=false
@@ -826,12 +826,46 @@ test_installer_preserves_modified_untracked_legacy_source_only_test() {
     init_updated_checksums
 
     fetch_file_to_temp() {
-      if [ "$1" = "tests/unit/test_quest_complete.py" ]; then
-        cp "$tmpdir/upstream_test_quest_complete.py" "$2"
+      if [ "$1" = "tests/unit/test_allowlist_matcher.py" ]; then
+        cp "$tmpdir/upstream_test_allowlist_matcher.py" "$2"
         return 0
       fi
       return 1
     }
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_legacy_source_only_tests
+
+    [ -e tests/unit/test_allowlist_matcher.py ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_preserves_unowned_source_only_test_path() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p tests/unit
+    printf 'repo-local source-only test\n' > tests/unit/test_quest_complete.py
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=()
+    LOCAL_CHECKSUM_VALUES=()
+    init_updated_checksums
+
     log_info() { :; }
     log_warn() { :; }
     log_success() { :; }
@@ -1461,8 +1495,9 @@ run_test test_installer_records_checksum_for_new_agents_file
 run_test test_installer_preserves_customized_agents_file_with_sidecar
 run_test test_installer_prunes_pristine_removed_managed_files
 run_test test_installer_preserves_modified_removed_managed_files_for_manual_cleanup
-run_test test_installer_prunes_untracked_legacy_source_only_test_matching_upstream
-run_test test_installer_preserves_modified_untracked_legacy_source_only_test
+run_test test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream
+run_test test_installer_preserves_modified_untracked_legacy_installed_source_only_test
+run_test test_installer_preserves_unowned_source_only_test_path
 run_test test_manifest_lists_prefixed_scripts
 run_test test_manifest_lists_installed_quest_smoke_tests
 run_test test_manifest_excludes_source_only_unit_tests

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -539,6 +539,17 @@ test_workflow_documents_no_vcs_review_path() {
     grep -q 'review the implementation directly' "$WORKFLOW_FILE"
 }
 
+test_workflow_documents_arbiter_validate_build_publish_contract() {
+  grep -Fq 'review_findings.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'review_backlog.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")' "$WORKFLOW_FILE" &&
+    grep -Fq 'If arbiter handoff says `next: planner`' "$WORKFLOW_FILE" &&
+    grep -Fq 'Do **not** call `quest_state.py --transition plan_reviewed`.' "$WORKFLOW_FILE"
+}
+
 test_installer_cleans_up_renamed_scripts() {
   grep -q 'OLD_SCRIPT_NAMES=(' "$INSTALLER_SCRIPT" &&
     grep -q 'scripts/claude_cli_bridge.py' "$INSTALLER_SCRIPT" &&
@@ -736,6 +747,498 @@ test_quest_startup_branch_exception_handler_tolerates_missing_git() {
     echo "$message" | grep -qi "failed"
 }
 
+test_plan_review_retry_harness_preserves_canonical_artifacts_until_publish() {
+  local tmpdir phase_dir findings_file backlog_file findings_next backlog_next
+  tmpdir=$(mktemp -d)
+  phase_dir="$tmpdir/phase_01_plan"
+  findings_file="$phase_dir/review_findings.json"
+  backlog_file="$phase_dir/review_backlog.json"
+  findings_next="$phase_dir/review_findings.json.next"
+  backlog_next="$phase_dir/review_backlog.json.next"
+  mkdir -p "$phase_dir"
+
+  cat > "$findings_file" <<'EOF'
+[
+  {
+    "finding_id": "old-1",
+    "source": "arbiter",
+    "kind": "correctness",
+    "severity": "low",
+    "confidence": "high",
+    "path": "scripts/old.py",
+    "line": 1,
+    "summary": "Old canonical finding.",
+    "why_it_matters": "Old value should survive failed validation.",
+    "evidence": ["old"],
+    "action": "none",
+    "needs_test": false,
+    "write_scope": ["scripts/old.py"],
+    "related_acceptance_criteria": ["AC-0"]
+  }
+]
+EOF
+  cat > "$backlog_file" <<'EOF'
+{
+  "version": 1,
+  "generated_at": "2026-04-22T00:00:00Z",
+  "phase": "plan",
+  "at_loop_cap": false,
+  "allowed_decisions": ["fix_now", "verify_first", "defer", "drop", "needs_human_decision"],
+  "counts": {"fix_now": 1, "verify_first": 0, "defer": 0, "drop": 0, "needs_human_decision": 0},
+  "items": [
+    {
+      "finding_id": "old-1",
+      "source": "arbiter",
+      "kind": "correctness",
+      "severity": "low",
+      "confidence": "high",
+      "path": "scripts/old.py",
+      "line": 1,
+      "summary": "Old canonical finding.",
+      "why_it_matters": "Old value should survive failed validation.",
+      "evidence": ["old"],
+      "action": "none",
+      "needs_test": false,
+      "write_scope": ["scripts/old.py"],
+      "related_acceptance_criteria": ["AC-0"],
+      "decision": "fix_now",
+      "decision_confidence": "high",
+      "reason": "old",
+      "needs_validation": ["typecheck"],
+      "owner": "builder",
+      "batch": "correctness-scripts"
+    }
+  ]
+}
+EOF
+
+  local canonical_findings_before canonical_backlog_before
+  canonical_findings_before=$(cat "$findings_file")
+  canonical_backlog_before=$(cat "$backlog_file")
+
+  local attempts=0 retries=0 validated=false
+  local transition_attempts=0 transition_attempts_before_publish=0 published=false
+  while [ "$attempts" -lt 2 ]; do
+    attempts=$((attempts + 1))
+    rm -f "$findings_next" "$backlog_next"
+    if [ "$attempts" -eq 1 ]; then
+      cat > "$findings_next" <<'EOF'
+[
+  {
+    "id": "bad-shape"
+  }
+]
+EOF
+    else
+      cat > "$findings_next" <<'EOF'
+[
+  {
+    "finding_id": "new-1",
+    "source": "arbiter",
+    "kind": "regression-risk",
+    "severity": "high",
+    "confidence": "high",
+    "path": "scripts/new.py",
+    "line": 12,
+    "summary": "New canonical finding.",
+    "why_it_matters": "Used to validate retry and publish ordering.",
+    "evidence": ["new"],
+    "action": "fix now",
+    "needs_test": true,
+    "write_scope": ["scripts/new.py"],
+    "related_acceptance_criteria": ["B5"]
+  }
+]
+EOF
+    fi
+
+    if python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$findings_next" >/dev/null 2>&1; then
+      validated=true
+      break
+    fi
+
+    retries=$((retries + 1))
+    [ "$(cat "$findings_file")" = "$canonical_findings_before" ] || { rm -rf "$tmpdir"; return 1; }
+    [ "$(cat "$backlog_file")" = "$canonical_backlog_before" ] || { rm -rf "$tmpdir"; return 1; }
+    [ "$retries" -le 1 ] || { rm -rf "$tmpdir"; return 1; }
+  done
+
+  "$validated" || { rm -rf "$tmpdir"; return 1; }
+  [ "$attempts" -eq 2 ] || { rm -rf "$tmpdir"; return 1; }
+  [ "$retries" -eq 1 ] || { rm -rf "$tmpdir"; return 1; }
+
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" build-backlog --phase plan --findings "$findings_next" --output "$backlog_next" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
+
+  attempt_transition() {
+    transition_attempts=$((transition_attempts + 1))
+    if [ "$published" != true ]; then
+      transition_attempts_before_publish=$((transition_attempts_before_publish + 1))
+    fi
+  }
+
+  [ -s "$findings_next" ] || { rm -rf "$tmpdir"; return 1; }
+  [ -s "$backlog_next" ] || { rm -rf "$tmpdir"; return 1; }
+
+  mv "$findings_next" "$findings_file" || { rm -rf "$tmpdir"; return 1; }
+  mv "$backlog_next" "$backlog_file" || { rm -rf "$tmpdir"; return 1; }
+  published=true
+  attempt_transition
+
+  local canonical_findings_after canonical_backlog_after
+  canonical_findings_after=$(cat "$findings_file")
+  canonical_backlog_after=$(cat "$backlog_file")
+
+  local rc=0
+  [ "$transition_attempts" -eq 1 ] || rc=1
+  [ "$transition_attempts_before_publish" -eq 0 ] || rc=1
+  [ "$canonical_findings_after" != "$canonical_findings_before" ] || rc=1
+  [ "$canonical_backlog_after" != "$canonical_backlog_before" ] || rc=1
+  [ -s "$findings_file" ] || rc=1
+  [ -s "$backlog_file" ] || rc=1
+
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish() {
+  local tmpdir phase_dir findings_file backlog_file findings_next backlog_next prompt_file handoff_file
+  tmpdir=$(mktemp -d)
+  phase_dir="$tmpdir/phase_01_plan"
+  findings_file="$phase_dir/review_findings.json"
+  backlog_file="$phase_dir/review_backlog.json"
+  findings_next="$phase_dir/review_findings.json.next"
+  backlog_next="$phase_dir/review_backlog.json.next"
+  prompt_file="$phase_dir/arbiter_prompt.txt"
+  handoff_file="$phase_dir/handoff_arbiter.json"
+  mkdir -p "$phase_dir"
+
+  cat > "$findings_file" <<'EOF'
+[
+  {
+    "finding_id": "old-runner-1",
+    "source": "arbiter",
+    "kind": "correctness",
+    "severity": "low",
+    "confidence": "high",
+    "path": "scripts/old_runner.py",
+    "line": 1,
+    "summary": "Old canonical finding.",
+    "why_it_matters": "Must remain unchanged before successful publish.",
+    "evidence": ["old-runner"],
+    "action": "none",
+    "needs_test": false,
+    "write_scope": ["scripts/old_runner.py"],
+    "related_acceptance_criteria": ["B5"]
+  }
+]
+EOF
+  cat > "$backlog_file" <<'EOF'
+{
+  "version": 1,
+  "generated_at": "2026-04-22T00:00:00Z",
+  "phase": "plan",
+  "at_loop_cap": false,
+  "allowed_decisions": ["fix_now", "verify_first", "defer", "drop", "needs_human_decision"],
+  "counts": {"fix_now": 1, "verify_first": 0, "defer": 0, "drop": 0, "needs_human_decision": 0},
+  "items": [
+    {
+      "finding_id": "old-runner-1",
+      "source": "arbiter",
+      "kind": "correctness",
+      "severity": "low",
+      "confidence": "high",
+      "path": "scripts/old_runner.py",
+      "line": 1,
+      "summary": "Old canonical finding.",
+      "why_it_matters": "Must remain unchanged before successful publish.",
+      "evidence": ["old-runner"],
+      "action": "none",
+      "needs_test": false,
+      "write_scope": ["scripts/old_runner.py"],
+      "related_acceptance_criteria": ["B5"],
+      "decision": "fix_now",
+      "decision_confidence": "high",
+      "reason": "old",
+      "needs_validation": ["typecheck"],
+      "owner": "builder",
+      "batch": "correctness-scripts"
+    }
+  ]
+}
+EOF
+  cat > "$tmpdir/fake_arbiter_bridge.py" <<'EOF'
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+prompt_file = pathlib.Path(args[args.index("--prompt-file") + 1])
+phase_dir = prompt_file.parent
+attempt_file = phase_dir / "arbiter_attempt.txt"
+
+attempt = 1
+if attempt_file.exists():
+    try:
+        attempt = int(attempt_file.read_text(encoding="utf-8").strip()) + 1
+    except ValueError:
+        attempt = 1
+attempt_file.write_text(str(attempt), encoding="utf-8")
+
+verdict_path = phase_dir / "arbiter_verdict.md"
+findings_path = phase_dir / "review_findings.json.next"
+handoff_path = phase_dir / "handoff_arbiter.json"
+verdict_path.write_text(f"arbiter attempt {attempt}\n", encoding="utf-8")
+
+if attempt == 1:
+    findings_path.write_text('[{"id":"bad-shape"}]\n', encoding="utf-8")
+else:
+    findings_path.write_text(
+        json.dumps(
+            [
+                {
+                    "finding_id": "runner-new-1",
+                    "source": "arbiter",
+                    "kind": "regression-risk",
+                    "severity": "high",
+                    "confidence": "high",
+                    "path": "scripts/new_runner.py",
+                    "line": 7,
+                    "summary": "Valid findings after retry.",
+                    "why_it_matters": "Validates runner/orchestrator retry path.",
+                    "evidence": ["runner"],
+                    "action": "fix now",
+                    "needs_test": True,
+                    "write_scope": ["scripts/new_runner.py"],
+                    "related_acceptance_criteria": ["B5"],
+                }
+            ],
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+handoff_path.write_text(
+    json.dumps(
+        {
+            "status": "complete",
+            "artifacts": [str(verdict_path), str(findings_path)],
+            "next": "planner",
+            "summary": f"attempt {attempt}",
+        }
+    ),
+    encoding="utf-8",
+)
+print("---HANDOFF---")
+print("STATUS: complete")
+print(f"ARTIFACTS: {verdict_path}, {findings_path}")
+print("NEXT: planner")
+print(f"SUMMARY: attempt {attempt}")
+EOF
+  chmod +x "$tmpdir/fake_arbiter_bridge.py"
+  cat > "$prompt_file" <<EOF
+Write arbiter outputs for retry testing.
+EOF
+
+  # --- Runtime-evidence instrumentation ---------------------------------
+  # Telemetry log: the runner appends JSON lines when QUEST_RUNNER_TELEMETRY_LOG
+  # is set. The test also appends non-runner events (validate/publish/transition)
+  # to the same file to produce a single ordered event stream that asserts the
+  # real runtime sequence. A regression that called transition before publish
+  # would show up as a "transition" line preceding the "publish" line here.
+  local telemetry_log="$tmpdir/runner_telemetry.log"
+  : > "$telemetry_log"
+  export QUEST_RUNNER_TELEMETRY_LOG="$telemetry_log"
+
+  record_event() {
+    # Append a single JSON event line for non-runner activity.
+    python3 - "$telemetry_log" "$@" <<'PY'
+import json, sys, time
+log_path = sys.argv[1]
+payload = {"ts": time.time(), "event": sys.argv[2]}
+for pair in sys.argv[3:]:
+    if "=" in pair:
+        k, v = pair.split("=", 1)
+        payload[k] = v
+with open(log_path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(payload, ensure_ascii=True) + "\n")
+PY
+  }
+
+  # Stat snapshot: (mtime_ns, inode, size, sha256). Any change — including an
+  # identical-byte rewrite (mtime_ns changes) — will differ from the recorded
+  # snapshot and cause the invariant assertion to fail.
+  stat_snapshot() {
+    python3 - "$1" <<'PY'
+import hashlib, os, sys
+p = sys.argv[1]
+st = os.stat(p)
+with open(p, "rb") as fh:
+    digest = hashlib.sha256(fh.read()).hexdigest()
+print(f"{st.st_mtime_ns}|{st.st_ino}|{st.st_size}|{digest}")
+PY
+  }
+
+  local canonical_findings_before canonical_backlog_before
+  canonical_findings_before=$(cat "$findings_file")
+  canonical_backlog_before=$(cat "$backlog_file")
+  local findings_snapshot_before backlog_snapshot_before
+  findings_snapshot_before=$(stat_snapshot "$findings_file")
+  backlog_snapshot_before=$(stat_snapshot "$backlog_file")
+
+  local attempts=0 retries=0 validated=false
+  local published=false
+  while [ "$attempts" -lt 3 ]; do
+    local output runner_rc result_kind
+    output=$(python3 "$CLAUDE_RUNNER" \
+      --quest-dir "$tmpdir" \
+      --phase plan_review \
+      --agent arbiter \
+      --iter 1 \
+      --prompt-file "$prompt_file" \
+      --handoff-file "$handoff_file" \
+      --bridge-script "$tmpdir/fake_arbiter_bridge.py" \
+      --cwd "$REPO_ROOT" 2>&1)
+    runner_rc=$?
+    result_kind=$(printf '%s' "$output" | jq -r '.result_kind')
+    attempts=$((attempts + 1))
+    [ "$runner_rc" -eq 0 ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+    [ "$result_kind" = "handoff_json" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+    # Stat-level canonical invariant: fails identical-byte rewrites too.
+    [ "$(stat_snapshot "$findings_file")" = "$findings_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+    [ "$(stat_snapshot "$backlog_file")" = "$backlog_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+    if python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$findings_next" >/dev/null 2>&1; then
+      record_event validate result=ok attempt="$attempts"
+      validated=true
+      break
+    fi
+    record_event validate result=fail attempt="$attempts"
+
+    retries=$((retries + 1))
+    [ "$(cat "$findings_file")" = "$canonical_findings_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+    [ "$(cat "$backlog_file")" = "$canonical_backlog_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+    [ "$retries" -le 1 ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  done
+
+  "$validated" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  [ "$attempts" -eq 2 ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  [ "$retries" -eq 1 ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  [ "$(cat "$phase_dir/arbiter_attempt.txt")" = "2" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" build-backlog --phase plan --findings "$findings_next" --output "$backlog_next" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+  # Canonical files must still be untouched after build-backlog/validate — including
+  # any identical-byte rewrite (detected by mtime/inode shift in stat_snapshot).
+  [ "$(stat_snapshot "$findings_file")" = "$findings_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  [ "$(stat_snapshot "$backlog_file")" = "$backlog_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+  # Capture the .next sha256 immediately before publish for a post-publish
+  # content-identity check that doesn't depend on the local canonical_* strings.
+  local findings_next_sha_prepublish backlog_next_sha_prepublish
+  findings_next_sha_prepublish=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$findings_next")
+  backlog_next_sha_prepublish=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$backlog_next")
+
+  attempt_transition() {
+    # Records a transition event to the shared telemetry log. If an orchestration
+    # regression called this before publish, the "transition" line would appear
+    # before the "publish" line and the ordering assertion below would fail.
+    record_event transition when="$1"
+  }
+
+  [ -s "$findings_next" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  [ -s "$backlog_next" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+  mv "$findings_next" "$findings_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  mv "$backlog_next" "$backlog_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  published=true
+  record_event publish
+  attempt_transition post_publish
+
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$findings_file" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_file" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+
+  local canonical_findings_after canonical_backlog_after
+  canonical_findings_after=$(cat "$findings_file")
+  canonical_backlog_after=$(cat "$backlog_file")
+
+  # Post-publish: canonical sha256 must match the .next sha256 captured immediately
+  # before publish (proves publish is the only event that mutated canonical).
+  local findings_post_sha backlog_post_sha
+  findings_post_sha=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$findings_file")
+  backlog_post_sha=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$backlog_file")
+
+  # Parse telemetry log and assert the observed runtime sequence.
+  local sequence_report
+  sequence_report=$(python3 - "$telemetry_log" <<'PY'
+import json, sys
+lines = [l for l in open(sys.argv[1], encoding="utf-8").read().splitlines() if l.strip()]
+events = [json.loads(l) for l in lines]
+order = [e.get("event") for e in events]
+
+attempt_starts = [e for e in events if e.get("event") == "attempt_start"]
+attempt_ends = [e for e in events if e.get("event") == "attempt_end"]
+transitions = [i for i, ev in enumerate(order) if ev == "transition"]
+publish_idxs = [i for i, ev in enumerate(order) if ev == "publish"]
+
+# Invariants:
+#  - exactly two runner attempt_start/attempt_end pairs (1 initial + 1 retry)
+#  - every attempt_end has result_kind=handoff_json (runner produced a handoff)
+#  - exactly one "publish" event
+#  - no "transition" event appears BEFORE "publish"
+#  - validate events: one fail (attempt 1) then one ok (attempt 2)
+errors = []
+if len(attempt_starts) != 2:
+    errors.append(f"attempt_start count={len(attempt_starts)}")
+if len(attempt_ends) != 2:
+    errors.append(f"attempt_end count={len(attempt_ends)}")
+for e in attempt_ends:
+    if e.get("result_kind") != "handoff_json":
+        errors.append(f"attempt_end result_kind={e.get('result_kind')}")
+if len(publish_idxs) != 1:
+    errors.append(f"publish count={len(publish_idxs)}")
+if publish_idxs and any(t < publish_idxs[0] for t in transitions):
+    errors.append("transition before publish")
+validate_results = [e.get("result") for e in events if e.get("event") == "validate"]
+if validate_results != ["fail", "ok"]:
+    errors.append(f"validate sequence={validate_results}")
+
+# Ensure attempt iterations observed by runner are 1 and 2 in order.
+iters = [e.get("iter") for e in attempt_ends]
+# Both invocations use --iter 1 (outer loop provides the retry semantics), so all
+# runner-observed iter values should be 1; the retry is counted by the outer loop
+# via attempt_file. What matters is that the runner produced TWO independent
+# attempt_end records, proving it actually ran twice.
+if len(set(iters)) > 2:
+    errors.append(f"iter values={iters}")
+
+if errors:
+    print("FAIL:" + ";".join(errors))
+else:
+    print("OK")
+PY
+  )
+
+  local rc=0
+  [ "$sequence_report" = "OK" ] || rc=1
+
+  [ "$findings_post_sha" = "$findings_next_sha_prepublish" ] || rc=1
+  [ "$backlog_post_sha" = "$backlog_next_sha_prepublish" ] || rc=1
+
+  [ "$canonical_findings_after" != "$canonical_findings_before" ] || rc=1
+  [ "$canonical_backlog_after" != "$canonical_backlog_before" ] || rc=1
+  [ -s "$findings_file" ] || rc=1
+  [ -s "$backlog_file" ] || rc=1
+
+  unset QUEST_RUNNER_TELEMETRY_LOG
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 run_test test_quest_state_updates_phase_and_timestamp
 run_test test_quest_state_transition_valid
 run_test test_quest_state_transition_invalid_leaves_state_unchanged
@@ -750,7 +1253,10 @@ run_test test_quest_startup_branch_invalid_mode_keeps_vcs_available_true
 run_test test_quest_startup_branch_skips_outside_git_repo
 run_test test_quest_startup_branch_invalid_slug_preserves_requested_mode
 run_test test_quest_startup_branch_exception_handler_tolerates_missing_git
+run_test test_plan_review_retry_harness_preserves_canonical_artifacts_until_publish
+run_test test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish
 run_test test_workflow_documents_no_vcs_review_path
+run_test test_workflow_documents_arbiter_validate_build_publish_contract
 run_test test_installer_cleans_up_renamed_scripts
 run_test test_installer_updates_pristine_agents_file_in_place
 run_test test_installer_records_checksum_for_new_agents_file

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -763,6 +763,73 @@ test_installer_preserves_modified_removed_managed_files_for_manual_cleanup() {
   return $rc
 }
 
+test_load_local_checksums_skips_unsafe_paths() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    cat > .quest-checksums <<'EOF'
+# Quest Installer Checksums
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  tests/unit/test_review_intelligence.py
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  /tmp/outside.txt
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  ../outside.txt
+EOF
+    load_installer_functions
+
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    load_local_checksums
+
+    [ "${#LOCAL_CHECKSUM_FILES[@]}" -eq 1 ] &&
+      [ "${LOCAL_CHECKSUM_FILES[0]}" = "tests/unit/test_review_intelligence.py" ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_skips_unsafe_removed_managed_file_path() {
+  local tmpdir
+  local outside_file
+  tmpdir=$(mktemp -d)
+  outside_file="$(dirname "$tmpdir")/quest-installer-outside-$$.txt"
+
+  (
+    cd "$tmpdir" || exit 1
+    printf 'outside repo file\n' > "$outside_file"
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=("../$(basename "$outside_file")")
+    LOCAL_CHECKSUM_VALUES=("$(get_file_checksum "../$(basename "$outside_file")")")
+    init_updated_checksums
+
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_removed_managed_files
+
+    [ -e "../$(basename "$outside_file")" ] &&
+      [ "${#UPDATED_CHECKSUM_FILES[@]}" -eq 0 ]
+  )
+  local rc=$?
+  rm -f "$outside_file"
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -1495,6 +1562,8 @@ run_test test_installer_records_checksum_for_new_agents_file
 run_test test_installer_preserves_customized_agents_file_with_sidecar
 run_test test_installer_prunes_pristine_removed_managed_files
 run_test test_installer_preserves_modified_removed_managed_files_for_manual_cleanup
+run_test test_load_local_checksums_skips_unsafe_paths
+run_test test_installer_skips_unsafe_removed_managed_file_path
 run_test test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream
 run_test test_installer_preserves_modified_untracked_legacy_installed_source_only_test
 run_test test_installer_preserves_unowned_source_only_test_path

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -544,7 +544,8 @@ test_workflow_documents_arbiter_validate_build_publish_contract() {
     grep -Fq 'review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
-    grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults' "$WORKFLOW_FILE" &&
+    grep -Fq 'Existing `arbiter_verdict.md` is preserved during pre-run preparation.' "$WORKFLOW_FILE" &&
     grep -Fq 'os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")' "$WORKFLOW_FILE" &&
     grep -Fq 'If arbiter handoff says `next: planner`' "$WORKFLOW_FILE" &&
     grep -Fq 'Do **not** call `quest_state.py --transition plan_reviewed`.' "$WORKFLOW_FILE"

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -693,12 +693,96 @@ test_installer_preserves_customized_agents_file_with_sidecar() {
   return $rc
 }
 
+test_installer_prunes_pristine_removed_managed_files() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p tests/unit
+    printf 'stale quest unit test\n' > tests/unit/test_review_intelligence.py
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=("tests/unit/test_review_intelligence.py")
+    LOCAL_CHECKSUM_VALUES=("$(get_file_checksum "tests/unit/test_review_intelligence.py")")
+    init_updated_checksums
+
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_removed_managed_files
+
+    [ ! -e tests/unit/test_review_intelligence.py ] &&
+      [ "${#UPDATED_CHECKSUM_FILES[@]}" -eq 0 ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_preserves_modified_removed_managed_files_for_manual_cleanup() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p tests/unit
+    printf 'locally modified stale quest unit test\n' > tests/unit/test_review_intelligence.py
+    load_installer_functions
+
+    DRY_RUN=false
+    FORCE_MODE=true
+    COPY_AS_IS=("scripts/quest_state.py")
+    USER_CUSTOMIZED=()
+    MERGE_CAREFULLY=()
+    LOCAL_CHECKSUM_FILES=("tests/unit/test_review_intelligence.py")
+    LOCAL_CHECKSUM_VALUES=("different-stored-checksum")
+    init_updated_checksums
+
+    log_info() { :; }
+    log_warn() { :; }
+    log_success() { :; }
+    log_action() { :; }
+    clear_progress() { :; }
+
+    cleanup_removed_managed_files
+
+    [ -e tests/unit/test_review_intelligence.py ] &&
+      [ "${#UPDATED_CHECKSUM_FILES[@]}" -eq 0 ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 test_manifest_lists_prefixed_scripts() {
   grep -q '^scripts/quest_claude_bridge.py$' "$MANIFEST_FILE" &&
     grep -q '^scripts/quest_validate-handoff-contracts.sh$' "$MANIFEST_FILE" &&
     grep -q '^scripts/quest_validate-manifest.sh$' "$MANIFEST_FILE" &&
     grep -q '^scripts/quest_validate-quest-config.sh$' "$MANIFEST_FILE" &&
     grep -q '^scripts/quest_validate-quest-state.sh$' "$MANIFEST_FILE"
+}
+
+test_manifest_lists_installed_quest_smoke_tests() {
+  grep -q '^tests/integration/test-enforce-allowlist.sh$' "$MANIFEST_FILE" &&
+    grep -q '^tests/test-quest-preflight.sh$' "$MANIFEST_FILE" &&
+    grep -q '^tests/test-quest-runtime.sh$' "$MANIFEST_FILE" &&
+    grep -q '^tests/test-validate-handoff-contracts.sh$' "$MANIFEST_FILE" &&
+    grep -q '^tests/test-validate-quest-state.sh$' "$MANIFEST_FILE"
+}
+
+test_manifest_excludes_source_only_unit_tests() {
+  ! grep -q '^tests/unit/test_allowlist_matcher.py$' "$MANIFEST_FILE" &&
+    ! grep -q '^tests/unit/test_review_intelligence.py$' "$MANIFEST_FILE" &&
+    ! grep -q '^tests/unit/test_codex_skill_wrappers.py$' "$MANIFEST_FILE"
 }
 
 test_validation_hook_script_accepts_legacy_symlink_target() {
@@ -1291,7 +1375,11 @@ run_test test_installer_cleans_up_renamed_scripts
 run_test test_installer_updates_pristine_agents_file_in_place
 run_test test_installer_records_checksum_for_new_agents_file
 run_test test_installer_preserves_customized_agents_file_with_sidecar
+run_test test_installer_prunes_pristine_removed_managed_files
+run_test test_installer_preserves_modified_removed_managed_files_for_manual_cleanup
 run_test test_manifest_lists_prefixed_scripts
+run_test test_manifest_lists_installed_quest_smoke_tests
+run_test test_manifest_excludes_source_only_unit_tests
 run_test test_validation_hook_script_accepts_legacy_symlink_target
 run_test test_quest_claude_runner_polls_handoff_and_logs_runtime
 run_test test_quest_claude_probe_requires_real_artifacts

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -545,8 +545,9 @@ test_workflow_documents_arbiter_validate_build_publish_contract() {
     grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults' "$WORKFLOW_FILE" &&
-    grep -Fq 'Existing `arbiter_verdict.md` is preserved during pre-run preparation.' "$WORKFLOW_FILE" &&
+    grep -Fq 'Canonical `arbiter_verdict.md` is not prepared or truncated; publish `arbiter_verdict.md.next` only after validation succeeds.' "$WORKFLOW_FILE" &&
     grep -Fq 'os.replace(".quest/<id>/phase_01_plan/review_findings.json.next", ".quest/<id>/phase_01_plan/review_findings.json")' "$WORKFLOW_FILE" &&
+    grep -Fq 'os.replace(".quest/<id>/phase_01_plan/arbiter_verdict.md.next", ".quest/<id>/phase_01_plan/arbiter_verdict.md")' "$WORKFLOW_FILE" &&
     grep -Fq 'If arbiter handoff says `next: planner`' "$WORKFLOW_FILE" &&
     grep -Fq 'Do **not** call `quest_state.py --transition plan_reviewed`.' "$WORKFLOW_FILE"
 }
@@ -749,11 +750,13 @@ test_quest_startup_branch_exception_handler_tolerates_missing_git() {
 }
 
 test_plan_review_retry_harness_preserves_canonical_artifacts_until_publish() {
-  local tmpdir phase_dir findings_file backlog_file findings_next backlog_next
+  local tmpdir phase_dir verdict_file findings_file backlog_file verdict_next findings_next backlog_next
   tmpdir=$(mktemp -d)
   phase_dir="$tmpdir/phase_01_plan"
+  verdict_file="$phase_dir/arbiter_verdict.md"
   findings_file="$phase_dir/review_findings.json"
   backlog_file="$phase_dir/review_backlog.json"
+  verdict_next="$phase_dir/arbiter_verdict.md.next"
   findings_next="$phase_dir/review_findings.json.next"
   backlog_next="$phase_dir/review_backlog.json.next"
   mkdir -p "$phase_dir"
@@ -812,8 +815,10 @@ EOF
   ]
 }
 EOF
+  echo "old verdict" > "$verdict_file"
 
-  local canonical_findings_before canonical_backlog_before
+  local canonical_verdict_before canonical_findings_before canonical_backlog_before
+  canonical_verdict_before=$(cat "$verdict_file")
   canonical_findings_before=$(cat "$findings_file")
   canonical_backlog_before=$(cat "$backlog_file")
 
@@ -821,7 +826,8 @@ EOF
   local transition_attempts=0 transition_attempts_before_publish=0 published=false
   while [ "$attempts" -lt 2 ]; do
     attempts=$((attempts + 1))
-    rm -f "$findings_next" "$backlog_next"
+    rm -f "$verdict_next" "$findings_next" "$backlog_next"
+    echo "arbiter attempt $attempts" > "$verdict_next"
     if [ "$attempts" -eq 1 ]; then
       cat > "$findings_next" <<'EOF'
 [
@@ -859,6 +865,7 @@ EOF
     fi
 
     retries=$((retries + 1))
+    [ "$(cat "$verdict_file")" = "$canonical_verdict_before" ] || { rm -rf "$tmpdir"; return 1; }
     [ "$(cat "$findings_file")" = "$canonical_findings_before" ] || { rm -rf "$tmpdir"; return 1; }
     [ "$(cat "$backlog_file")" = "$canonical_backlog_before" ] || { rm -rf "$tmpdir"; return 1; }
     [ "$retries" -le 1 ] || { rm -rf "$tmpdir"; return 1; }
@@ -869,7 +876,7 @@ EOF
   [ "$retries" -eq 1 ] || { rm -rf "$tmpdir"; return 1; }
 
   python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" build-backlog --phase plan --findings "$findings_next" --output "$backlog_next" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
-  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" --expected-phase plan --strict-plan-defaults >/dev/null 2>&1 || { rm -rf "$tmpdir"; return 1; }
 
   attempt_transition() {
     transition_attempts=$((transition_attempts + 1))
@@ -878,23 +885,28 @@ EOF
     fi
   }
 
+  [ -s "$verdict_next" ] || { rm -rf "$tmpdir"; return 1; }
   [ -s "$findings_next" ] || { rm -rf "$tmpdir"; return 1; }
   [ -s "$backlog_next" ] || { rm -rf "$tmpdir"; return 1; }
 
+  mv "$verdict_next" "$verdict_file" || { rm -rf "$tmpdir"; return 1; }
   mv "$findings_next" "$findings_file" || { rm -rf "$tmpdir"; return 1; }
   mv "$backlog_next" "$backlog_file" || { rm -rf "$tmpdir"; return 1; }
   published=true
   attempt_transition
 
-  local canonical_findings_after canonical_backlog_after
+  local canonical_verdict_after canonical_findings_after canonical_backlog_after
+  canonical_verdict_after=$(cat "$verdict_file")
   canonical_findings_after=$(cat "$findings_file")
   canonical_backlog_after=$(cat "$backlog_file")
 
   local rc=0
   [ "$transition_attempts" -eq 1 ] || rc=1
   [ "$transition_attempts_before_publish" -eq 0 ] || rc=1
+  [ "$canonical_verdict_after" != "$canonical_verdict_before" ] || rc=1
   [ "$canonical_findings_after" != "$canonical_findings_before" ] || rc=1
   [ "$canonical_backlog_after" != "$canonical_backlog_before" ] || rc=1
+  [ -s "$verdict_file" ] || rc=1
   [ -s "$findings_file" ] || rc=1
   [ -s "$backlog_file" ] || rc=1
 
@@ -903,16 +915,20 @@ EOF
 }
 
 test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish() {
-  local tmpdir phase_dir findings_file backlog_file findings_next backlog_next prompt_file handoff_file
+  local tmpdir phase_dir verdict_file findings_file backlog_file verdict_next findings_next backlog_next prompt_file handoff_file
   tmpdir=$(mktemp -d)
   phase_dir="$tmpdir/phase_01_plan"
+  verdict_file="$phase_dir/arbiter_verdict.md"
   findings_file="$phase_dir/review_findings.json"
   backlog_file="$phase_dir/review_backlog.json"
+  verdict_next="$phase_dir/arbiter_verdict.md.next"
   findings_next="$phase_dir/review_findings.json.next"
   backlog_next="$phase_dir/review_backlog.json.next"
   prompt_file="$phase_dir/arbiter_prompt.txt"
   handoff_file="$phase_dir/handoff_arbiter.json"
   mkdir -p "$phase_dir"
+
+  echo "old canonical verdict" > "$verdict_file"
 
   cat > "$findings_file" <<'EOF'
 [
@@ -987,7 +1003,7 @@ if attempt_file.exists():
         attempt = 1
 attempt_file.write_text(str(attempt), encoding="utf-8")
 
-verdict_path = phase_dir / "arbiter_verdict.md"
+verdict_path = phase_dir / "arbiter_verdict.md.next"
 findings_path = phase_dir / "review_findings.json.next"
 handoff_path = phase_dir / "handoff_arbiter.json"
 verdict_path.write_text(f"arbiter attempt {attempt}\n", encoding="utf-8")
@@ -1082,10 +1098,12 @@ print(f"{st.st_mtime_ns}|{st.st_ino}|{st.st_size}|{digest}")
 PY
   }
 
-  local canonical_findings_before canonical_backlog_before
+  local canonical_verdict_before canonical_findings_before canonical_backlog_before
+  canonical_verdict_before=$(cat "$verdict_file")
   canonical_findings_before=$(cat "$findings_file")
   canonical_backlog_before=$(cat "$backlog_file")
-  local findings_snapshot_before backlog_snapshot_before
+  local verdict_snapshot_before findings_snapshot_before backlog_snapshot_before
+  verdict_snapshot_before=$(stat_snapshot "$verdict_file")
   findings_snapshot_before=$(stat_snapshot "$findings_file")
   backlog_snapshot_before=$(stat_snapshot "$backlog_file")
 
@@ -1109,6 +1127,7 @@ PY
     [ "$result_kind" = "handoff_json" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
     # Stat-level canonical invariant: fails identical-byte rewrites too.
+    [ "$(stat_snapshot "$verdict_file")" = "$verdict_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$(stat_snapshot "$findings_file")" = "$findings_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$(stat_snapshot "$backlog_file")" = "$backlog_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
@@ -1120,6 +1139,7 @@ PY
     record_event validate result=fail attempt="$attempts"
 
     retries=$((retries + 1))
+    [ "$(cat "$verdict_file")" = "$canonical_verdict_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$(cat "$findings_file")" = "$canonical_findings_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$(cat "$backlog_file")" = "$canonical_backlog_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$retries" -le 1 ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
@@ -1131,16 +1151,18 @@ PY
   [ "$(cat "$phase_dir/arbiter_attempt.txt")" = "2" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
   python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" build-backlog --phase plan --findings "$findings_next" --output "$backlog_next" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
-  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+  python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_next" --expected-phase plan --strict-plan-defaults >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
   # Canonical files must still be untouched after build-backlog/validate — including
   # any identical-byte rewrite (detected by mtime/inode shift in stat_snapshot).
+  [ "$(stat_snapshot "$verdict_file")" = "$verdict_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   [ "$(stat_snapshot "$findings_file")" = "$findings_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   [ "$(stat_snapshot "$backlog_file")" = "$backlog_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
   # Capture the .next sha256 immediately before publish for a post-publish
   # content-identity check that doesn't depend on the local canonical_* strings.
-  local findings_next_sha_prepublish backlog_next_sha_prepublish
+  local verdict_next_sha_prepublish findings_next_sha_prepublish backlog_next_sha_prepublish
+  verdict_next_sha_prepublish=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$verdict_next")
   findings_next_sha_prepublish=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$findings_next")
   backlog_next_sha_prepublish=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$backlog_next")
 
@@ -1151,9 +1173,11 @@ PY
     record_event transition when="$1"
   }
 
+  [ -s "$verdict_next" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   [ -s "$findings_next" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   [ -s "$backlog_next" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
+  mv "$verdict_next" "$verdict_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   mv "$findings_next" "$findings_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   mv "$backlog_next" "$backlog_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   published=true
@@ -1163,13 +1187,15 @@ PY
   python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$findings_file" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
   python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-backlog --input "$backlog_file" >/dev/null 2>&1 || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
-  local canonical_findings_after canonical_backlog_after
+  local canonical_verdict_after canonical_findings_after canonical_backlog_after
+  canonical_verdict_after=$(cat "$verdict_file")
   canonical_findings_after=$(cat "$findings_file")
   canonical_backlog_after=$(cat "$backlog_file")
 
   # Post-publish: canonical sha256 must match the .next sha256 captured immediately
   # before publish (proves publish is the only event that mutated canonical).
-  local findings_post_sha backlog_post_sha
+  local verdict_post_sha findings_post_sha backlog_post_sha
+  verdict_post_sha=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$verdict_file")
   findings_post_sha=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$findings_file")
   backlog_post_sha=$(python3 -c 'import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$backlog_file")
 
@@ -1227,11 +1253,14 @@ PY
   local rc=0
   [ "$sequence_report" = "OK" ] || rc=1
 
+  [ "$verdict_post_sha" = "$verdict_next_sha_prepublish" ] || rc=1
   [ "$findings_post_sha" = "$findings_next_sha_prepublish" ] || rc=1
   [ "$backlog_post_sha" = "$backlog_next_sha_prepublish" ] || rc=1
 
+  [ "$canonical_verdict_after" != "$canonical_verdict_before" ] || rc=1
   [ "$canonical_findings_after" != "$canonical_findings_before" ] || rc=1
   [ "$canonical_backlog_after" != "$canonical_backlog_before" ] || rc=1
+  [ -s "$verdict_file" ] || rc=1
   [ -s "$findings_file" ] || rc=1
   [ -s "$backlog_file" ] || rc=1
 

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -719,6 +719,60 @@ test_plan_to_plan_reviewed_rejects_review_owner_and_batch() {
   [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected builder" && echo "$output" | grep -q "expected correctness-scripts"
 }
 
+test_plan_to_plan_reviewed_accepts_canonical_raw_write_scope_sorting() {
+  # The canonical Python builder filters whitespace-only write_scope entries,
+  # sorts the original strings, then trims the selected candidate. Keep the
+  # shell validator aligned so it does not reject valid plan-phase backlogs.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-a.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
+  cat > "$tmpdir/phase_01_plan/review_backlog.json" <<'EOF'
+{
+  "version": 1,
+  "generated_at": "2026-04-23T00:00:00Z",
+  "at_loop_cap": false,
+  "phase": "plan",
+  "allowed_decisions": ["fix_now", "verify_first", "defer", "drop", "needs_human_decision"],
+  "counts": {"fix_now": 1, "verify_first": 0, "defer": 0, "drop": 0, "needs_human_decision": 0},
+  "items": [
+    {
+      "finding_id": "RF-001",
+      "source": "code-reviewer-a",
+      "kind": "correctness",
+      "severity": "medium",
+      "confidence": "medium",
+      "path": "scripts/example.py",
+      "line": 10,
+      "summary": "Potential issue in edge-case handling.",
+      "why_it_matters": "Could break behavior for uncommon inputs.",
+      "evidence": ["Reproducible with malformed payload."],
+      "action": "Add guard and tests for this edge case.",
+      "needs_test": true,
+      "write_scope": [" zeta/example.py", "alpha/example.py"],
+      "related_acceptance_criteria": ["AC-1"],
+      "decision": "fix_now",
+      "decision_confidence": "medium",
+      "reason": "Plan-phase canonical default: builder implements this finding now.",
+      "needs_validation": ["unit_test", "typecheck", "lint"],
+      "owner": "builder",
+      "batch": "correctness-zeta"
+    }
+  ]
+}
+EOF
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ]
+}
+
 test_valid_reviewing_to_fixing() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -1157,6 +1211,7 @@ run_test test_plan_to_plan_reviewed_rejects_review_phase_backlog
 run_test test_plan_to_plan_reviewed_rejects_non_actionable_decision
 run_test test_plan_to_plan_reviewed_rejects_verify_first_decision
 run_test test_plan_to_plan_reviewed_rejects_review_owner_and_batch
+run_test test_plan_to_plan_reviewed_accepts_canonical_raw_write_scope_sorting
 run_test test_non_numeric_allowlist_iterations
 run_test test_zero_allowlist_iterations_are_rejected
 run_test test_validation_log_written

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -76,6 +76,8 @@ write_review_backlog() {
   local decision="drop"
   local needs_validation='[]'
   local needs_test='false'
+  local owner="scripts"
+  local batch="scripts/example.py"
 
   case "$mode" in
     actionable)
@@ -95,6 +97,16 @@ write_review_backlog() {
       needs_validation='["unit_test", "typecheck", "lint"]'
       needs_test='true'
       phase="plan"
+      owner="builder"
+      batch="correctness-scripts"
+      ;;
+    plan_verify_first)
+      decision="verify_first"
+      needs_validation='["unit_test", "typecheck", "lint"]'
+      needs_test='true'
+      phase="plan"
+      owner="builder"
+      batch="correctness-scripts"
       ;;
     *)
       decision="drop"
@@ -116,7 +128,7 @@ write_review_backlog() {
   ],
   "counts": {
     "fix_now": $([ "$decision" = "fix_now" ] && echo 1 || echo 0),
-    "verify_first": 0,
+    "verify_first": $([ "$decision" = "verify_first" ] && echo 1 || echo 0),
     "defer": 0,
     "drop": $([ "$decision" = "drop" ] && echo 1 || echo 0),
     "needs_human_decision": $([ "$decision" = "needs_human_decision" ] && echo 1 || echo 0)
@@ -141,8 +153,8 @@ write_review_backlog() {
       "decision_confidence": "medium",
       "reason": "Example reason",
       "needs_validation": $needs_validation,
-      "owner": "scripts",
-      "batch": "scripts/example.py"
+      "owner": "$owner",
+      "batch": "$batch"
     }
   ]
 }
@@ -588,7 +600,7 @@ test_plan_to_plan_reviewed_rejects_review_phase_backlog() {
   # Guard: a future orchestrator that forgets --phase plan would build a
   # review-phase backlog (with decision values like verify_first/drop) and
   # still pass schema checks. The validator must reject it so approved
-  # plans never fall through without actionable fix_now/verify_first tags.
+  # plans never fall through without canonical plan-phase defaults.
   local tmpdir
   tmpdir=$(mktemp -d)
   create_state_json "$tmpdir" "plan"
@@ -628,7 +640,7 @@ test_plan_to_plan_reviewed_rejects_non_actionable_decision() {
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-canonical"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected fix_now"
 }
 
 test_plan_to_plan_reviewed_rejects_verify_first_decision() {
@@ -683,7 +695,28 @@ EOF
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-canonical"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "decision=verify_first"
+}
+
+test_plan_to_plan_reviewed_rejects_review_owner_and_batch() {
+  # Plan-phase build-backlog routes every item to the builder and uses the
+  # deterministic <kind>-<path-group> batch slug.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-a.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
+  # decision=fix_now and phase=plan, but review-phase owner/batch defaults.
+  write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "actionable" "plan"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected builder" && echo "$output" | grep -q "expected correctness-scripts"
 }
 
 test_valid_reviewing_to_fixing() {
@@ -1123,6 +1156,7 @@ run_test test_plan_to_plan_reviewed_rejects_invalid_backlog_finding_fields
 run_test test_plan_to_plan_reviewed_rejects_review_phase_backlog
 run_test test_plan_to_plan_reviewed_rejects_non_actionable_decision
 run_test test_plan_to_plan_reviewed_rejects_verify_first_decision
+run_test test_plan_to_plan_reviewed_rejects_review_owner_and_batch
 run_test test_non_numeric_allowlist_iterations
 run_test test_zero_allowlist_iterations_are_rejected
 run_test test_validation_log_written

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -72,6 +72,7 @@ EOF
 write_review_backlog() {
   local filepath="$1"
   local mode="$2"
+  local phase="${3:-review}"
   local decision="drop"
   local needs_validation='[]'
   local needs_test='false'
@@ -88,6 +89,13 @@ write_review_backlog() {
     clean)
       decision="drop"
       ;;
+    plan_actionable)
+      # Plan-phase canonical: every item flows to the builder.
+      decision="fix_now"
+      needs_validation='["unit_test", "typecheck", "lint"]'
+      needs_test='true'
+      phase="plan"
+      ;;
     *)
       decision="drop"
       ;;
@@ -98,6 +106,7 @@ write_review_backlog() {
   "version": 1,
   "generated_at": "2026-04-16T00:00:00Z",
   "at_loop_cap": false,
+  "phase": "$phase",
   "allowed_decisions": [
     "fix_now",
     "verify_first",
@@ -173,7 +182,7 @@ test_valid_plan_to_plan_reviewed() {
   touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
   touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
   write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
-  write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "clean"
+  write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "plan_actionable"
   local output
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
@@ -573,6 +582,52 @@ PY
   local rc=$?
   rm -rf "$tmpdir"
   [ "$rc" -eq 1 ] && echo "$output" | grep -q "review backlog schema invalid" && echo "$output" | grep -q "field 'severity'" && echo "$output" | grep -q "field 'summary'"
+}
+
+test_plan_to_plan_reviewed_rejects_review_phase_backlog() {
+  # Guard: a future orchestrator that forgets --phase plan would build a
+  # review-phase backlog (with decision values like verify_first/drop) and
+  # still pass schema checks. The validator must reject it so approved
+  # plans never fall through without actionable fix_now/verify_first tags.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-a.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
+  # "actionable" mode with default phase="review" -> schema valid but
+  # phase mismatch.
+  write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "actionable" "review"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected phase='plan'"
+}
+
+test_plan_to_plan_reviewed_rejects_non_actionable_decision() {
+  # Plan-phase approval requires every item to be actionable for the builder.
+  # A drop/defer/needs_human_decision item must fail -- even if phase="plan"
+  # is set, a forgotten --phase flag on merge would produce exactly that.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-a.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
+  # phase="plan" but decision="drop" -> must fail the actionable check
+  write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "clean" "plan"
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-actionable"
 }
 
 test_valid_reviewing_to_fixing() {
@@ -1009,6 +1064,8 @@ run_test test_valid_presentation_complete_to_building
 run_test test_plan_to_plan_reviewed_rejects_invalid_backlog_item_schema
 run_test test_plan_to_plan_reviewed_rejects_false_typed_backlog_fields
 run_test test_plan_to_plan_reviewed_rejects_invalid_backlog_finding_fields
+run_test test_plan_to_plan_reviewed_rejects_review_phase_backlog
+run_test test_plan_to_plan_reviewed_rejects_non_actionable_decision
 run_test test_non_numeric_allowlist_iterations
 run_test test_zero_allowlist_iterations_are_rejected
 run_test test_validation_log_written

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -609,9 +609,10 @@ test_plan_to_plan_reviewed_rejects_review_phase_backlog() {
 }
 
 test_plan_to_plan_reviewed_rejects_non_actionable_decision() {
-  # Plan-phase approval requires every item to be actionable for the builder.
-  # A drop/defer/needs_human_decision item must fail -- even if phase="plan"
-  # is set, a forgotten --phase flag on merge would produce exactly that.
+  # Plan-phase approval requires every item to match the canonical plan-phase
+  # producer, which hardcodes decision=fix_now. Any other decision in a
+  # plan-phase backlog is drift -- a drop/defer/needs_human_decision item
+  # must fail -- even if phase="plan" is set.
   local tmpdir
   tmpdir=$(mktemp -d)
   create_state_json "$tmpdir" "plan"
@@ -621,13 +622,68 @@ test_plan_to_plan_reviewed_rejects_non_actionable_decision() {
   touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
   touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
   write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
-  # phase="plan" but decision="drop" -> must fail the actionable check
+  # phase="plan" but decision="drop" -> must fail the canonical check
   write_review_backlog "$tmpdir/phase_01_plan/review_backlog.json" "clean" "plan"
   local output
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-actionable"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-canonical"
+}
+
+test_plan_to_plan_reviewed_rejects_verify_first_decision() {
+  # verify_first is legitimate in review-phase backlogs but not plan-phase:
+  # the canonical _plan_phase_decision helper only emits fix_now.
+  # A drifted producer that emits verify_first under phase="plan" must fail.
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  create_state_json "$tmpdir" "plan"
+  mkdir -p "$tmpdir/phase_01_plan"
+  touch "$tmpdir/phase_01_plan/plan.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-a.md"
+  touch "$tmpdir/phase_01_plan/review_plan-reviewer-b.md"
+  touch "$tmpdir/phase_01_plan/arbiter_verdict.md"
+  write_valid_review_findings "$tmpdir/phase_01_plan/review_findings.json"
+  # Hand-write a plan-phase backlog whose decision is verify_first
+  cat > "$tmpdir/phase_01_plan/review_backlog.json" <<'EOF'
+{
+  "version": 1,
+  "generated_at": "2026-04-23T00:00:00Z",
+  "at_loop_cap": false,
+  "phase": "plan",
+  "allowed_decisions": ["fix_now", "verify_first", "defer", "drop", "needs_human_decision"],
+  "counts": {"fix_now": 0, "verify_first": 1, "defer": 0, "drop": 0, "needs_human_decision": 0},
+  "items": [
+    {
+      "finding_id": "RF-001",
+      "source": "code-reviewer-a",
+      "kind": "correctness",
+      "severity": "medium",
+      "confidence": "medium",
+      "path": "scripts/example.py",
+      "line": 10,
+      "summary": "Potential issue in edge-case handling.",
+      "why_it_matters": "Could break behavior for uncommon inputs.",
+      "evidence": ["Reproducible with malformed payload."],
+      "action": "Add guard and tests for this edge case.",
+      "needs_test": true,
+      "write_scope": ["scripts/example.py"],
+      "related_acceptance_criteria": ["AC-1"],
+      "decision": "verify_first",
+      "decision_confidence": "medium",
+      "reason": "Drift: plan-phase producer should emit fix_now.",
+      "needs_validation": ["unit_test"],
+      "owner": "builder",
+      "batch": "correctness-scripts"
+    }
+  ]
+}
+EOF
+  local output
+  output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
+  local rc=$?
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "non-canonical"
 }
 
 test_valid_reviewing_to_fixing() {
@@ -1066,6 +1122,7 @@ run_test test_plan_to_plan_reviewed_rejects_false_typed_backlog_fields
 run_test test_plan_to_plan_reviewed_rejects_invalid_backlog_finding_fields
 run_test test_plan_to_plan_reviewed_rejects_review_phase_backlog
 run_test test_plan_to_plan_reviewed_rejects_non_actionable_decision
+run_test test_plan_to_plan_reviewed_rejects_verify_first_decision
 run_test test_non_numeric_allowlist_iterations
 run_test test_zero_allowlist_iterations_are_rejected
 run_test test_validation_log_written

--- a/tests/test-validate-quest-state.sh
+++ b/tests/test-validate-quest-state.sh
@@ -640,7 +640,7 @@ test_plan_to_plan_reviewed_rejects_non_actionable_decision() {
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected fix_now"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "must be 'fix_now'"
 }
 
 test_plan_to_plan_reviewed_rejects_verify_first_decision() {
@@ -695,7 +695,7 @@ EOF
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "decision=verify_first"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "verify_first"
 }
 
 test_plan_to_plan_reviewed_rejects_review_owner_and_batch() {
@@ -716,7 +716,7 @@ test_plan_to_plan_reviewed_rejects_review_owner_and_batch() {
   output=$(bash "$SCRIPT" "$tmpdir" "plan_reviewed" 2>&1)
   local rc=$?
   rm -rf "$tmpdir"
-  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "expected builder" && echo "$output" | grep -q "expected correctness-scripts"
+  [ "$rc" -eq 1 ] && echo "$output" | grep -q "\[FAIL\]" && echo "$output" | grep -q "must be 'builder'" && echo "$output" | grep -q "must be 'correctness-scripts'"
 }
 
 test_plan_to_plan_reviewed_accepts_canonical_raw_write_scope_sorting() {

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -184,6 +184,15 @@ def test_find_delete_is_blocked_for_bare_find_entry():
     assert reason == "blocked_find_action"
 
 
+def test_absolute_path_find_exec_is_blocked_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "/usr/bin/find . -name '*.py' -exec rm {} +",
+        ["find"],
+    )
+    assert allowed is False
+    assert reason == "blocked_find_action"
+
+
 def test_exact_find_exec_entry_is_allowed():
     command = "find . -name '*.py' -exec echo {} +"
     allowed, reason = is_bash_command_allowed(command, [command])
@@ -230,6 +239,15 @@ def test_rg_pre_equals_form_is_blocked_for_bare_rg_entry():
 def test_rg_pre_glob_is_blocked_for_bare_rg_entry():
     allowed, reason = is_bash_command_allowed(
         "rg --pre-glob '*.md' TODO",
+        ["rg"],
+    )
+    assert allowed is False
+    assert reason == "blocked_rg_flag"
+
+
+def test_absolute_path_rg_pre_is_blocked_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "/opt/homebrew/bin/rg --pre sh TODO",
         ["rg"],
     )
     assert allowed is False

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -193,6 +193,15 @@ def test_absolute_path_find_exec_is_blocked_for_bare_find_entry():
     assert reason == "blocked_find_action"
 
 
+def test_absolute_path_find_query_is_allowed_for_bare_find_entry():
+    allowed, reason = is_bash_command_allowed(
+        "/usr/bin/find . -name '*.py' -type f",
+        ["find"],
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"
+
+
 def test_exact_find_exec_entry_is_allowed():
     command = "find . -name '*.py' -exec echo {} +"
     allowed, reason = is_bash_command_allowed(command, [command])
@@ -252,6 +261,15 @@ def test_absolute_path_rg_pre_is_blocked_for_bare_rg_entry():
     )
     assert allowed is False
     assert reason == "blocked_rg_flag"
+
+
+def test_absolute_path_rg_query_is_allowed_for_bare_rg_entry():
+    allowed, reason = is_bash_command_allowed(
+        "/opt/homebrew/bin/rg TODO tests/unit/",
+        ["rg"],
+    )
+    assert allowed is True
+    assert reason == "token_prefix_match"
 
 
 def test_exact_rg_pre_entry_is_allowed():

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -63,11 +63,11 @@ class TestExpectedArtifactsForRole:
         names = [p.name for p in paths]
         assert names == ["review_fix_feedback_discussion.md", "handoff_fixer.json"]
 
-    def test_arbiter_uses_next_findings_artifact_and_no_backlog(self, tmp_path: Path):
+    def test_arbiter_uses_next_artifacts_and_no_backlog(self, tmp_path: Path):
         paths = expected_artifacts_for_role(tmp_path, "plan_review", "arbiter")
         names = [p.name for p in paths]
         assert names == [
-            "arbiter_verdict.md",
+            "arbiter_verdict.md.next",
             "review_findings.json.next",
             "handoff_arbiter.json",
         ]
@@ -147,7 +147,9 @@ class TestPrepareArtifactFiles:
         assert len(result) == 1
         assert ".." not in str(result[0])
 
-    def test_arbiter_prepare_touches_next_file_not_canonical_findings(self, tmp_path: Path):
+    def test_arbiter_prepare_touches_next_files_not_canonical_artifacts(
+        self, tmp_path: Path
+    ):
         quest_dir = tmp_path / "quest"
         canonical = quest_dir / "phase_01_plan" / "review_findings.json"
         verdict = quest_dir / "phase_01_plan" / "arbiter_verdict.md"
@@ -162,17 +164,20 @@ class TestPrepareArtifactFiles:
 
         assert canonical.read_text(encoding="utf-8") == original
         assert verdict.read_text(encoding="utf-8") == original_verdict
+        assert (quest_dir / "phase_01_plan" / "arbiter_verdict.md.next").exists()
         assert (quest_dir / "phase_01_plan" / "review_findings.json.next").exists()
 
-    def test_arbiter_prepare_creates_missing_verdict(self, tmp_path: Path):
+    def test_arbiter_prepare_creates_missing_verdict_scratch(self, tmp_path: Path):
         quest_dir = tmp_path / "quest"
         verdict = quest_dir / "phase_01_plan" / "arbiter_verdict.md"
+        verdict_next = quest_dir / "phase_01_plan" / "arbiter_verdict.md.next"
 
         artifacts = expected_artifacts_for_role(quest_dir, "plan_review", "arbiter")
         prepare_artifact_files(artifacts)
 
-        assert verdict.exists()
-        assert verdict.read_text(encoding="utf-8") == ""
+        assert not verdict.exists()
+        assert verdict_next.exists()
+        assert verdict_next.read_text(encoding="utf-8") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -63,13 +63,12 @@ class TestExpectedArtifactsForRole:
         names = [p.name for p in paths]
         assert names == ["review_fix_feedback_discussion.md", "handoff_fixer.json"]
 
-    def test_arbiter_includes_findings_and_backlog_artifacts(self, tmp_path: Path):
+    def test_arbiter_uses_next_findings_artifact_and_no_backlog(self, tmp_path: Path):
         paths = expected_artifacts_for_role(tmp_path, "plan_review", "arbiter")
         names = [p.name for p in paths]
         assert names == [
             "arbiter_verdict.md",
-            "review_findings.json",
-            "review_backlog.json",
+            "review_findings.json.next",
             "handoff_arbiter.json",
         ]
 
@@ -147,6 +146,19 @@ class TestPrepareArtifactFiles:
         result = prepare_artifact_files([relative_looking])
         assert len(result) == 1
         assert ".." not in str(result[0])
+
+    def test_arbiter_prepare_touches_next_file_not_canonical_findings(self, tmp_path: Path):
+        quest_dir = tmp_path / "quest"
+        canonical = quest_dir / "phase_01_plan" / "review_findings.json"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text('[{"finding_id":"stable"}]\n', encoding="utf-8")
+        original = canonical.read_text(encoding="utf-8")
+
+        artifacts = expected_artifacts_for_role(quest_dir, "plan_review", "arbiter")
+        prepare_artifact_files(artifacts)
+
+        assert canonical.read_text(encoding="utf-8") == original
+        assert (quest_dir / "phase_01_plan" / "review_findings.json.next").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -150,15 +150,29 @@ class TestPrepareArtifactFiles:
     def test_arbiter_prepare_touches_next_file_not_canonical_findings(self, tmp_path: Path):
         quest_dir = tmp_path / "quest"
         canonical = quest_dir / "phase_01_plan" / "review_findings.json"
+        verdict = quest_dir / "phase_01_plan" / "arbiter_verdict.md"
         canonical.parent.mkdir(parents=True, exist_ok=True)
         canonical.write_text('[{"finding_id":"stable"}]\n', encoding="utf-8")
+        verdict.write_text("APPROVED\n", encoding="utf-8")
         original = canonical.read_text(encoding="utf-8")
+        original_verdict = verdict.read_text(encoding="utf-8")
 
         artifacts = expected_artifacts_for_role(quest_dir, "plan_review", "arbiter")
         prepare_artifact_files(artifacts)
 
         assert canonical.read_text(encoding="utf-8") == original
+        assert verdict.read_text(encoding="utf-8") == original_verdict
         assert (quest_dir / "phase_01_plan" / "review_findings.json.next").exists()
+
+    def test_arbiter_prepare_creates_missing_verdict(self, tmp_path: Path):
+        quest_dir = tmp_path / "quest"
+        verdict = quest_dir / "phase_01_plan" / "arbiter_verdict.md"
+
+        artifacts = expected_artifacts_for_role(quest_dir, "plan_review", "arbiter")
+        prepare_artifact_files(artifacts)
+
+        assert verdict.exists()
+        assert verdict.read_text(encoding="utf-8") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_check_quest_checksum_drift.py
+++ b/tests/unit/test_check_quest_checksum_drift.py
@@ -1,0 +1,67 @@
+"""Tests for the repo-local Quest checksum drift helper."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_module():
+    module_path = _repo_root() / "scripts" / "check_quest_checksum_drift.py"
+    spec = importlib.util.spec_from_file_location("check_quest_checksum_drift", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_reports_no_drift_for_matching_repo_file(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "tracked.txt"
+    target.write_text("ok\n", encoding="utf-8")
+    checksum = hashlib.sha256(target.read_bytes()).hexdigest()
+    (repo / ".quest-checksums").write_text(
+        f"{checksum}  tracked.txt\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sys, "argv", ["check_quest_checksum_drift.py", str(repo)])
+
+    assert module.main() == 0
+    assert capsys.readouterr().out.strip() == "OK: no checksum drift"
+
+
+def test_main_reports_unsafe_path_without_hashing_outside_repo(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n", encoding="utf-8")
+    (repo / ".quest-checksums").write_text(
+        "0" * 64 + "  ../outside.txt\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sys, "argv", ["check_quest_checksum_drift.py", str(repo)])
+
+    assert module.main() == 1
+    captured = capsys.readouterr().out
+    assert "DRIFT" in captured
+    assert "../outside.txt\tunsafe path" in captured
+    assert hashlib.sha256(outside.read_bytes()).hexdigest() not in captured

--- a/tests/unit/test_codex_review.py
+++ b/tests/unit/test_codex_review.py
@@ -701,6 +701,42 @@ class TestFetchDeepCiFiles:
         assert snapshots[1]["mode"] == "skipped"
         assert "total-cap-exhausted" in rendered
 
+    def test_render_deep_ci_context_surfaces_partial_total_cap_omitted_windows(self):
+        # Manually construct a chunked snapshot with the total-cap omission
+        # metadata populated. The renderer must surface those dropped windows
+        # in the output so reviewers see them as explicitly omitted rather
+        # than silently absent.
+        snapshots = [
+            {
+                "path": "src/big.py",
+                "mode": "chunked",
+                "content": "",
+                "chunks": [
+                    {
+                        "start_line": 10,
+                        "end_line": 12,
+                        "changed_lines": [11],
+                        "changed_lines_included": [11],
+                        "changed_lines_omitted": [],
+                        "content": "row1\nrow2\nrow3",
+                    }
+                ],
+                "char_count": 9999,
+                "line_count": 500,
+                "changed_line_ranges": [(11, 11), (200, 205), (450, 452)],
+                "total_cap_omitted_windows": [
+                    {"start_line": 180, "end_line": 220},
+                    {"start_line": 430, "end_line": 470},
+                ],
+                "omitted": False,
+                "reason": "full file exceeded cap",
+            }
+        ]
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/big.py"])
+        assert "Total-cap omitted: 2 changed-line window(s)" in rendered
+        assert "180-220" in rendered
+        assert "430-470" in rendered
+
     def test_render_deep_ci_context_uses_longer_fence_for_chunk_backticks(self):
         snapshots = [
             {

--- a/tests/unit/test_codex_review.py
+++ b/tests/unit/test_codex_review.py
@@ -314,7 +314,7 @@ class TestBuildDedupState:
 
 
 # ---------------------------------------------------------------------------
-# Deep CI filtering and selection
+# Deep CI filtering, diff parsing, and chunking
 # ---------------------------------------------------------------------------
 
 class TestDeepCiCandidateFiltering:
@@ -338,12 +338,12 @@ class TestDeepCiCandidateFiltering:
         assert not codex_review.is_deep_ci_candidate("src/app.min.js")
         assert not codex_review.is_deep_ci_candidate("src/runtime.lock.ts")
 
-    def test_deep_ci_candidate_rejects_deleted_and_large_files(self):
+    def test_deep_ci_candidate_rejects_deleted_and_noisy_change_files(self):
         assert not codex_review.is_deep_ci_candidate(
             "src/deleted.py",
             {"path": "src/deleted.py", "status": "removed"},
         )
-        assert not codex_review.is_deep_ci_candidate(
+        assert codex_review.is_deep_ci_candidate(
             "src/large.py",
             {"path": "src/large.py", "size": codex_review.DEEP_CI_MAX_FILE_CHARS + 1},
         )
@@ -395,98 +395,285 @@ class TestSelectDeepCiFiles:
 
 
 # ---------------------------------------------------------------------------
-# Deep CI fetching and rendering
+# Deep CI diff parsing and window helpers
 # ---------------------------------------------------------------------------
 
-class TestFetchDeepCiFiles:
-    def test_fetch_deep_ci_files_renders_full_file_snapshots(self, monkeypatch):
-        calls = []
+class TestDeepCiDiffParsing:
+    def test_parse_changed_line_ranges_records_right_side_additions(self):
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -10,2 +10,3 @@\n"
+            " context\n"
+            "+added one\n"
+            "+added two\n"
+            " tail\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {"src/app.py": [(11, 12)]}
 
+    def test_parse_changed_line_ranges_ignores_deletions_and_metadata(self):
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n"
+            "--- a/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -2,2 +2,2 @@\n"
+            "-old\n"
+            "+new\n"
+            " context\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {"src/app.py": [(2, 2)]}
+
+    def test_parse_changed_line_ranges_handles_multiple_hunks_and_files(self):
+        diff = (
+            "diff --git a/src/a.py b/src/a.py\n"
+            "+++ b/src/a.py\n"
+            "@@ -1,1 +1,1 @@\n"
+            "+a\n"
+            "@@ -10,1 +10,2 @@\n"
+            "+b\n"
+            "+c\n"
+            "diff --git a/src/b.py b/src/b.py\n"
+            "+++ b/src/b.py\n"
+            "@@ -4,1 +4,1 @@\n"
+            "+d\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {
+            "src/a.py": [(1, 1), (10, 11)],
+            "src/b.py": [(4, 4)],
+        }
+
+    def test_parse_changed_line_ranges_handles_new_file_from_dev_null(self):
+        diff = (
+            "diff --git a/dev/null b/src/new.py\n"
+            "--- /dev/null\n"
+            "+++ b/src/new.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+hello\n"
+            "+world\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {"src/new.py": [(1, 2)]}
+
+    def test_parse_changed_line_ranges_handles_paths_with_spaces_and_rename_new_paths(self):
+        diff = (
+            "diff --git a/src/old name.py b/src/new name.py\n"
+            "similarity index 90%\n"
+            "rename from src/old name.py\n"
+            "rename to src/new name.py\n"
+            "--- a/src/old name.py\n"
+            "+++ b/src/new name.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            "+x\n"
+            "+y\n"
+        )
+        parsed = codex_review.parse_changed_line_ranges(diff)
+        assert "src/new name.py" in parsed
+        assert "src/old name.py" not in parsed
+        assert parsed["src/new name.py"] == [(1, 2)]
+
+    def test_parse_changed_line_ranges_handles_omitted_count_hunk_header(self):
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -5 +5 @@\n"
+            "+replacement\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {"src/app.py": [(5, 5)]}
+
+    def test_parse_changed_line_ranges_does_not_treat_in_hunk_plus_plus_space_as_header(self):
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n"
+            "--- a/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -5,0 +6,2 @@\n"
+            "+++ suspicious\n"
+            "+normal\n"
+        )
+        assert codex_review.parse_changed_line_ranges(diff) == {"src/app.py": [(6, 7)]}
+
+
+class TestDeepCiChunkHelpers:
+    def test_build_line_windows_expands_merges_and_bounds_to_file(self):
+        windows = codex_review.build_line_windows(
+            [(3, 3), (5, 5), (40, 40)],
+            line_count=45,
+            context_lines=2,
+            max_chunks=4,
+        )
+        assert windows[0]["start_line"] == 1
+        assert windows[0]["end_line"] == 7
+        assert windows[1]["start_line"] == 38
+        assert windows[1]["end_line"] == 42
+
+    def test_build_line_windows_caps_deterministically_and_restores_file_order(self):
+        windows = codex_review.build_line_windows(
+            [(1, 1), (20, 22), (40, 44)],
+            line_count=100,
+            context_lines=0,
+            max_chunks=2,
+        )
+        # keep ranges with highest changed-line counts, rendered in file order
+        assert [(w["start_line"], w["end_line"]) for w in windows] == [(20, 22), (40, 44)]
+
+    def test_extract_line_chunk_and_fit_chunk_to_char_cap_respect_line_boundaries(self):
+        content = "line1\nline2\nline3\nline4\nline5\n"
+        chunk = codex_review.extract_line_chunk(content, 2, 4)
+        assert chunk == "line2\nline3\nline4"
+
+        fitted = codex_review.fit_chunk_to_char_cap(
+            {"start_line": 2, "end_line": 4, "content": chunk},
+            [2, 3, 4],
+            cap=11,
+        )
+        assert fitted["start_line"] >= 2
+        assert fitted["end_line"] <= 4
+        assert len(fitted["content"]) <= 11
+        assert set(fitted["changed_lines_included"]).issubset({2, 3, 4})
+
+
+class TestFetchDeepCiFiles:
+    def test_fetch_deep_ci_files_keeps_small_file_as_full_snapshot(self, monkeypatch):
         def fake_run(cmd, check, capture_output, text):
-            calls.append(cmd)
             return subprocess.CompletedProcess(cmd, 0, stdout="print('ok')\n", stderr="")
 
         monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
 
         snapshots = codex_review.fetch_deep_ci_files("owner/repo", "abc123", ["src/app.py"])
+        assert snapshots[0]["mode"] == "full"
         rendered = codex_review.render_deep_ci_context(snapshots, ["src/app.py"])
-
-        assert calls[0][:4] == ["gh", "api", "-H", "Accept: application/vnd.github.raw"]
-        assert "repos/owner/repo/contents/src/app.py?ref=abc123" in calls[0]
-        assert "## src/app.py" in rendered
+        assert "Mode: full-file" in rendered
         assert "print('ok')" in rendered
-        assert "truncated" not in rendered
 
-    def test_render_deep_ci_context_uses_longer_fence_for_embedded_backticks(self):
-        snapshots = [
-            {
-                "path": "src/app.py",
-                "content": "def example():\n    return '''```payload```'''\n",
-                "omitted": False,
-                "reason": "",
-            }
-        ]
-
-        rendered = codex_review.render_deep_ci_context(snapshots, ["src/app.py"])
-
-        assert "````\ndef example():" in rendered
-        assert "```payload```" in rendered
-        assert rendered.rstrip().endswith("````")
-
-    def test_fetch_deep_ci_files_omits_large_content_with_note(self, monkeypatch):
+    def test_deep_ci_hard_cap_file_renders_mode_skipped_with_reason(self, monkeypatch):
         def fake_run(cmd, check, capture_output, text):
-            return subprocess.CompletedProcess(cmd, 0, stdout="x" * 11, stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="x" * 50, stderr="")
 
         monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
+        snapshots = codex_review.fetch_deep_ci_files(
+            "owner/repo",
+            "abc123",
+            ["src/huge.py"],
+            changed_line_ranges={"src/huge.py": [(1, 2)]},
+            max_fetch_chars=20,
+        )
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/huge.py"])
+        assert snapshots[0]["mode"] == "skipped"
+        assert "Mode: skipped" in rendered
+        assert "hard fetch cap of 20 chars" in rendered
 
+    def test_fetch_deep_ci_files_chunks_oversized_file_with_changed_ranges(self, monkeypatch):
+        content = "\n".join(f"line {i}" for i in range(1, 30)) + "\n"
+
+        def fake_run(cmd, check, capture_output, text):
+            return subprocess.CompletedProcess(cmd, 0, stdout=content, stderr="")
+
+        monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
         snapshots = codex_review.fetch_deep_ci_files(
             "owner/repo",
             "abc123",
             ["src/large.py"],
-            max_chars_per_file=10,
+            changed_line_ranges={"src/large.py": [(10, 10)]},
+            max_chars_per_file=20,
+            context_lines=1,
+            max_chunks_per_file=2,
+            max_chunk_chars=500,
         )
+        assert snapshots[0]["mode"] == "chunked"
         rendered = codex_review.render_deep_ci_context(snapshots, ["src/large.py"])
+        assert "Mode: chunked-large-file" in rendered
+        assert "Included chunks:" in rendered
 
-        assert snapshots[0]["omitted"] is True
-        assert "current file size exceeds 10 chars" in rendered
-        assert "xxxxxxxxxxx" not in rendered
-        assert "truncated" not in rendered
-
-    def test_fetch_deep_ci_files_marks_unavailable_without_crashing(self, monkeypatch):
+    def test_fetch_deep_ci_files_skips_oversized_file_without_changed_ranges(self, monkeypatch):
         def fake_run(cmd, check, capture_output, text):
-            raise subprocess.CalledProcessError(1, cmd, output="", stderr="not found")
+            return subprocess.CompletedProcess(cmd, 0, stdout=("line\n" * 30), stderr="")
 
         monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
+        snapshots = codex_review.fetch_deep_ci_files(
+            "owner/repo",
+            "abc123",
+            ["src/large.py"],
+            changed_line_ranges={},
+            max_chars_per_file=20,
+        )
+        assert snapshots[0]["mode"] == "skipped"
+        assert "no changed-line ranges" in snapshots[0]["reason"]
 
-        snapshots = codex_review.fetch_deep_ci_files("owner/repo", "abc123", ["src/missing.py"])
-        rendered = codex_review.render_deep_ci_context(snapshots, ["src/missing.py"])
+    def test_chunk_metadata_reports_included_and_omitted_changed_lines_under_cap_pressure(
+        self, monkeypatch
+    ):
+        content = "\n".join(f"{i}-" + ("x" * 20) for i in range(1, 40)) + "\n"
 
-        assert snapshots[0]["omitted"] is True
-        assert "Skipped Deep CI whole-file review for src/missing.py" in rendered
-        assert "unavailable: not found" in rendered
+        def fake_run(cmd, check, capture_output, text):
+            return subprocess.CompletedProcess(cmd, 0, stdout=content, stderr="")
 
-    def test_fetch_deep_ci_files_omits_when_total_cap_would_be_exceeded(self, monkeypatch):
-        contents = {"src/a.py": "aaaaaa", "src/b.py": "bbbbbb"}
+        monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
+        snapshots = codex_review.fetch_deep_ci_files(
+            "owner/repo",
+            "abc123",
+            ["src/large.py"],
+            changed_line_ranges={"src/large.py": [(10, 15)]},
+            max_chars_per_file=20,
+            context_lines=0,
+            max_chunk_chars=45,
+        )
+        chunk = snapshots[0]["chunks"][0]
+        assert chunk["changed_lines_omitted"]
+        assert chunk["changed_lines_included"]
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/large.py"])
+        assert "changed_lines_included:" in rendered
+        assert "changed_lines_omitted:" in rendered
+
+    def test_fetch_deep_ci_files_respects_total_cap_across_full_files_and_chunks(self, monkeypatch):
+        contents = {
+            "src/a.py": "aaaaaa",
+            "src/b.py": "\n".join(["line"] * 40) + "\n",
+        }
 
         def fake_run(cmd, check, capture_output, text):
             path_part = cmd[-1].split("/contents/", 1)[1].split("?ref=", 1)[0]
             return subprocess.CompletedProcess(cmd, 0, stdout=contents[path_part], stderr="")
 
         monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
-
         snapshots = codex_review.fetch_deep_ci_files(
             "owner/repo",
             "abc123",
             ["src/a.py", "src/b.py"],
-            max_total_chars=8,
+            changed_line_ranges={"src/b.py": [(10, 10)]},
+            max_chars_per_file=5,
+            max_total_chars=3,
+            context_lines=0,
+            max_chunk_chars=50,
         )
         rendered = codex_review.render_deep_ci_context(snapshots, ["src/a.py", "src/b.py"])
+        assert snapshots[0]["mode"] == "skipped"
+        assert snapshots[1]["mode"] == "skipped"
+        assert "total-cap-exhausted" in rendered
 
-        assert snapshots[0]["omitted"] is False
-        assert snapshots[1]["omitted"] is True
-        assert "aaaaaa" in rendered
-        assert "bbbbbb" not in rendered
-        assert "Deep CI total content cap exceeds 8 chars" in rendered
+    def test_render_deep_ci_context_uses_longer_fence_for_chunk_backticks(self):
+        snapshots = [
+            {
+                "path": "src/app.py",
+                "mode": "chunked",
+                "content": "",
+                "chunks": [
+                    {
+                        "start_line": 10,
+                        "end_line": 12,
+                        "changed_lines": [11],
+                        "changed_lines_included": [11],
+                        "changed_lines_omitted": [],
+                        "content": "return ```payload```",
+                    }
+                ],
+                "char_count": 100,
+                "line_count": 20,
+                "changed_line_ranges": [(11, 11)],
+                "omitted": False,
+                "reason": "full file exceeded 20 chars; only changed-line windows are included",
+            }
+        ]
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/app.py"])
+        assert "Mode: chunked-large-file" in rendered
+        assert "````\nreturn ```payload```\n````" in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +719,7 @@ class TestWorkflowContextContract:
             Path("/tmp/changed_files.txt"),
             Path("/tmp/pr_head_files.md"),
             Path("/tmp/deep_ci_files.md"),
+            Path("/tmp/pr.diff"),
         ]
         originals = {
             path: path.read_bytes() if path.exists() else None
@@ -548,8 +736,20 @@ class TestWorkflowContextContract:
 
         monkeypatch.setenv("REPO", "owner/repo")
         monkeypatch.setattr(codex_review, "fetch_head_files", fake_fetch_head_files)
-        monkeypatch.setattr(codex_review, "load_changed_file_metadata", lambda: [])
-        monkeypatch.setattr(codex_review, "fetch_deep_ci_files", lambda *args: [])
+        monkeypatch.setattr(
+            codex_review,
+            "load_changed_file_metadata",
+            lambda: [{"path": "src/app.py"}, {"path": "lib/space name.py"}],
+        )
+
+        def fake_fetch_deep_ci_files(repo, head_sha, selected_files, **kwargs):
+            captured["deep_ci_repo"] = repo
+            captured["deep_ci_head_sha"] = head_sha
+            captured["selected_files"] = selected_files
+            captured["changed_line_ranges"] = kwargs.get("changed_line_ranges")
+            return []
+
+        monkeypatch.setattr(codex_review, "fetch_deep_ci_files", fake_fetch_deep_ci_files)
 
         try:
             Path("/tmp/pr_head_sha.txt").write_text("abc123\n", encoding="utf-8")
@@ -557,14 +757,23 @@ class TestWorkflowContextContract:
                 "src/app.py\nlib/space name.py\n",
                 encoding="utf-8",
             )
+            Path("/tmp/pr.diff").write_text(
+                "diff --git a/src/app.py b/src/app.py\n"
+                "+++ b/src/app.py\n"
+                "@@ -1 +1 @@\n"
+                "+added\n",
+                encoding="utf-8",
+            )
 
             codex_review.gather_context()
 
-            assert captured == {
-                "repo": "owner/repo",
-                "head_sha": "abc123",
-                "changed_files": ["src/app.py", "lib/space name.py"],
-            }
+            assert captured["repo"] == "owner/repo"
+            assert captured["head_sha"] == "abc123"
+            assert captured["changed_files"] == ["src/app.py", "lib/space name.py"]
+            assert captured["deep_ci_repo"] == "owner/repo"
+            assert captured["deep_ci_head_sha"] == "abc123"
+            assert captured["selected_files"] == ["lib/space name.py", "src/app.py"]
+            assert captured["changed_line_ranges"] == {"src/app.py": [(1, 1)]}
         finally:
             for path, content in originals.items():
                 if content is None:
@@ -616,7 +825,7 @@ class TestBuildReviewPrompt:
         )
 
         assert "PLACEHOLDER_" not in prompt
-        assert "## Deep CI Whole-File Logic Pass" in prompt
+        assert "## Deep CI Whole-File / Chunked Logic Pass" in prompt
         assert "deep snapshot" in prompt
 
     def test_build_review_prompt_does_not_reprocess_inserted_placeholders(self):

--- a/tests/unit/test_codex_review.py
+++ b/tests/unit/test_codex_review.py
@@ -544,6 +544,8 @@ class TestFetchDeepCiFiles:
         assert "print('ok')" in rendered
 
     def test_deep_ci_hard_cap_file_renders_mode_skipped_with_reason(self, monkeypatch):
+        # Backstop path: metadata is unknown (no size field), so the gh api
+        # call runs and the post-fetch safeguard rejects the oversized body.
         def fake_run(cmd, check, capture_output, text):
             return subprocess.CompletedProcess(cmd, 0, stdout="x" * 50, stderr="")
 
@@ -559,6 +561,57 @@ class TestFetchDeepCiFiles:
         assert snapshots[0]["mode"] == "skipped"
         assert "Mode: skipped" in rendered
         assert "hard fetch cap of 20 chars" in rendered
+
+    def test_fetch_deep_ci_files_skips_pre_fetch_when_metadata_size_exceeds_hard_cap(
+        self, monkeypatch
+    ):
+        # Pre-fetch path: metadata reports size > cap, so the gh api call
+        # must NEVER run. The snapshot still renders as Mode: skipped with
+        # the same hard-cap reason string to preserve F1 visibility.
+        calls = []
+
+        def fake_run(cmd, check, capture_output, text):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="should-not-be-read", stderr="")
+
+        monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
+        snapshots = codex_review.fetch_deep_ci_files(
+            "owner/repo",
+            "abc123",
+            ["src/huge.py"],
+            changed_line_ranges={"src/huge.py": [(1, 2)]},
+            max_fetch_chars=20,
+            file_metadata=[{"path": "src/huge.py", "size": 500}],
+        )
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/huge.py"])
+
+        assert calls == []  # hard-cap candidate never reached gh api
+        assert len(snapshots) == 1
+        assert snapshots[0]["mode"] == "skipped"
+        assert "hard fetch cap of 20 chars" in snapshots[0]["reason"]
+        assert "Mode: skipped" in rendered
+        assert "hard fetch cap of 20 chars" in rendered
+
+    def test_fetch_deep_ci_files_still_fetches_when_metadata_size_under_cap(
+        self, monkeypatch
+    ):
+        # Metadata-under-cap path: fetch proceeds and small body is kept.
+        calls = []
+
+        def fake_run(cmd, check, capture_output, text):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="print('ok')\n", stderr="")
+
+        monkeypatch.setattr(codex_review.subprocess, "run", fake_run)
+        snapshots = codex_review.fetch_deep_ci_files(
+            "owner/repo",
+            "abc123",
+            ["src/small.py"],
+            file_metadata=[{"path": "src/small.py", "size": 10}],
+        )
+
+        assert len(calls) == 1
+        assert snapshots[0]["mode"] == "full"
 
     def test_fetch_deep_ci_files_chunks_oversized_file_with_changed_ranges(self, monkeypatch):
         content = "\n".join(f"line {i}" for i in range(1, 30)) + "\n"

--- a/tests/unit/test_codex_review.py
+++ b/tests/unit/test_codex_review.py
@@ -514,6 +514,22 @@ class TestDeepCiChunkHelpers:
         # keep ranges with highest changed-line counts, rendered in file order
         assert [(w["start_line"], w["end_line"]) for w in windows] == [(20, 22), (40, 44)]
 
+    def test_build_line_windows_can_report_chunk_cap_omissions(self):
+        plan = codex_review.build_line_windows(
+            [(1, 1), (20, 22), (40, 44)],
+            line_count=100,
+            context_lines=0,
+            max_chunks=2,
+            include_omitted=True,
+        )
+        assert [(w["start_line"], w["end_line"]) for w in plan["included"]] == [
+            (20, 22),
+            (40, 44),
+        ]
+        assert [(w["start_line"], w["end_line"]) for w in plan["omitted"]] == [
+            (1, 1)
+        ]
+
     def test_extract_line_chunk_and_fit_chunk_to_char_cap_respect_line_boundaries(self):
         content = "line1\nline2\nline3\nline4\nline5\n"
         chunk = codex_review.extract_line_chunk(content, 2, 4)
@@ -736,6 +752,36 @@ class TestFetchDeepCiFiles:
         assert "Total-cap omitted: 2 changed-line window(s)" in rendered
         assert "180-220" in rendered
         assert "430-470" in rendered
+
+    def test_render_deep_ci_context_surfaces_chunk_cap_omitted_windows(self):
+        snapshots = [
+            {
+                "path": "src/big.py",
+                "mode": "chunked",
+                "content": "",
+                "chunks": [
+                    {
+                        "start_line": 20,
+                        "end_line": 25,
+                        "changed_lines": [22],
+                        "changed_lines_included": [22],
+                        "changed_lines_omitted": [],
+                        "content": "row1\nrow2",
+                    }
+                ],
+                "char_count": 9999,
+                "line_count": 500,
+                "changed_line_ranges": [(10, 10), (22, 22), (300, 300)],
+                "chunk_cap_omitted_windows": [
+                    {"start_line": 300, "end_line": 305},
+                ],
+                "omitted": False,
+                "reason": "full file exceeded cap",
+            }
+        ]
+        rendered = codex_review.render_deep_ci_context(snapshots, ["src/big.py"])
+        assert "Chunk-cap omitted: 1 changed-line window(s)" in rendered
+        assert "300-305" in rendered
 
     def test_render_deep_ci_context_uses_longer_fence_for_chunk_backticks(self):
         snapshots = [

--- a/tests/unit/test_codex_skill_wrappers.py
+++ b/tests/unit/test_codex_skill_wrappers.py
@@ -15,25 +15,28 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def test_codex_wrapper_surface_includes_required_project_skills() -> None:
+def _wrapper_names() -> set[str]:
     wrappers_root = _repo_root() / ".agents" / "skills"
-    wrapper_names = {
+    return {
         path.name
         for path in wrappers_root.iterdir()
         if path.is_dir() and (path / "SKILL.md").exists()
     }
 
-    assert EXPECTED_QUEST_WRAPPERS <= wrapper_names
+
+def test_codex_wrapper_surface_includes_required_project_skills() -> None:
+    assert EXPECTED_QUEST_WRAPPERS <= _wrapper_names()
 
 
 def test_codex_wrappers_delegate_to_matching_project_skills() -> None:
     wrappers_root = _repo_root() / ".agents" / "skills"
 
-    for skill_name in EXPECTED_QUEST_WRAPPERS:
+    for skill_name in _wrapper_names():
         wrapper_path = wrappers_root / skill_name / "SKILL.md"
         content = wrapper_path.read_text(encoding="utf-8")
         assert f"name: {skill_name}" in content
         assert f"Read and follow the instructions in `.skills/{skill_name}/SKILL.md`." in content
+        assert (_repo_root() / ".skills" / skill_name / "SKILL.md").exists()
 
 
 def test_codex_wrapper_surface_intentionally_excludes_gpt() -> None:

--- a/tests/unit/test_quest_checks_cli.py
+++ b/tests/unit/test_quest_checks_cli.py
@@ -1,0 +1,68 @@
+"""Unit tests for the installed quest_checks CLI contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import runpy
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_cli_module():
+    module_path = _repo_root() / "scripts" / "quest_checks" / "cli.py"
+    spec = importlib.util.spec_from_file_location("quest_checks_cli", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_references_installed_commands_that_exist() -> None:
+    module = _load_cli_module()
+    missing_paths: list[str] = []
+
+    for _, command in module.COMMANDS:
+        for token in command[1:]:
+            if token.startswith(("scripts/", "tests/")) and not (_repo_root() / token).exists():
+                missing_paths.append(token)
+
+    assert missing_paths == []
+
+
+def test_cli_main_runs_all_installed_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_cli_module()
+    calls: list[tuple[list[str], Path, bool]] = []
+
+    def fake_run(command: list[str], cwd: Path, check: bool) -> SimpleNamespace:
+        calls.append((command, cwd, check))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert module.main() == 0
+    assert [command for _, command in module.COMMANDS] == [command for command, _, _ in calls]
+    assert all(cwd == module.REPO_ROOT and check is False for _, cwd, check in calls)
+
+
+def test_cli_entrypoint_executes_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    script_path = _repo_root() / "scripts" / "quest_checks" / "cli.py"
+    calls: list[tuple[list[str], Path, bool]] = []
+
+    def fake_run(command: list[str], cwd: Path, check: bool) -> SimpleNamespace:
+        calls.append((command, cwd, check))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(script_path), run_name="__main__")
+
+    assert exc_info.value.code == 0
+    assert [command for _, command in _load_cli_module().COMMANDS] == [command for command, _, _ in calls]

--- a/tests/unit/test_quest_complete.py
+++ b/tests/unit/test_quest_complete.py
@@ -3,7 +3,10 @@
 from datetime import date
 import json
 from pathlib import Path
+import sys
+from types import SimpleNamespace
 
+import quest_complete
 from quest_complete import build_journal_entry
 from quest_celebrate.quest_data import QuestData
 
@@ -205,3 +208,33 @@ def test_generate_journal_entry_includes_empty_carryover_status_when_absent():
     assert "## Carry-Over Findings" in entry
     assert "nothing was inherited from earlier quests" in entry
     assert "## Inherited Findings Used" not in entry
+
+
+def test_main_reports_invalid_date(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    (quest_dir / "state.json").write_text(
+        json.dumps({"status": "complete"}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(quest_complete, "load_quest_data", lambda _: SimpleNamespace())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "quest_complete.py",
+            "--quest-dir",
+            str(quest_dir),
+            "--date",
+            "2026-13-40",
+        ],
+    )
+
+    assert quest_complete.main() == 1
+    captured = capsys.readouterr()
+    assert "invalid date" in captured.err

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -1,0 +1,84 @@
+"""Source-only tests for the installed Quest manifest contract."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _manifest_entries() -> list[str]:
+    manifest = _repo_root() / ".quest-manifest"
+    entries: list[str] = []
+    for raw_line in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+        entries.append(line)
+    return entries
+
+
+def _validator_patterns() -> list[str]:
+    validator = _repo_root() / "scripts" / "quest_validate-manifest.sh"
+    patterns: list[str] = []
+    in_patterns = False
+    for raw_line in validator.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line == "EXPECTED_PATTERNS=(":
+            in_patterns = True
+            continue
+        if in_patterns and line == ")":
+            break
+        if in_patterns and line.startswith('"') and line.endswith('"'):
+            patterns.append(line.strip('"'))
+    return patterns
+
+
+def test_manifest_installs_shell_smoke_tests_not_source_unit_tests() -> None:
+    entries = set(_manifest_entries())
+
+    expected_installed_tests = {
+        "tests/integration/test-enforce-allowlist.sh",
+        "tests/test-quest-preflight.sh",
+        "tests/test-quest-runtime.sh",
+        "tests/test-validate-handoff-contracts.sh",
+        "tests/test-validate-quest-state.sh",
+    }
+    assert expected_installed_tests <= entries
+
+    excluded_source_tests = {
+        "tests/unit/test_allowlist_matcher.py",
+        "tests/unit/test_review_intelligence.py",
+        "tests/unit/test_codex_skill_wrappers.py",
+        "tests/unit/test_quest_checks_cli.py",
+        "tests/unit/test_quest_manifest.py",
+    }
+    assert excluded_source_tests.isdisjoint(entries)
+
+
+def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
+    patterns = _validator_patterns()
+    expected_paths = {
+        "scripts/quest_backfill_journal.py",
+        "scripts/quest_complete.py",
+        "scripts/quest_preflight.sh",
+        "scripts/quest_state.py",
+        "scripts/quest_celebrate/celebrate.py",
+        "scripts/quest_celebrate/quest-celebrate.sh",
+        "tests/integration/test-enforce-allowlist.sh",
+        "tests/test-quest-preflight.sh",
+        "tests/test-quest-runtime.sh",
+        "tests/test-validate-handoff-contracts.sh",
+        "tests/test-validate-quest-state.sh",
+    }
+
+    uncovered = sorted(
+        path
+        for path in expected_paths
+        if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+    )
+
+    assert uncovered == []

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -762,6 +762,39 @@ def test_validate_backlog_cli_expected_phase_accepts_matching_plan_backlog(
     assert payload["errors"] == []
 
 
+def test_validate_backlog_cli_handles_null_items_without_crashing(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    backlog_path = tmp_path / "bad_backlog.json"
+    backlog_path.write_text(
+        json.dumps({"phase": "plan", "items": None}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+            "--expected-phase",
+            "plan",
+            "--strict-plan-defaults",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["count"] == 0
+    assert any("must contain an 'items' list" in err for err in payload["errors"])
+
+
 def test_validate_backlog_cli_strict_plan_defaults_rejects_drifted_plan_backlog(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
+# Make scripts/quest_review_intelligence.py importable when pytest is not run
+# through the repo-level conftest fallback.
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import quest_review_intelligence
 from quest_runtime.pr_review_cycle import (
     normalize_pr_review_intake,
     retag_backlog_at_cap,
@@ -343,6 +353,88 @@ def test_append_deferred_findings_bootstraps_missing_file(tmp_path: Path) -> Non
         },
     )
     assert nested.exists()
+
+
+def test_append_deferred_findings_is_idempotent_per_quest_and_finding(tmp_path: Path) -> None:
+    backlog_path = tmp_path / "deferred_findings.jsonl"
+    finding = _finding(finding_id="F-idempotent")
+    lineage = {
+        "deferred_by_quest": "quest-idempotent",
+        "deferred_at": "2026-04-23T00:00:00Z",
+        "defer_reason": "loop cap reached",
+        "proposed_followup": "Retry once backlog publish succeeds.",
+    }
+
+    first = append_deferred_findings(backlog_path, [finding], lineage)
+    second = append_deferred_findings(backlog_path, [finding], lineage)
+
+    lines = backlog_path.read_text(encoding="utf-8").splitlines()
+    assert first == 1
+    assert second == 0
+    assert len(lines) == 1
+
+
+def test_classify_pr_stop_does_not_persist_retagged_backlog_when_append_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backlog_path = tmp_path / "review_backlog.json"
+    original = {
+        "version": 1,
+        "phase": "review",
+        "items": [
+            _finding(
+                finding_id="F-unsafe-ordering",
+                severity="medium",
+                confidence="medium",
+            )
+        ],
+    }
+    backlog_path.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        quest_review_intelligence,
+        "classify_pr_loop_stop",
+        lambda *args, **kwargs: {"stop": True, "retag_required": True, "outcome": "cap_enforced"},
+    )
+    monkeypatch.setattr(
+        quest_review_intelligence,
+        "retag_backlog_at_cap",
+        lambda payload: {
+            **payload,
+            "items": [
+                {
+                    **payload["items"][0],
+                    "decision": "defer",
+                }
+            ],
+        },
+    )
+
+    def _explode(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(quest_review_intelligence, "append_deferred_findings", _explode)
+
+    with pytest.raises(OSError, match="disk full"):
+        quest_review_intelligence._cmd_classify_pr_stop(
+            argparse.Namespace(
+                ci_state="failing",
+                actionable=1,
+                iteration=3,
+                cap=3,
+                backlog=str(backlog_path),
+                retag_output=None,
+                deferred_jsonl=None,
+                deferred_by_quest=None,
+                deferred_at=None,
+                defer_reason="Loop cap reached during PR review cycle.",
+                proposed_followup="Create a follow-up quest to resolve deferred review findings.",
+            )
+        )
+
+    persisted = json.loads(backlog_path.read_text(encoding="utf-8"))
+    assert persisted == original
 
 
 def test_scan_deferred_backlog_matches_exact_write_scope_path(tmp_path: Path) -> None:

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -509,3 +509,161 @@ def test_validate_backlog_cli_rejects_invalid_shape(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert payload["errors"]
+
+
+def test_validate_backlog_cli_expected_phase_rejects_review_phase_backlog(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    findings_path = tmp_path / "findings.json"
+    backlog_path = tmp_path / "backlog.json"
+    findings_path.write_text(
+        json.dumps([_finding()], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-backlog",
+            "--findings",
+            str(findings_path),
+            "--output",
+            str(backlog_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0
+    built = json.loads(backlog_path.read_text(encoding="utf-8"))
+    assert built["phase"] == "review"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+            "--expected-phase",
+            "plan",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert any(
+        "expected phase='plan'" in err and "phase='review'" in err
+        for err in payload["errors"]
+    )
+
+
+def test_validate_backlog_cli_expected_phase_accepts_matching_plan_backlog(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    findings_path = tmp_path / "findings.json"
+    backlog_path = tmp_path / "backlog.json"
+    findings_path.write_text(
+        json.dumps([_finding()], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-backlog",
+            "--phase",
+            "plan",
+            "--findings",
+            str(findings_path),
+            "--output",
+            str(backlog_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+            "--expected-phase",
+            "plan",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+
+
+def test_validate_backlog_cli_expected_phase_rejects_missing_phase_field(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    findings_path = tmp_path / "findings.json"
+    backlog_path = tmp_path / "backlog.json"
+    findings_path.write_text(
+        json.dumps([_finding()], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-backlog",
+            "--phase",
+            "plan",
+            "--findings",
+            str(findings_path),
+            "--output",
+            str(backlog_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0
+
+    # Simulate a legacy backlog that predates the phase field.
+    legacy = json.loads(backlog_path.read_text(encoding="utf-8"))
+    legacy.pop("phase", None)
+    backlog_path.write_text(json.dumps(legacy, indent=2) + "\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+            "--expected-phase",
+            "plan",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert any("expected phase='plan'" in err for err in payload["errors"])

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -12,6 +12,7 @@ from quest_runtime.pr_review_cycle import (
     retag_backlog_at_cap,
 )
 from quest_runtime.review_intelligence import (
+    ALLOWED_BACKLOG_PHASES,
     append_deferred_findings,
     build_review_backlog,
     merge_and_dedupe,
@@ -262,8 +263,9 @@ def test_validate_review_backlog_rejects_phase_outside_allowed_values() -> None:
 
     errors = validate_review_backlog(backlog)
 
+    expected_allowed = ", ".join(ALLOWED_BACKLOG_PHASES)
     assert any(
-        "'phase' must be one of 'plan' or 'review'" in error for error in errors
+        f"'phase' must be one of {expected_allowed}" in error for error in errors
     ), f"expected an invalid-phase error, got: {errors}"
 
 

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -19,6 +19,7 @@ from quest_runtime.review_intelligence import (
     select_decision,
     synthesize_findings_from_review_markdown,
     synthesize_plan_review_findings,
+    validate_review_backlog,
     validate_findings,
 )
 
@@ -158,9 +159,82 @@ def test_build_review_backlog_merges_dedupes_and_decides() -> None:
     ]
     backlog = build_review_backlog(findings, at_loop_cap=False)
     assert backlog["version"] == 1
+    assert backlog["phase"] == "review"
     assert len(backlog["items"]) == 1
     assert backlog["items"][0]["decision"] == "fix_now"
     assert backlog["counts"]["fix_now"] == 1
+
+
+def test_build_backlog_plan_phase_defaults_to_fix_now_builder_and_deterministic_batch_slug() -> None:
+    finding = _finding(
+        finding_id="PLAN-1",
+        source="arbiter",
+        kind="edge-case",
+        severity="low",
+        confidence="medium",
+        path="scripts/quest_runtime/review_intelligence.py",
+        write_scope=[
+            "tests/unit/test_review_intelligence.py",
+            "scripts/quest_runtime/review_intelligence.py",
+        ],
+    )
+
+    backlog = build_review_backlog([finding], at_loop_cap=False, phase="plan")
+
+    assert backlog["phase"] == "plan"
+    assert backlog["counts"]["fix_now"] == 1
+    item = backlog["items"][0]
+    assert item["decision"] == "fix_now"
+    assert item["owner"] == "builder"
+    assert item["batch"] == "edge-case-scripts"
+    assert item["needs_validation"] == ["unit_test", "typecheck", "lint"]
+
+
+def test_build_backlog_preserves_review_phase_policy_for_code_review_findings() -> None:
+    finding = _finding(
+        finding_id="REV-1",
+        severity="medium",
+        confidence="medium",
+        evidence=["a", "b"],
+    )
+
+    backlog = build_review_backlog([finding], at_loop_cap=False, phase="review")
+
+    assert backlog["phase"] == "review"
+    item = backlog["items"][0]
+    assert item["decision"] == "verify_first"
+    assert item["owner"] == "scripts"
+    assert item["batch"] == "scripts/example.py"
+
+
+def test_build_backlog_plan_phase_uses_root_batch_for_root_level_paths() -> None:
+    finding = _finding(
+        finding_id="PLAN-ROOT-1",
+        source="arbiter",
+        kind="edge-case",
+        severity="low",
+        confidence="high",
+        path="README.md",
+        write_scope=["README.md"],
+    )
+
+    backlog = build_review_backlog([finding], at_loop_cap=False, phase="plan")
+
+    assert backlog["phase"] == "plan"
+    item = backlog["items"][0]
+    assert item["batch"] == "edge-case-root"
+
+
+def test_validate_review_backlog_rejects_missing_decision_fields() -> None:
+    backlog = {
+        "version": 1,
+        "generated_at": "2026-04-22T00:00:00Z",
+        "items": [_finding()],
+    }
+
+    errors = validate_review_backlog(backlog)
+
+    assert any("missing required field 'decision'" in error for error in errors)
 
 
 def test_append_deferred_findings_writes_one_json_object_per_line(tmp_path: Path) -> None:
@@ -363,3 +437,75 @@ def test_scan_backlog_cli_accepts_empty_paths(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["count"] == 0
+
+
+def test_build_backlog_cli_plan_phase_uses_builder_defaults(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    findings_path = tmp_path / "findings.json"
+    output_path = tmp_path / "backlog.json"
+    findings_path.write_text(
+        json.dumps(
+            [
+                _finding(
+                    finding_id="CLI-PLAN-1",
+                    kind="edge-case",
+                    path="scripts/demo.py",
+                    write_scope=["scripts/demo.py"],
+                )
+            ],
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-backlog",
+            "--phase",
+            "plan",
+            "--findings",
+            str(findings_path),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    backlog = json.loads(output_path.read_text(encoding="utf-8"))
+    assert backlog["phase"] == "plan"
+    assert backlog["items"][0]["decision"] == "fix_now"
+    assert backlog["items"][0]["owner"] == "builder"
+    assert backlog["items"][0]["batch"] == "edge-case-scripts"
+
+
+def test_validate_backlog_cli_rejects_invalid_shape(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    backlog_path = tmp_path / "bad_backlog.json"
+    backlog_path.write_text(
+        json.dumps({"items": [{"finding_id": "bad"}]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["errors"]

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -20,6 +20,7 @@ from quest_runtime.review_intelligence import (
     select_decision,
     synthesize_findings_from_review_markdown,
     synthesize_plan_review_findings,
+    validate_plan_phase_defaults,
     validate_review_backlog,
     validate_findings,
 )
@@ -189,6 +190,27 @@ def test_build_backlog_plan_phase_defaults_to_fix_now_builder_and_deterministic_
     assert item["owner"] == "builder"
     assert item["batch"] == "edge-case-scripts"
     assert item["needs_validation"] == ["unit_test", "typecheck", "lint"]
+
+
+def test_validate_plan_phase_defaults_rejects_review_style_semantics() -> None:
+    finding = _finding(
+        finding_id="PLAN-DRIFT-1",
+        source="arbiter",
+        kind="edge-case",
+        path="scripts/quest_runtime/review_intelligence.py",
+        write_scope=["scripts/quest_runtime/review_intelligence.py"],
+    )
+    backlog = build_review_backlog([finding], at_loop_cap=False, phase="plan")
+    item = backlog["items"][0]
+    item["decision"] = "verify_first"
+    item["owner"] = "scripts"
+    item["batch"] = "scripts/quest_runtime/review_intelligence.py"
+
+    errors = validate_plan_phase_defaults(backlog)
+
+    assert any("field 'decision' must be 'fix_now'" in error for error in errors)
+    assert any("field 'owner' must be 'builder'" in error for error in errors)
+    assert any("field 'batch' must be 'edge-case-scripts'" in error for error in errors)
 
 
 def test_build_backlog_preserves_review_phase_policy_for_code_review_findings() -> None:
@@ -581,6 +603,7 @@ def test_validate_backlog_cli_expected_phase_rejects_review_phase_backlog(
             str(backlog_path),
             "--expected-phase",
             "plan",
+            "--strict-plan-defaults",
         ],
         capture_output=True,
         text=True,
@@ -634,6 +657,7 @@ def test_validate_backlog_cli_expected_phase_accepts_matching_plan_backlog(
             str(backlog_path),
             "--expected-phase",
             "plan",
+            "--strict-plan-defaults",
         ],
         capture_output=True,
         text=True,
@@ -644,6 +668,72 @@ def test_validate_backlog_cli_expected_phase_accepts_matching_plan_backlog(
     payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["errors"] == []
+
+
+def test_validate_backlog_cli_strict_plan_defaults_rejects_drifted_plan_backlog(
+    tmp_path: Path,
+) -> None:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "quest_review_intelligence.py"
+    findings_path = tmp_path / "findings.json"
+    backlog_path = tmp_path / "backlog.json"
+    findings_path.write_text(
+        json.dumps([_finding(kind="edge-case")], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    build = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "build-backlog",
+            "--phase",
+            "plan",
+            "--findings",
+            str(findings_path),
+            "--output",
+            str(backlog_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0
+    drifted = json.loads(backlog_path.read_text(encoding="utf-8"))
+    drifted["items"][0]["decision"] = "verify_first"
+    drifted["items"][0]["owner"] = "scripts"
+    drifted["items"][0]["batch"] = "scripts/example.py"
+    backlog_path.write_text(
+        json.dumps(drifted, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "validate-backlog",
+            "--input",
+            str(backlog_path),
+            "--expected-phase",
+            "plan",
+            "--strict-plan-defaults",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert any(
+        "field 'decision' must be 'fix_now'" in err for err in payload["errors"]
+    )
+    assert any("field 'owner' must be 'builder'" in err for err in payload["errors"])
+    assert any(
+        "field 'batch' must be 'edge-case-scripts'" in err
+        for err in payload["errors"]
+    )
 
 
 def test_validate_backlog_cli_expected_phase_rejects_missing_phase_field(

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -229,12 +229,42 @@ def test_validate_review_backlog_rejects_missing_decision_fields() -> None:
     backlog = {
         "version": 1,
         "generated_at": "2026-04-22T00:00:00Z",
+        "phase": "review",
         "items": [_finding()],
     }
 
     errors = validate_review_backlog(backlog)
 
     assert any("missing required field 'decision'" in error for error in errors)
+
+
+def test_validate_review_backlog_rejects_missing_phase_field() -> None:
+    backlog = {
+        "version": 1,
+        "generated_at": "2026-04-22T00:00:00Z",
+        "items": [],
+    }
+
+    errors = validate_review_backlog(backlog)
+
+    assert any(
+        "'phase'" in error and "must include" in error for error in errors
+    ), f"expected a missing-phase error, got: {errors}"
+
+
+def test_validate_review_backlog_rejects_phase_outside_allowed_values() -> None:
+    backlog = {
+        "version": 1,
+        "generated_at": "2026-04-22T00:00:00Z",
+        "phase": "garbage",
+        "items": [],
+    }
+
+    errors = validate_review_backlog(backlog)
+
+    assert any(
+        "'phase' must be one of 'plan' or 'review'" in error for error in errors
+    ), f"expected an invalid-phase error, got: {errors}"
 
 
 def test_append_deferred_findings_writes_one_json_object_per_line(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds Deep CI oversized-file chunk fallback and hardens the plan-phase arbiter backlog contract against schema drift so canonical review artifacts are validated and atomically published by the orchestrator, not hand-written by a model.
- Track A: selected files larger than `DEEP_CI_MAX_FILE_CHARS` now render deterministic changed-line context chunks with explicit `Mode:` metadata instead of being silently skipped.
- Track B: arbiter emits only `arbiter_verdict.md` + canonical `review_findings.json`; orchestrator validates findings, builds backlog, and atomically publishes from `.next` scratch files; retries arbiter exactly once on validator failure.

## Changes

- **Deep CI (.github/)**:
  - New constants in `.github/scripts/codex_review.py`: `DEEP_CI_CHUNK_CONTEXT_LINES=100`, `DEEP_CI_MAX_CHUNKS_PER_FILE=4`, `DEEP_CI_MAX_CHUNK_CHARS=12000`, `DEEP_CI_MAX_FETCH_CHARS=200000`.
  - New helpers: `parse_changed_line_ranges`, `build_line_windows`, `extract_line_chunk`, `fit_chunk_to_char_cap`.
  - `fetch_deep_ci_files()` threads parsed diff ranges from `/tmp/pr.diff`; `render_deep_ci_context()` emits `Mode: full-file | chunked-large-file | skipped` with reasons (`hard-cap`, `no-range`, `total-cap-exhausted`).
  - Chunked rendering reports `changed_lines_included` vs `changed_lines_omitted` under per-chunk cap pressure.
  - Parser handles paths with spaces, rename/new-path diffs, omitted-count hunk headers (`@@ -a +b @@`), and no longer misclassifies in-hunk `+++ ` added-line content as a file header.
  - Prompt text in `.github/codex-review-prompt.md` distinguishes full vs chunked partial context and preserves the RIGHT-side-only Deep CI findings constraint.

- **Arbiter contract (.skills/quest/)**:
  - `.skills/quest/agents/arbiter.md`: drops backlog authorship from the output contract; inlines `REQUIRED_FINDING_FIELDS`, allowed `severity`/`confidence` enums, and a minimal valid finding example.
  - `.skills/quest/delegation/workflow.md` Step 3 (Invoke Arbiter): clean stale `.next`, run `validate-findings`, retry arbiter once on failure, run `build-backlog --phase plan`, run `validate-backlog`, atomic `os.replace` publish, stop route on any failure, iterate/`solo`/stale-scratch handling, rollout-ordering constraint.

- **Orchestration (scripts/)**:
  - `scripts/quest_review_intelligence.py`: `build-backlog --phase {plan,review}`; new `validate-backlog` CLI; plan-phase defaults (`decision=fix_now`, `owner=builder`, `batch=<kind>-<path_group>`).
  - `scripts/quest_runtime/review_intelligence.py`: `_path_group_from_finding` uses first directory segment with `root` fallback; decoupled plan-phase vs review-phase decision policies; runtime-exposed `validate_review_backlog`.
  - `scripts/quest_runtime/artifacts.py`: arbiter `ROLE_ARTIFACTS` retargeted to `review_findings.json.next` so canonical findings are never zeroed by pre-run truncation.
  - `scripts/quest_claude_runner.py`: opt-in JSONL telemetry seam gated by `QUEST_RUNNER_TELEMETRY_LOG`; emits `attempt_start` / `attempt_end` events on every invocation; zero production overhead when unset.
  - `scripts/quest_validate-quest-state.sh`: accepts `--quest-dir`/`--target` flags and supports checkpoint re-validation so the explicit validator command works after the quest has advanced phases.

- **Tests**:
  - `tests/unit/test_codex_review.py`: new coverage for F1 hard-cap `Mode: skipped`, F2 chunk-metadata honesty under cap, F3 path-with-spaces / rename / new-path diffs, F4 omitted-count hunk header, in-hunk `+++ ` content, total-cap-exhausted render, and unchanged full-file behavior.
  - `tests/unit/test_review_intelligence.py`: plan-phase defaults, root-batch fallback, review-phase policy preservation.
  - `tests/unit/test_artifacts.py`: arbiter findings `.next` retarget.
  - `tests/test-quest-runtime.sh`: helper-level retry harness plus runner-path test that invokes `scripts/quest_claude_runner.py` with a fake bridge, parses `QUEST_RUNNER_TELEMETRY_LOG`, and asserts `attempts==2`, `retries==1`, no `transition` event before `publish`, and canonical `(mtime_ns, inode, size, sha256)` snapshots unchanged until atomic publish.

## Validation

- [x] **Unit tests — Deep CI**: Action: `python3 -m pytest tests/unit/test_codex_review.py -x`. Expected: 70 passed, including `test_deep_ci_hard_cap_file_renders_mode_skipped_with_reason`, `test_chunk_metadata_reports_included_and_omitted_changed_lines_under_cap_pressure`, `test_parse_changed_line_ranges_handles_paths_with_spaces_and_rename_new_paths`, `test_parse_changed_line_ranges_handles_omitted_count_hunk_header`, and `test_parse_changed_line_ranges_does_not_treat_in_hunk_plus_plus_space_as_header`.

- [x] **Unit tests — review intelligence**: Action: `python3 -m pytest tests/unit/test_review_intelligence.py -x`. Expected: 27 passed, including `test_build_backlog_plan_phase_defaults_to_fix_now_builder_and_deterministic_batch_slug`, `test_build_backlog_plan_phase_uses_root_batch_for_root_level_paths`, and `test_build_backlog_preserves_review_phase_policy_for_code_review_findings`.

- [x] **Full Python suite**: Action: `python3 -m pytest tests/ -x`. Expected: 445 passed.

- [x] **Quest runtime harness**: Action: `bash tests/test-quest-runtime.sh`. Expected: 26 passed / 0 failed. Both `test_plan_review_retry_harness_preserves_canonical_artifacts_until_publish` (helper-level) and `test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish` (runner-path with stat-snapshot invariants) pass.

- [x] **Validate-quest-state harness**: Action: `bash tests/test-validate-quest-state.sh`. Expected: 47 passed / 0 failed. New `--quest-dir/--target` flag parsing and plan-phase checkpoint re-validation exercised.

- [ ] **Walkthrough — exercise the arbiter retry contract manually**: Prerequisites: working tree on this branch, Python 3 available. Action: read `.skills/quest/delegation/workflow.md` around "Invoke Arbiter" section and trace through the validate → retry → build-backlog → atomic publish flow; then inspect `scripts/quest_runtime/artifacts.py` to confirm arbiter's findings target is `review_findings.json.next`. Expected: single validator retry cap is documented; stop route on failure does not call `quest_state.py --transition plan_reviewed`; canonical `review_findings.json` / `review_backlog.json` are only written by `os.replace` from `.next`.

Watch for: the `QUEST_RUNNER_TELEMETRY_LOG` seam is opt-in; if an unrelated test ever sets this env var, runner telemetry will append there.

## Notes

- Rollout ordering inside this PR follows the `arb-it2-b4` constraint: workflow/helper/runtime edits land before the arbiter contract trim in `arbiter.md`, so no intermediate state breaks the `plan_reviewed` transition. All changes ship in one commit so this is a deploy-ordering invariant for reviewers to validate, not a merge-ordering one.
- The builder also extended `scripts/quest_validate-quest-state.sh` with `--quest-dir`/`--target` flags. The positional form used by existing callers still works; `tests/test-validate-quest-state.sh` covers both.
- Two fix iterations were needed: iteration 1 resolved a parser `+++ ` edge case and a batch-slug root-fallback mismatch; iteration 2 strengthened the B5 runner-path test to assert transition ordering from runtime telemetry and canonical immutability from `(mtime_ns, inode, size, sha256)` snapshots rather than from a local counter and content-equality.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>