### PR TITLE
Add PreToolUse branch/directory hook for Claude and Codex

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '📍 Branch:' $(git branch --show-current 2>/dev/null || echo 'no git') '| Dir:' $(pwd)"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '📍 Branch:' $(git branch --show-current 2>/dev/null || echo 'no git') '| Dir:' $(pwd)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md
+++ b/ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md
@@ -1,0 +1,61 @@
+---
+title: PreToolUse Branch/Directory Verification Hook
+purpose: Add a safe, additive hook pattern that surfaces branch and directory context before edits.
+audience:
+  - quest-developers
+  - quest-users
+scope: Hook-level observability guardrails for Edit/Write actions.
+status: in-progress
+owner: kjell
+---
+
+## Problem
+The evaluation identifies wrong-location edits as the top friction pattern (`Wrong Approach` = 55), with repeated incidents where changes landed in the wrong branch, wrong directory, or wrong nested Quest path. The report explicitly calls out that Codex sub-agents wrote to incorrect directories and forced recovery cycles.
+
+## Proposal
+Use the exact hook command from the evaluation before `Edit|Write` tool calls so branch/directory context is always visible:
+
+```json
+{
+  "matcher": "Edit|Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "echo '📍 Branch:' $(git branch --show-current) '| Dir:' $(pwd)"
+    }
+  ]
+}
+```
+
+Quest-specific adaptation: merge this additively into existing hooks and add non-git fallback behavior for outside-in runs where repository VCS is unavailable.
+
+## Dual-Mode Sanity Check
+### Inside-repo use (Quest developed here)
+Inside this repo, branch and path are almost always available; printing both before writes directly targets the most frequent error class with minimal behavior change.
+
+### Outside-in use (Quest invoked from another repo)
+Outside-in sessions can run with `vcs_available == false` in `.skills/quest/delegation/workflow.md`, so `git branch --show-current` may fail. The hook should degrade safely (for example, `git branch --show-current 2>/dev/null || echo 'no git'`) while still printing `pwd`.
+
+### Conflicts and Required Adaptations
+`.claude/settings.json` already has `SessionStart` and a `PostToolUse` `Write|Edit` audit hook. This proposal must be an additive merge, not a replacement, to avoid stomping existing audit behavior.
+
+## Actionable Steps
+1. Inspect current hooks with `jq '.hooks' .claude/settings.json`.
+2. Add a `PreToolUse` entry for `Edit|Write` containing the evaluation command.
+3. Adapt the command to tolerate non-git workspaces using `2>/dev/null` fallback.
+4. Validate in two contexts: a git repo and a temporary non-git directory.
+5. Document the hook intent in `AGENTS.md` or a canonical policy pointer file so the rule is discoverable.
+
+## Cross-References
+- `ideas/2026-04-15-claude-rule-confirm-pwd-branch-before-edits.md`
+- `ideas/2026-04-15-subagent-path-constraints-hardening.md`
+- `ideas/2026-04-13-instruction-architecture.md`
+- `ideas/quest-policy-canonicalization-and-enforcement-roadmap.md`
+
+## Risks / Non-Goals
+- Non-goal: this does not guarantee correctness; it only improves context visibility.
+- Risk: noisy output can be ignored if overused, so the message should stay short and consistent.
+- Risk: overwriting `.claude/settings.json` hooks would regress existing audit logging.
+
+## Success Signal
+During edits, every `Edit|Write` action logs branch+directory context (or explicit `no git` fallback), and wrong-directory edits decrease in subsequent Quest sessions.


### PR DESCRIPTION
## Summary
Adds a `PreToolUse` hook that prints the current git branch and working directory before every file-edit tool call, giving both Claude Code and Codex visible context that targets the top friction pattern from recent evaluation — wrong-location edits (wrong branch, directory, or repo).

## Changes
- **Hooks**:
  - `.claude/settings.json`: new `PreToolUse` entry matching `Edit|Write`. Additive merge alongside existing `SessionStart` and `PostToolUse` hooks.
  - `.codex/hooks.json`: new file, `PreToolUse` entry matching `apply_patch` (Codex's file-edit tool).
- **Both hooks** run:
  `echo '📍 Branch:' $(git branch --show-current 2>/dev/null || echo 'no git') '| Dir:' $(pwd)`
  Degrades safely in non-git contexts (prints `no git` + `pwd`).
- **Ideas**:
  - `ideas/2026-04-15-pretooluse-branch-dir-verification-hook.md`: cherry-picked from `quest/claude-insights-ideas` and marked `status: in-progress`.

## Validation
- [ ] **Claude side — in-repo**: Run `echo '📍 Branch:' $(git branch --show-current 2>/dev/null || echo 'no git') '| Dir:' $(pwd)` from the repo root. Expected: `📍 Branch: <your-branch> | Dir: /Users/<you>/.../quest-execution-discipline`.
- [ ] **Claude side — non-git**: `cd /tmp && ` same command. Expected: `📍 Branch: no git | Dir: /tmp`.
- [ ] **Claude hook activation**: In a Claude Code session running this branch, trigger any `Edit` or `Write`. Expected: the `📍 Branch: ... | Dir: ...` line appears before the edit output. (Harness watches `.claude/settings.json` — should work in the current session without a restart; worst case, `--resume` picks it up.)
- [ ] **Codex JSON validity**: `jq . .codex/hooks.json` exits 0. (Already confirmed pre-commit.)
- [ ] **Codex hook activation**: Invoke a Codex MCP call from the repo root that performs an `apply_patch`. Expected: branch/dir line appears in Codex's output before the patch is applied. Requires `codex_hooks = true` in Codex config if not already enabled globally.
Watch for: if the terminal filter strips the 📍 emoji, the text still surfaces — no functional loss, only visual.

## Notes
- Branch name (`quest/installer-writes-manifest`) does not describe this PR's contents. The `installer-writes-manifest` quest is still in the plan phase and paused at Step 3.5 — this hook PR is a side-quest captured here because the work landed cleanly and independently. A separate follow-up PR will bring the installer-manifest fix on its own.
- This is read-only observability; the hook only \`echo\`s. It cannot block, deny, or modify tool calls. Exit code is always 0.
- Existing \`SessionStart\` script and \`PostToolUse\` audit hook in \`.claude/settings.json\` are untouched.
- User-level \`~/.claude/settings.json\` hooks (git-ai checkpoints) are independent and unaffected.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>