### PR TITLE
Add review ergonomics guidance and indexed findings

### DIFF
--- a/.agents/skills/pr-shepherd/SKILL.md
+++ b/.agents/skills/pr-shepherd/SKILL.md
@@ -3,4 +3,6 @@ name: pr-shepherd
 description: Push a draft PR and iterate until CI passes and review comments are resolved, then mark ready for review. Handles the full lifecycle of getting a PR merged with inline-first review handling.
 ---
 
+At activation, announce the skill name and scope in one line. Example: `[pr-shepherd] shepherding PR #97`.
+
 Read and follow the instructions in `.skills/pr-shepherd/SKILL.md`.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are the Code Review Agent in a quest orchestration system.
 
+At activation, announce the role and scope in one line. Example: `[code-reviewer] reviewing quest <id> implementation`.
+
 ## Your Task
 
 Read and follow the instructions in `.skills/quest/agents/code-reviewer.md`.

--- a/.claude/agents/fixer.md
+++ b/.claude/agents/fixer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are the Fixer Agent in a quest orchestration system.
 
+At activation, announce the role and scope in one line. Example: `[fixer] fixing review findings for <quest id>`.
+
 ## Your Task
 
 Read and follow the instructions in `.skills/quest/agents/fixer.md`.

--- a/.claude/agents/plan-reviewer.md
+++ b/.claude/agents/plan-reviewer.md
@@ -7,6 +7,8 @@ model: inherit
 
 You are a Plan Review Agent in a quest orchestration system.
 
+At activation, announce the role and scope in one line. Example: `[plan-reviewer] reviewing .quest/<id>/phase_01_plan/plan.md`.
+
 ## Your Task
 
 Read and follow the instructions in `.skills/quest/agents/plan-reviewer.md`.

--- a/.claude/skills/pr-shepherd/SKILL.md
+++ b/.claude/skills/pr-shepherd/SKILL.md
@@ -4,4 +4,6 @@ description: Push draft PR, monitor CI, respond to review comments, fix issues, 
 user-invocable: true
 ---
 
+At activation, announce the skill name and scope in one line. Example: `[pr-shepherd] shepherding PR #97`.
+
 Read and follow the instructions in `.skills/pr-shepherd/SKILL.md`.

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -4,6 +4,8 @@ description: Reviews code changes for quality, security, and correctness
 
 You are a Quest Code Reviewer.
 
+At activation, announce the role and scope in one line. Example: `[code-reviewer] reviewing quest <id> implementation`.
+
 Read and follow `.skills/quest/agents/code-reviewer.md` for your role definition.
 Read `AGENTS.md` for coding conventions.
 

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -4,6 +4,8 @@ description: Addresses code review feedback and fixes issues
 
 You are the Quest Fixer.
 
+At activation, announce the role and scope in one line. Example: `[fixer] fixing review findings for <quest id>`.
+
 Read and follow `.skills/quest/agents/fixer.md` for your role definition.
 
 ## Non-Interactive Contract

--- a/.opencode/agents/plan-reviewer.md
+++ b/.opencode/agents/plan-reviewer.md
@@ -4,6 +4,8 @@ description: Reviews implementation plans for completeness and correctness
 
 You are a Quest Plan Reviewer.
 
+At activation, announce the role and scope in one line. Example: `[plan-reviewer] reviewing .quest/<id>/phase_01_plan/plan.md`.
+
 Read and follow `.skills/quest/agents/plan-reviewer.md` for your role definition.
 Read `AGENTS.md` for coding conventions.
 

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -61,6 +61,7 @@
 .skills/implementer/SKILL.md
 .skills/plan-maker/SKILL.md
 .skills/plan-reviewer/SKILL.md
+.skills/review-anti-patterns.md
 .skills/celebrate/SKILL.md
 .skills/gpt/SKILL.md
 .skills/quest/SKILL.md

--- a/.skills/BOOTSTRAP.md
+++ b/.skills/BOOTSTRAP.md
@@ -38,6 +38,9 @@ Use a skill when:
 - The user names it explicitly, or
 - The task clearly matches the skill description.
 
+## Activation Announcement
+When activating a skill, announce the skill name and scope in one line before starting work. Examples: `[code-reviewer] reviewing PR #97 against plan.md`, `[plan-reviewer] reviewing .quest/example/phase_01_plan/plan.md`.
+
 ## Platform Notes
 - **Claude Code / Cursor:** skills are auto-discovered.
 - **OpenAI GPT:** load the relevant `SKILL.md` explicitly in the prompt or via tooling.

--- a/.skills/ci-code-reviewer/SKILL.md
+++ b/.skills/ci-code-reviewer/SKILL.md
@@ -107,9 +107,9 @@ If all criteria align, stay silent on this section.
 ### Step 0.6: Existing Comment Fetch Budget
 
 When fetching existing PR review comments before posting the CI review, use a bounded budget:
-- `interval_seconds = 10`
-- `max_retries = 10`
-- Hard cap: 100 seconds (100-second cap, `10 seconds x 10 retries`).
+- `interval_seconds = 20`
+- `max_retries = 20`
+- Hard cap: 400 seconds (400-second cap, `20 seconds x 20 retries`).
 
 Stop when the fetch succeeds, a confirmed permission/API failure occurs, or the budget is exhausted.
 

--- a/.skills/ci-code-reviewer/SKILL.md
+++ b/.skills/ci-code-reviewer/SKILL.md
@@ -12,6 +12,10 @@ This skill extends `.skills/code-reviewer/SKILL.md` with CI-specific
 adaptations: no interactive prompts, PR description validation, manifest
 pre-checks, and concise output formatting for automated comments.
 
+At activation, announce the skill name and scope in one line. Example: `[ci-code-reviewer] reviewing PR #97`.
+
+See `.skills/review-anti-patterns.md` for the shared rule set.
+
 ---
 
 ## When to Use
@@ -99,6 +103,15 @@ For each acceptance criterion:
 - Unclear from diff -> mark `unclear - needs human review`
 
 If all criteria align, stay silent on this section.
+
+### Step 0.6: Existing Comment Fetch Budget
+
+When fetching existing PR review comments before posting the CI review, use a bounded budget:
+- `interval_seconds = 10`
+- `max_retries = 10`
+- Hard cap: 100 seconds (100-second cap, `10 seconds x 10 retries`).
+
+Stop when the fetch succeeds, a confirmed permission/API failure occurs, or the budget is exhausted.
 
 ### Step 1: Identify Changed Files and Scope
 
@@ -199,14 +212,21 @@ Keep output concise. Omit sections with no findings.
 
 **Findings** (only sections with issues):
 
-**Blocker** - [path] Description and suggested fix
-**Must fix** - [path] Description and suggested fix
-**Should fix** - [path] Description and suggested fix
+**Blocker**
+[1] Blocker - path:line - description and suggested fix
+
+**Must fix**
+[2] Must fix - path:line - description and suggested fix
+
+**Should fix**
+[3] Should fix - path:line - description and suggested fix
 
 **Plan alignment** (only if gaps/scope creep found): list issues
 **Test gaps** (only if gaps found): list missing coverage
 **Architecture** (only if violations found): list violations
 ```
+
+Finding numbers are review-local indices. Use `[N]` format, increment in current-review order, and keep the number with the finding if it is converted to canonical JSON as `review_local_index`.
 
 Line number guidance:
 - Include `path:line` when the line comes from the diff.

--- a/.skills/ci-code-reviewer/SKILL.md
+++ b/.skills/ci-code-reviewer/SKILL.md
@@ -213,13 +213,13 @@ Keep output concise. Omit sections with no findings.
 **Findings** (only sections with issues):
 
 **Blocker**
-[1] Blocker - path:line - description and suggested fix
+[N] Blocker - path:line - description and suggested fix
 
 **Must fix**
-[2] Must fix - path:line - description and suggested fix
+[N] Must fix - path:line - description and suggested fix
 
 **Should fix**
-[3] Should fix - path:line - description and suggested fix
+[N] Should fix - path:line - description and suggested fix
 
 **Plan alignment** (only if gaps/scope creep found): list issues
 **Test gaps** (only if gaps found): list missing coverage

--- a/.skills/code-reviewer/SKILL.md
+++ b/.skills/code-reviewer/SKILL.md
@@ -200,13 +200,13 @@ Write a PR review that is short and high signal:
 - Recommendation: approve / request changes
 
 ### 2. Blockers
-- Numbered findings in current-review order: `[1] Blocker - path:line - summary and concrete fix`
+- Numbered findings in current-review order: `[N] Blocker - path:line - summary and concrete fix`
 
 ### 3. Must Fix
-- Numbered findings in current-review order: `[2] Must fix - path:line - summary and concrete fix`
+- Numbered findings in current-review order: `[N] Must fix - path:line - summary and concrete fix`
 
 ### 4. Should Fix
-- Numbered findings in current-review order: `[3] Should fix - path:line - summary and concrete fix`
+- Numbered findings in current-review order: `[N] Should fix - path:line - summary and concrete fix`
 
 Finding numbers are review-local indices. Keep numbering stable within the current review and use `[N]` format for every finding that appears in Blockers, Must Fix, or Should Fix.
 

--- a/.skills/code-reviewer/SKILL.md
+++ b/.skills/code-reviewer/SKILL.md
@@ -9,6 +9,10 @@ Review actual code implementations for correctness, maintainability, security hy
 
 This skill focuses on the code itself and the tests that ship with it, but it must validate test coverage against the **acceptance criteria from the plan/spec**.
 
+At activation, announce the skill name and scope in one line. Example: `[code-reviewer] reviewing PR #97 against .quest/example/phase_01_plan/plan.md`.
+
+See `.skills/review-anti-patterns.md` for the shared rule set.
+
 ---
 
 ## Required Inputs (Do Not Start Without These)
@@ -196,13 +200,15 @@ Write a PR review that is short and high signal:
 - Recommendation: approve / request changes
 
 ### 2. Blockers
-- Bullet list with concrete fixes
+- Numbered findings in current-review order: `[1] Blocker - path:line - summary and concrete fix`
 
 ### 3. Must Fix
-- Bullet list with concrete fixes
+- Numbered findings in current-review order: `[2] Must fix - path:line - summary and concrete fix`
 
 ### 4. Should Fix
-- Bullet list with concrete fixes
+- Numbered findings in current-review order: `[3] Should fix - path:line - summary and concrete fix`
+
+Finding numbers are review-local indices. Keep numbering stable within the current review and use `[N]` format for every finding that appears in Blockers, Must Fix, or Should Fix.
 
 ### 5. Test Coverage vs Acceptance Criteria
 - A short mapping table or bullet list

--- a/.skills/plan-reviewer/SKILL.md
+++ b/.skills/plan-reviewer/SKILL.md
@@ -259,10 +259,10 @@ Use this structure by default:
 
 ## 3. Open Requirements
 ### Must resolve before coding (blocking)
-- Numbered findings in current-review order: `[1] Must fix - plan.md:section - acceptance criterion is missing, ambiguous, or untestable`
+- Numbered findings in current-review order: `[N] Must fix - plan.md:section - acceptance criterion is missing, ambiguous, or untestable`
 
 ### Resolve during implementation (non-blocking)
-- Numbered findings in current-review order: `[2] Should fix - plan.md:section - the WHAT is clear, but the exact HOW is an implementation detail`
+- Numbered findings in current-review order: `[N] Should fix - plan.md:section - the WHAT is clear, but the exact HOW is an implementation detail`
 - Example: "a test seam is needed for year injection" is non-blocking if the AC already says "rejects non-2026 year before writes"
 - Example: "which exact mock library to use" is non-blocking
 

--- a/.skills/plan-reviewer/SKILL.md
+++ b/.skills/plan-reviewer/SKILL.md
@@ -5,6 +5,9 @@ description: Review implementation plans, PR specifications, and feature documen
 
 # Plan Reviewer
 
+At activation, announce the skill name and scope in one line. Example: `[plan-reviewer] reviewing .quest/example/phase_01_plan/plan.md`.
+
+See `.skills/review-anti-patterns.md` for the shared rule set.
 
 ## Minimum required inputs from the plan (reviewer gate)
 
@@ -256,12 +259,14 @@ Use this structure by default:
 
 ## 3. Open Requirements
 ### Must resolve before coding (blocking)
-- Items where the acceptance criterion itself is missing, ambiguous, or untestable
+- Numbered findings in current-review order: `[1] Must fix - plan.md:section - acceptance criterion is missing, ambiguous, or untestable`
 
 ### Resolve during implementation (non-blocking)
-- Items where the WHAT is clear from the acceptance criteria but the exact HOW is an implementation detail
+- Numbered findings in current-review order: `[2] Should fix - plan.md:section - the WHAT is clear, but the exact HOW is an implementation detail`
 - Example: "a test seam is needed for year injection" is non-blocking if the AC already says "rejects non-2026 year before writes"
 - Example: "which exact mock library to use" is non-blocking
+
+Finding numbers are review-local indices. Use `[N]` format for every finding so the planner, arbiter, and builder can refer to findings unambiguously.
 
 ## 4. Validation Plan Summary
 ### Manual

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -2,6 +2,10 @@
 
 Push a draft PR and iterate until CI passes and review comments are resolved, then mark ready for review.
 
+At activation, announce the skill name and scope in one line. Example: `[pr-shepherd] shepherding PR #97`.
+
+See `.skills/review-anti-patterns.md` for the shared rule set.
+
 ## Default Commenting Mode
 
 Use **inline-first** commenting by default.
@@ -18,9 +22,15 @@ Use **inline-first** commenting by default.
 3. Create a **draft** PR via `gh pr create --draft`.
 
 ### Step 2: Wait for CI
-1. Run `gh pr checks <PR_NUMBER>` to get an early read.
-2. If any checks are still pending, sleep ~180 seconds.
-3. Run `gh pr checks <PR_NUMBER>` again to observe final CI status.
+Use a hard polling budget for CI waits:
+- `interval_seconds = 30`
+- `max_retries = 30`
+- Hard cap: 15 minutes (15-minute cap, `30 seconds x 30 retries`)
+
+Loop:
+1. Run `gh pr checks <PR_NUMBER>` to get the current status.
+2. Stop when all checks are green, a confirmed failure is present, or the polling budget is exhausted.
+3. If checks are still pending and budget remains, sleep 30 seconds before the next retry.
 
 ### Step 3: Evaluate CI Results
 - **All checks pass** → proceed to Step 4.
@@ -29,6 +39,8 @@ Use **inline-first** commenting by default.
 ### Step 4: Check PR Comments
 1. Fetch **inline** review comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments`
 2. Fetch **general** PR comments: `gh pr view <PR_NUMBER> --comments`
+   - Comment fetch is single-shot by default.
+   - If a transient API state requires retrying, use `interval_seconds = 10`, `max_retries = 10`, 100-second cap (`10 seconds x 10 retries`).
 3. For each comment, respond **on the comment itself** (threaded reply), never move an inline discussion to the general PR thread:
    - **Inline review comments** → reply via `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -f body="..."`
    - **General discussion comments** → reply via `gh pr comment <PR_NUMBER> --body "..."`
@@ -80,7 +92,7 @@ Comment formula:
 4. Keep tone warm; humor is optional and brief.
 
 Example shape:
-`Nice cleanup here. One tiny gremlin: <specific issue>. Could we <specific fix>?`
+`Nice cleanup here. One issue: <specific issue>. Could we <specific fix>?`
 
 Tone rules:
 - Be kind, not vague.
@@ -104,7 +116,7 @@ Signature requirement for every posted review comment:
 `- Reviewed by <model>, in collaboration with <github username>`
 
 Ready-to-use template:
-`Nice improvement here. One small gremlin: <issue>. This can cause <impact>. Suggestion: <specific change>.`
+`Nice improvement here. One issue: <issue>. This can cause <impact>. Suggestion: <specific change>.`
 `- Reviewed by <model>, in collaboration with <github username>`
 
 ### Step 4.6: Decision Policy Alignment

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -40,7 +40,7 @@ Loop:
 1. Fetch **inline** review comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments`
 2. Fetch **general** PR comments: `gh pr view <PR_NUMBER> --comments`
    - Comment fetch is single-shot by default.
-   - If a transient API state requires retrying, use `interval_seconds = 10`, `max_retries = 10`, 100-second cap (`10 seconds x 10 retries`).
+   - If a transient API state requires retrying, use `interval_seconds = 20`, `max_retries = 20`, 400-second cap (`20 seconds x 20 retries`).
 3. For each comment, respond **on the comment itself** (threaded reply), never move an inline discussion to the general PR thread:
    - **Inline review comments** → reply via `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -f body="..."`
    - **General discussion comments** → reply via `gh pr comment <PR_NUMBER> --body "..."`

--- a/.skills/quest/agents/code-reviewer.md
+++ b/.skills/quest/agents/code-reviewer.md
@@ -45,7 +45,7 @@ Canonical findings schema (required fields per finding):
 Optional field per finding:
 - `review_local_index`: positive integer index from the current markdown review when the finding is numbered.
 
-Markdown review findings must use `[N]` format in current-review order, for example: `[1] Must fix - scripts/example.py:42 - explain the issue and fix`.
+Markdown review findings must use `[N]` format in current-review order, for example: `[N] Must fix - scripts/example.py:42 - explain the issue and fix`.
 
 Allowed enum values:
 - `severity`: `critical`, `high`, `medium`, `low`, `info`

--- a/.skills/quest/agents/code-reviewer.md
+++ b/.skills/quest/agents/code-reviewer.md
@@ -1,5 +1,7 @@
 # Code Review Agent
 
+At activation, announce the role and scope in one line. Example: `[code-reviewer] reviewing quest <id> implementation`.
+
 ## Overview
 There are **two** Code Review Agent invocations on each review pass. They run **in parallel** using different model families for independent perspectives, writing both markdown review artifacts and canonical findings JSON artifacts.
 
@@ -22,6 +24,7 @@ There are **two** Code Review Agent invocations on each review pass. They run **
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
 - `AGENTS.md` (coding conventions and architecture boundaries)
 - `.skills/code-reviewer/SKILL.md` (review skill)
+- `.skills/review-anti-patterns.md` (shared review anti-patterns)
 - Changed files from `git diff --name-only` when VCS is available
 - Optional diff summary from `git diff --stat` when VCS is available
 - `.quest/<id>/phase_02_implementation/builder_feedback_discussion.md` for touched files/tests when VCS is unavailable
@@ -38,6 +41,11 @@ There are **two** Code Review Agent invocations on each review pass. They run **
 
 Canonical findings schema (required fields per finding):
 `finding_id, source, kind, severity, confidence, path, line, summary, why_it_matters, evidence, action, needs_test, write_scope, related_acceptance_criteria`
+
+Optional field per finding:
+- `review_local_index`: positive integer index from the current markdown review when the finding is numbered.
+
+Markdown review findings must use `[N]` format in current-review order, for example: `[1] Must fix - scripts/example.py:42 - explain the issue and fix`.
 
 Allowed enum values:
 - `severity`: `critical`, `high`, `medium`, `low`, `info`

--- a/.skills/quest/agents/fixer.md
+++ b/.skills/quest/agents/fixer.md
@@ -1,5 +1,7 @@
 # Fixer Agent
 
+At activation, announce the role and scope in one line. Example: `[fixer] fixing review findings for <quest id>`.
+
 ## Role
 Fixes issues identified by the Code Review Agent. Applies targeted fixes and re-runs tests.
 
@@ -16,6 +18,7 @@ When running on Codex, this role is non-interactive:
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
 - `AGENTS.md` (coding conventions and architecture boundaries)
 - `.skills/implementer/SKILL.md` (implementation skill, fix mode)
+- `.skills/review-anti-patterns.md` (shared review anti-patterns)
 - Code review artifacts (issues to fix):
   - `.quest/<id>/phase_03_review/review_code-reviewer-a.md`
   - `.quest/<id>/phase_03_review/review_code-reviewer-b.md`
@@ -29,6 +32,7 @@ When running on Codex, this role is non-interactive:
 4. For bug fixes: follow the prove-it pattern from `AGENTS.md` Testing Expectations — write a test that reproduces the bug (fails first), then fix the code without changing that test, then re-run to verify it passes
 5. Record fix decisions, touched files, and tests run in `.quest/<quest_id>/phase_03_review/review_fix_feedback_discussion.md`
 6. Do NOT make unrelated changes — fix only what the review identified
+7. Preserve and reference `review_local_index` values when reporting addressed findings, using `[N]` labels where present.
 
 ## Input
 - Code review (`.quest/<id>/phase_03_review/review_code-reviewer-a.md`)

--- a/.skills/quest/agents/plan-reviewer.md
+++ b/.skills/quest/agents/plan-reviewer.md
@@ -34,7 +34,7 @@ There are **two** Plan Review Agent invocations on every plan iteration. They ru
 5. Identify gaps, risks, or unclear areas
 6. Write review to the assigned artifact path for the current slot
 
-Review findings in markdown must use `[N]` format in current-review order, for example: `[1] Must fix - plan.md:Acceptance Criteria - make the criterion testable`.
+Review findings in markdown must use `[N]` format in current-review order, for example: `[N] Must fix - plan.md:Acceptance Criteria - make the criterion testable`.
 
 ## Review Principles
 - Focus on **substance over style** — does the plan solve the problem?

--- a/.skills/quest/agents/plan-reviewer.md
+++ b/.skills/quest/agents/plan-reviewer.md
@@ -1,5 +1,7 @@
 # Plan Review Agent
 
+At activation, announce the role and scope in one line. Example: `[plan-reviewer] reviewing .quest/<id>/phase_01_plan/plan.md`.
+
 ## Overview
 There are **two** Plan Review Agent invocations on every plan iteration. They run **in parallel** using different model families for independent perspectives, writing to `review_plan-reviewer-a.md` and `review_plan-reviewer-b.md`. Their reviews are fed to the Arbiter, never directly back to the Planner.
 
@@ -20,6 +22,7 @@ There are **two** Plan Review Agent invocations on every plan iteration. They ru
 - `.skills/BOOTSTRAP.md` (project bootstrapping)
 - `AGENTS.md` (coding conventions and architecture boundaries)
 - `.skills/plan-reviewer/SKILL.md` (review skill)
+- `.skills/review-anti-patterns.md` (shared review anti-patterns)
 - Plan artifact from Planner Agent
 - Quest brief (for acceptance criteria reference)
 
@@ -30,6 +33,8 @@ There are **two** Plan Review Agent invocations on every plan iteration. They ru
 4. Check test strategy completeness
 5. Identify gaps, risks, or unclear areas
 6. Write review to the assigned artifact path for the current slot
+
+Review findings in markdown must use `[N]` format in current-review order, for example: `[1] Must fix - plan.md:Acceptance Criteria - make the criterion testable`.
 
 ## Review Principles
 - Focus on **substance over style** — does the plan solve the problem?

--- a/.skills/review-anti-patterns.md
+++ b/.skills/review-anti-patterns.md
@@ -1,0 +1,18 @@
+# Review Anti-Patterns
+
+Shared rules for review-adjacent Quest skills. Reference these rules instead of duplicating local anti-chat guidance.
+
+## Rules
+
+1. Do not add reply comments justifying a finding.
+   - Rationale: the finding belongs in the review; extra thread replies create noise unless they answer a user or reviewer question.
+2. Do not restate inline findings as top-level PR comments.
+   - Rationale: inline-first review keeps code-specific feedback attached to the exact line.
+3. Do not ask which issues to fix when severity is unambiguous.
+   - Rationale: blockers and Must-fix items are fixed; ask only for Should-fix or Nit selection when the plan does not decide it.
+4. Do not introduce requirements the plan or PR description did not ask for.
+   - Rationale: review feedback should protect correctness and scope, not expand the feature.
+5. Do not pad clean reviews with empty PASS sections.
+   - Rationale: clean output should stay short enough for a reviewer to scan quickly.
+6. Bias toward action on iteration 3 and later.
+   - Rationale: only blockers justify another loop; defer the rest through `.skills/review-decisions/SKILL.md`.

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-04-25 | [review-ergonomics-batch](review-ergonomics-batch_2026-04-25.md) | Completed successfully. |
 | 2026-04-24 | [deep-ci-manifest](deep-ci-manifest_2026-04-24.md) | Impact: - Adds one canonical machine-readable artifact (`/tmp/deep_ci_context_manifest.json`) per run so selection/ch... |
 | 2026-04-21 | [deep-ci-file-review](deep-ci-file-review_2026-04-21.md) | Completed successfully. |
 | 2026-04-16 | [celebration-review-intel](celebration-review-intel_2026-04-16.md) | Add two narrow, artifact-backed carry-over sections to Quest celebration/journal output so Phase 1 review intelligenc... |

--- a/docs/quest-journal/review-ergonomics-batch_2026-04-25.md
+++ b/docs/quest-journal/review-ergonomics-batch_2026-04-25.md
@@ -1,0 +1,153 @@
+# Quest Journal: Review Ergonomics Batch
+
+- Quest ID: `review-ergonomics-batch_2026-04-24__1819`
+- Completed: 2026-04-25
+- Mode: workflow
+- Quality: Platinum
+- Outcome: Completed successfully.
+
+## What Shipped
+
+**Problem:** Review-adjacent Quest skills currently rely on soft polling language, duplicated anti-chat guidance, unannounced skill activation, and unnumbered review findings. That makes review loops less predictable and harder to act on when a user asks for "finding 2" or when installed repos re...
+
+## Files Changed
+
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_01_plan/plan.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_01_plan/review_findings.json.next`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_02_implementation/pr_description.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_03_review/review_code-reviewer-a.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_03_review/review_findings_code-reviewer-a.json`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_03_review/review_code-reviewer-b.md`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_03_review/review_findings_code-reviewer-b.json`
+- `.quest/review-ergonomics-batch_2026-04-24__1819/phase_03_review/review_fix_feedback_discussion.md`
+
+## Iterations
+
+- Plan iterations: 1
+- Fix iterations: 1
+
+## Agents
+
+- **The Judge** (arbiter): 
+- **The Implementer** (builder): 
+
+## Quest Brief
+
+```text
+Implement the same-day review ergonomics batch from ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md.
+
+Scope:
+1. Add hard polling budgets to review-adjacent skills, especially pr-shepherd CI waits and ci-code-reviewer comment-fetch waits.
+2. Add a shared review anti-pattern rules file and reference it from code-reviewer, ci-code-reviewer, plan-reviewer, pr-shepherd, and fixer.
+3. Add skill activation announcement guidance to BOOTSTRAP.md and each review-adjacent skill opener.
+4. Number findings in code-reviewer, ci-code-reviewer, and plan-reviewer outputs, and preserve the review-local index in downstream canonical findings when applicable.
+
+References:
+- ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
+- .skills/review-decisions/SKILL.md
+- .skills/pr-shepherd/SKILL.md
+- scripts/quest_review_intelligence.py
+- scripts/quest_runtime/review_intelligence.py
+- .quest-manifest
+
+Constraints:
+- Keep this to the same-day batch only; do not implement pre-commit-review, team-preference memory, skill renames, or checkpoint commits.
+- Preserve the existing review-decision taxonomy: fix_now, verify_first, defer, drop, needs_human_decision.
+- Ensure every installed file change is represented in .quest-manifest.
+- Update tests for any parser/schema/runtime changes.
+
+Installer portability:
+- Treat this as a Quest framework change that must benefit repos installed via quest_installer, not only this repository.
+- For every changed file, verify whether it is managed by .quest-manifest.
+- If adding a new shared file such as .skills/review-anti-patterns.md, add it to .quest-manifest and any relevant wrapper/mirror locations so quest_installer propagates it.
+- Avoid relying on Quest-repo-only files under ideas/, docs/, or .github/ for runtime behavior in installed repos.
+- If .ai/allowlist.json changes are required, keep them minimal and document the client-repo merge impact because allowlist.json is user-customized.
+
+Validation:
+- bash scripts/quest_validate-manifest.sh
+- python3 -m pytest tests/unit/test_review_intelligence.py tests/unit/test_pr_review_cycle.py tests/unit/test_quest_select_tests.py -q
+- Add or update focused tests for numbered finding extraction / review-local index if implementation touches parsing.
+```
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/review-ergonomics-batch_2026-04-25.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 32 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 1"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 5"
+    }
+  ],
+  "quality": {
+    "tier": "Platinum",
+    "grade": "P"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 12
+}
+```
+<!-- celebration-data-end -->

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -10,6 +10,7 @@ from quest_runtime.review_intelligence import (
     ALLOWED_DECISIONS,
     _batch_from_finding,
     merge_and_dedupe,
+    review_local_index_from_value,
     select_decision,
     validate_findings,
 )
@@ -104,6 +105,12 @@ def _finding_line(value: object) -> int | None:
     return value
 
 
+def _copy_review_local_index(source: JsonObject, target: JsonObject) -> None:
+    index = review_local_index_from_value(source.get("review_local_index"))
+    if index is not None:
+        target["review_local_index"] = index
+
+
 def _normalize_scope_entry(value: str) -> str:
     trimmed = value.strip().strip("/")
     if not trimmed:
@@ -188,24 +195,24 @@ def normalize_pr_review_intake(intake: JsonObject) -> list[JsonObject]:
         severity = "high" if tokens & set(BLOCKER_KEYWORDS) else "medium"
         summary = body[:120].strip() or f"Inline review feedback from {commenter}."
 
-        normalized_findings.append(
-            {
-                "finding_id": f"pr-inline-{inline_counter:03d}",
-                "source": f"pr-inline:{commenter}",
-                "kind": "review_comment",
-                "severity": severity,
-                "confidence": "medium",
-                "path": path,
-                "line": line,
-                "summary": summary,
-                "why_it_matters": "Unaddressed inline feedback can leave review concerns unresolved.",
-                "evidence": [_first_200_chars(body)],
-                "action": "Address reviewer feedback.",
-                "needs_test": severity == "high",
-                "write_scope": [path],
-                "related_acceptance_criteria": [],
-            }
-        )
+        finding: JsonObject = {
+            "finding_id": f"pr-inline-{inline_counter:03d}",
+            "source": f"pr-inline:{commenter}",
+            "kind": "review_comment",
+            "severity": severity,
+            "confidence": "medium",
+            "path": path,
+            "line": line,
+            "summary": summary,
+            "why_it_matters": "Unaddressed inline feedback can leave review concerns unresolved.",
+            "evidence": [_first_200_chars(body)],
+            "action": "Address reviewer feedback.",
+            "needs_test": severity == "high",
+            "write_scope": [path],
+            "related_acceptance_criteria": [],
+        }
+        _copy_review_local_index(comment, finding)
+        normalized_findings.append(finding)
 
     for comment in general_comments:
         general_counter += 1
@@ -214,24 +221,24 @@ def normalize_pr_review_intake(intake: JsonObject) -> list[JsonObject]:
         body = str(comment.get("body") or "").strip()
         summary = body[:120].strip() or f"General PR feedback from {commenter}."
 
-        normalized_findings.append(
-            {
-                "finding_id": f"pr-general-{general_counter:03d}",
-                "source": f"pr-general:{commenter}",
-                "kind": "review_comment",
-                "severity": "medium",
-                "confidence": "low",
-                "path": "pr/general",
-                "line": None,
-                "summary": summary,
-                "why_it_matters": "General PR comments can signal unresolved quality or scope concerns.",
-                "evidence": [_first_200_chars(body)],
-                "action": "Address reviewer feedback.",
-                "needs_test": False,
-                "write_scope": [],
-                "related_acceptance_criteria": [],
-            }
-        )
+        finding = {
+            "finding_id": f"pr-general-{general_counter:03d}",
+            "source": f"pr-general:{commenter}",
+            "kind": "review_comment",
+            "severity": "medium",
+            "confidence": "low",
+            "path": "pr/general",
+            "line": None,
+            "summary": summary,
+            "why_it_matters": "General PR comments can signal unresolved quality or scope concerns.",
+            "evidence": [_first_200_chars(body)],
+            "action": "Address reviewer feedback.",
+            "needs_test": False,
+            "write_scope": [],
+            "related_acceptance_criteria": [],
+        }
+        _copy_review_local_index(comment, finding)
+        normalized_findings.append(finding)
 
     return merge_and_dedupe([normalized_findings, existing_findings])
 

--- a/scripts/quest_runtime/review_intelligence.py
+++ b/scripts/quest_runtime/review_intelligence.py
@@ -39,6 +39,7 @@ ALLOWED_DECISIONS = (
 _SEVERITY_RANK = {name: index for index, name in enumerate(ALLOWED_SEVERITIES)}
 _CONFIDENCE_RANK = {name: index for index, name in enumerate(ALLOWED_CONFIDENCE)}
 ALLOWED_BACKLOG_PHASES = ("plan", "review")
+_REVIEW_LOCAL_INDEX_RE = re.compile(r"^(?:\[(?P<bracket>[1-9]\d*)\]|(?P<dot>[1-9]\d*)\.)\s+")
 
 
 def utc_now_iso() -> str:
@@ -65,6 +66,14 @@ def _severity_rank(value: str) -> int:
 
 def _confidence_rank(value: str) -> int:
     return _CONFIDENCE_RANK.get(value, -1)
+
+
+def review_local_index_from_value(value: Any) -> int | None:
+    """Return a positive integer review-local index, or None for all other values."""
+
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return None
+    return value
 
 
 def _dedupe_key(finding: dict[str, Any]) -> tuple[str, str, str, str]:
@@ -122,6 +131,11 @@ def validate_finding(finding: dict[str, Any]) -> list[str]:
     line_value = finding.get("line")
     if line_value is not None and (isinstance(line_value, bool) or not isinstance(line_value, int) or line_value < 1):
         errors.append("field 'line' must be null or an integer >= 1")
+
+    if "review_local_index" in finding and review_local_index_from_value(
+        finding.get("review_local_index")
+    ) is None:
+        errors.append("field 'review_local_index' must be a positive integer")
 
     if not isinstance(finding.get("needs_test"), bool):
         errors.append("field 'needs_test' must be a boolean")
@@ -589,6 +603,19 @@ _PATH_RE = re.compile(
 )
 
 
+def _strip_list_marker(value: str) -> str:
+    return re.sub(r"^[-*]\s+", "", value, count=1).strip()
+
+
+def _extract_review_local_index(value: str) -> tuple[int | None, str]:
+    markerless = _strip_list_marker(value)
+    match = _REVIEW_LOCAL_INDEX_RE.match(markerless)
+    if not match:
+        return None, markerless
+    token = match.group("bracket") or match.group("dot")
+    return int(token), markerless[match.end() :].strip()
+
+
 def synthesize_findings_from_review_markdown(
     review_markdown: str,
     *,
@@ -605,11 +632,12 @@ def synthesize_findings_from_review_markdown(
         if not (
             stripped.startswith("- ")
             or stripped.startswith("* ")
+            or re.match(r"^\[[1-9]\d*\]\s+", stripped)
             or re.match(r"^\d+\.\s+", stripped)
         ):
             continue
 
-        normalized = re.sub(r"^[-*]\s+|^\d+\.\s+", "", stripped).strip()
+        review_local_index, normalized = _extract_review_local_index(stripped)
         if len(normalized) < 8:
             continue
 
@@ -627,24 +655,25 @@ def synthesize_findings_from_review_markdown(
             write_scope = [finding_path]
 
         index = len(findings) + 1
-        findings.append(
-            {
-                "finding_id": f"{source}-{index:03d}",
-                "source": source,
-                "kind": "plan_review",
-                "severity": severity,
-                "confidence": "medium",
-                "path": finding_path,
-                "line": line_number,
-                "summary": normalized,
-                "why_it_matters": "Potential issue surfaced during plan review.",
-                "evidence": [normalized],
-                "action": "Confirm and adjust the plan if required.",
-                "needs_test": False,
-                "write_scope": write_scope,
-                "related_acceptance_criteria": [],
-            }
-        )
+        finding: dict[str, Any] = {
+            "finding_id": f"{source}-{index:03d}",
+            "source": source,
+            "kind": "plan_review",
+            "severity": severity,
+            "confidence": "medium",
+            "path": finding_path,
+            "line": line_number,
+            "summary": normalized,
+            "why_it_matters": "Potential issue surfaced during plan review.",
+            "evidence": [normalized],
+            "action": "Confirm and adjust the plan if required.",
+            "needs_test": False,
+            "write_scope": write_scope,
+            "related_acceptance_criteria": [],
+        }
+        if review_local_index is not None:
+            finding["review_local_index"] = review_local_index
+        findings.append(finding)
     return findings
 
 

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -11,6 +11,8 @@ ERRORS=0
 STRICT_MODE="${QUEST_MANIFEST_STRICT:-auto}"
 
 case "${1:-}" in
+  "")
+    ;;
   --strict)
     STRICT_MODE=1
     ;;
@@ -31,6 +33,11 @@ Default mode is auto: strict when scripts/quest_installer.sh exists, installed
 otherwise. Set QUEST_MANIFEST_STRICT=1 or 0 to override auto mode.
 EOF
     exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    echo "Usage: scripts/quest_validate-manifest.sh [--strict|--installed]" >&2
+    exit 2
     ;;
 esac
 

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -8,6 +8,39 @@ set -e
 
 MANIFEST=".quest-manifest"
 ERRORS=0
+STRICT_MODE="${QUEST_MANIFEST_STRICT:-auto}"
+
+case "${1:-}" in
+  --strict)
+    STRICT_MODE=1
+    ;;
+  --installed)
+    STRICT_MODE=0
+    ;;
+  --help|-h)
+    cat <<'EOF'
+Usage: scripts/quest_validate-manifest.sh [--strict|--installed]
+
+Validates .quest-manifest.
+
+Modes:
+  --strict     Also scan Quest source paths for files missing from the manifest.
+  --installed  Validate only manifest entries; allow repo-local custom files.
+
+Default mode is auto: strict when scripts/quest_installer.sh exists, installed
+otherwise. Set QUEST_MANIFEST_STRICT=1 or 0 to override auto mode.
+EOF
+    exit 0
+    ;;
+esac
+
+if [ "$STRICT_MODE" = "auto" ]; then
+  if [ -f "scripts/quest_installer.sh" ]; then
+    STRICT_MODE=1
+  else
+    STRICT_MODE=0
+  fi
+fi
 
 # Colors
 RED=$'\033[0;31m'
@@ -90,39 +123,43 @@ done
 # Clean up and sort
 FOUND_FILES=$(echo "$FOUND_FILES" | grep -v '^$' | sort | uniq)
 
-# Check each found file is in the manifest
-echo "Checking Quest files are listed in $MANIFEST..."
-echo ""
+if [ "$STRICT_MODE" = "1" ]; then
+  # Check each found file is in the manifest
+  echo "Checking Quest files are listed in $MANIFEST..."
+  echo ""
 
-MISSING_FILES=""
-while IFS= read -r file; do
-  [ -z "$file" ] && continue
+  MISSING_FILES=""
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
 
-  if ! echo "$MANIFEST_FILES" | grep -q "^${file}$"; then
-    MISSING_FILES="$MISSING_FILES$file"$'\n'
-    ((ERRORS++)) || true
+    if ! echo "$MANIFEST_FILES" | grep -q "^${file}$"; then
+      MISSING_FILES="$MISSING_FILES$file"$'\n'
+      ((ERRORS++)) || true
+    fi
+  done <<< "$FOUND_FILES"
+
+  # Report results
+  if [ $ERRORS -gt 0 ]; then
+    log_error "Found $ERRORS file(s) missing from .quest-manifest:"
+    echo ""
+    echo "$MISSING_FILES" | grep -v '^$' | while read -r f; do
+      echo "  - $f"
+    done
+    echo ""
+    echo "Please add these files to the appropriate section in .quest-manifest"
+    echo ""
+    echo "Sections:"
+    echo "  [copy-as-is]       - Files replaced with upstream (most files)"
+    echo "  [user-customized]  - Files that preserve local edits (AGENTS.md may auto-update if pristine)"
+    echo "  [merge-carefully]  - Files that prompt for merge (settings.json)"
+    echo "  [directories]      - Directories to create"
+    exit 1
   fi
-done <<< "$FOUND_FILES"
 
-# Report results
-if [ $ERRORS -gt 0 ]; then
-  log_error "Found $ERRORS file(s) missing from .quest-manifest:"
-  echo ""
-  echo "$MISSING_FILES" | grep -v '^$' | while read -r f; do
-    echo "  - $f"
-  done
-  echo ""
-  echo "Please add these files to the appropriate section in .quest-manifest"
-  echo ""
-  echo "Sections:"
-  echo "  [copy-as-is]       - Files replaced with upstream (most files)"
-  echo "  [user-customized]  - Files that preserve local edits (AGENTS.md may auto-update if pristine)"
-  echo "  [merge-carefully]  - Files that prompt for merge (settings.json)"
-  echo "  [directories]      - Directories to create"
-  exit 1
+  log_ok "All Quest files are listed in .quest-manifest"
+else
+  log_ok "Installed repo mode: allowing repo-local files outside .quest-manifest"
 fi
-
-log_ok "All Quest files are listed in .quest-manifest"
 
 # Also check for stale entries (files in manifest that don't exist)
 echo ""

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -970,6 +970,57 @@ test_manifest_excludes_source_only_unit_tests() {
     ! grep -q '^tests/unit/test_codex_skill_wrappers.py$' "$MANIFEST_FILE"
 }
 
+test_manifest_validator_allows_custom_skills_in_installed_mode() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p scripts .skills/prepare-mcp-quest
+    cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    cat > .quest-manifest <<'EOF'
+[copy-as-is]
+scripts/quest_validate-manifest.sh
+
+[directories]
+.quest
+EOF
+    printf '# local custom skill\n' > .skills/prepare-mcp-quest/SKILL.md
+
+    bash scripts/quest_validate-manifest.sh > output.txt 2>&1 &&
+      grep -q 'Installed repo mode' output.txt &&
+      ! grep -q 'prepare-mcp-quest' output.txt
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_manifest_validator_strict_mode_catches_unmanifested_skills() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p scripts .skills/prepare-mcp-quest
+    cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    cat > .quest-manifest <<'EOF'
+[copy-as-is]
+scripts/quest_validate-manifest.sh
+
+[directories]
+.quest
+EOF
+    printf '# local custom skill\n' > .skills/prepare-mcp-quest/SKILL.md
+
+    if QUEST_MANIFEST_STRICT=1 bash scripts/quest_validate-manifest.sh > output.txt 2>&1; then
+      exit 1
+    fi
+    grep -q '.skills/prepare-mcp-quest/SKILL.md' output.txt
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 test_validation_hook_script_accepts_legacy_symlink_target() {
   grep -q '\[\[ "\$target" == \*"quest_validate-quest-config.sh" \]\] || \[\[ "\$target" == \*"validate-quest-config.sh" \]\]' "$REPO_ROOT/scripts/quest_validate-quest-config.sh"
 }
@@ -1570,6 +1621,8 @@ run_test test_installer_preserves_unowned_source_only_test_path
 run_test test_manifest_lists_prefixed_scripts
 run_test test_manifest_lists_installed_quest_smoke_tests
 run_test test_manifest_excludes_source_only_unit_tests
+run_test test_manifest_validator_allows_custom_skills_in_installed_mode
+run_test test_manifest_validator_strict_mode_catches_unmanifested_skills
 run_test test_validation_hook_script_accepts_legacy_symlink_target
 run_test test_quest_claude_runner_polls_handoff_and_logs_runtime
 run_test test_quest_claude_probe_requires_real_artifacts

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -1021,6 +1021,29 @@ EOF
   return $rc
 }
 
+test_manifest_validator_rejects_unknown_option() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p scripts
+    cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    cat > .quest-manifest <<'EOF'
+[copy-as-is]
+scripts/quest_validate-manifest.sh
+EOF
+
+    if bash scripts/quest_validate-manifest.sh --bogus > output.txt 2>&1; then
+      exit 1
+    fi
+    grep -q 'Unknown option: --bogus' output.txt &&
+      grep -q 'Usage: scripts/quest_validate-manifest.sh' output.txt
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 test_validation_hook_script_accepts_legacy_symlink_target() {
   grep -q '\[\[ "\$target" == \*"quest_validate-quest-config.sh" \]\] || \[\[ "\$target" == \*"validate-quest-config.sh" \]\]' "$REPO_ROOT/scripts/quest_validate-quest-config.sh"
 }
@@ -1623,6 +1646,7 @@ run_test test_manifest_lists_installed_quest_smoke_tests
 run_test test_manifest_excludes_source_only_unit_tests
 run_test test_manifest_validator_allows_custom_skills_in_installed_mode
 run_test test_manifest_validator_strict_mode_catches_unmanifested_skills
+run_test test_manifest_validator_rejects_unknown_option
 run_test test_validation_hook_script_accepts_legacy_symlink_target
 run_test test_quest_claude_runner_polls_handoff_and_logs_runtime
 run_test test_quest_claude_probe_requires_real_artifacts

--- a/tests/unit/test_pr_review_cycle.py
+++ b/tests/unit/test_pr_review_cycle.py
@@ -129,6 +129,61 @@ def test_normalize_pr_review_intake_merges_ci_inline_general_into_canonical_find
     assert ci["needs_test"] is True
 
 
+def test_normalize_pr_review_intake_preserves_review_local_index_when_present() -> None:
+    intake = {
+        "inline_comments": [
+            {
+                "commenter": "alice",
+                "body": "[5] This explicit field, not body text, should determine the index.",
+                "path": "scripts/quest_runtime/pr_review_cycle.py",
+                "line": 42,
+                "review_local_index": 5,
+            },
+            {
+                "commenter": "bob",
+                "body": "[9] Body markers alone should not be parsed for PR comments.",
+                "path": "scripts/quest_runtime/pr_review_cycle.py",
+                "line": 43,
+            },
+        ],
+        "general_comments": [
+            {
+                "commenter": "carol",
+                "body": "General review note with explicit index.",
+                "review_local_index": 2,
+            },
+        ],
+        "existing_findings": [
+            {
+                "finding_id": "existing-001",
+                "source": "historical",
+                "kind": "review_comment",
+                "severity": "low",
+                "confidence": "low",
+                "path": "docs/notes.md",
+                "line": None,
+                "summary": "Existing note",
+                "why_it_matters": "Track deferred concern.",
+                "evidence": ["prior evidence"],
+                "action": "Keep in backlog.",
+                "needs_test": False,
+                "write_scope": ["docs/notes.md"],
+                "related_acceptance_criteria": [],
+                "review_local_index": 8,
+            }
+        ],
+    }
+
+    findings = normalize_pr_review_intake(intake)
+
+    assert validate_findings(findings) == []
+    by_id = {finding["finding_id"]: finding for finding in findings}
+    assert by_id["pr-inline-001"]["review_local_index"] == 5
+    assert "review_local_index" not in by_id["pr-inline-002"]
+    assert by_id["pr-general-001"]["review_local_index"] == 2
+    assert by_id["existing-001"]["review_local_index"] == 8
+
+
 def test_build_fix_batches_groups_by_write_scope_and_validation_scope() -> None:
     items = [
         _backlog_item(

--- a/tests/unit/test_review_intelligence.py
+++ b/tests/unit/test_review_intelligence.py
@@ -94,6 +94,23 @@ def test_validate_findings_rejects_wrong_types() -> None:
     assert any("field 'evidence' must be a list[str]" in error for error in errors)
 
 
+def test_validate_findings_accepts_optional_review_local_index_and_rejects_invalid_values() -> None:
+    valid = _finding()
+    valid["review_local_index"] = 2
+    assert validate_findings([valid]) == []
+
+    assert validate_findings([_finding()]) == []
+
+    for invalid_value in (0, -1, "2", True):
+        invalid = _finding()
+        invalid["review_local_index"] = invalid_value
+        errors = validate_findings([invalid])
+        assert any(
+            "field 'review_local_index' must be a positive integer" in error
+            for error in errors
+        ), invalid_value
+
+
 def test_select_decision_fix_now_for_high_severity_strong_evidence() -> None:
     finding = _finding(severity="high", confidence="high", evidence=["a", "b"])
     decision = select_decision(finding, at_loop_cap=False)
@@ -156,6 +173,29 @@ def test_merge_and_dedupe_uses_strongest_severity() -> None:
     assert len(merged) == 1
     assert merged[0]["severity"] == "critical"
     assert merged[0]["confidence"] == "high"
+
+
+def test_merge_and_dedupe_preserves_primary_review_local_index() -> None:
+    primary = _finding(
+        finding_id="F-primary",
+        source="code-reviewer-a",
+        severity="medium",
+        confidence="medium",
+    )
+    primary["review_local_index"] = 3
+    duplicate = _finding(
+        finding_id="F-duplicate",
+        source="code-reviewer-b",
+        severity="high",
+        confidence="high",
+    )
+    duplicate["review_local_index"] = 9
+
+    merged = merge_and_dedupe([[primary], [duplicate]])
+
+    assert len(merged) == 1
+    assert merged[0]["review_local_index"] == 3
+    assert merged[0]["finding_id_lineage"] == ["F-primary", "F-duplicate"]
 
 
 def test_build_review_backlog_merges_dedupes_and_decides() -> None:
@@ -496,6 +536,61 @@ def test_synthesize_findings_from_review_markdown_parses_path_and_skips_short_bu
     # v1.2 should not be mistaken for a filesystem path.
     assert second["path"] == "phase_01_plan/plan.md"
     assert second["line"] is None
+    assert validate_findings(findings) == []
+
+
+def test_synthesize_findings_from_review_markdown_preserves_bracketed_review_local_index() -> None:
+    markdown = """
+- [7] High - scripts/quest_runtime/review_intelligence.py:387 - Parser drops review numbering.
+"""
+    findings = synthesize_findings_from_review_markdown(
+        markdown,
+        source="plan-reviewer-a",
+        default_path="phase_01_plan/plan.md",
+    )
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["review_local_index"] == 7
+    assert finding["path"] == "scripts/quest_runtime/review_intelligence.py"
+    assert finding["line"] == 387
+    assert finding["severity"] == "high"
+    assert "[7]" not in finding["summary"]
+    assert validate_findings(findings) == []
+
+
+def test_synthesize_findings_from_review_markdown_preserves_dotted_review_local_index() -> None:
+    markdown = """
+2. Medium - scripts/quest_runtime/review_intelligence.py:401 - Dotted finding index should persist.
+"""
+    findings = synthesize_findings_from_review_markdown(
+        markdown,
+        source="plan-reviewer-b",
+        default_path="phase_01_plan/plan.md",
+    )
+
+    assert len(findings) == 1
+    assert findings[0]["review_local_index"] == 2
+    assert findings[0]["summary"].startswith("Medium -")
+    assert validate_findings(findings) == []
+
+
+def test_synthesize_findings_from_review_markdown_ignores_non_leading_numbers() -> None:
+    markdown = """
+- v1.2 causes edge behavior with no slash path.
+- scripts/v1.2/parser.py:12 Medium issue with versioned path text.
+"""
+    findings = synthesize_findings_from_review_markdown(
+        markdown,
+        source="plan-reviewer-a",
+        default_path="phase_01_plan/plan.md",
+    )
+
+    assert len(findings) == 2
+    assert "review_local_index" not in findings[0]
+    assert "review_local_index" not in findings[1]
+    assert findings[1]["path"] == "scripts/v1.2/parser.py"
+    assert findings[1]["line"] == 12
     assert validate_findings(findings) == []
 
 


### PR DESCRIPTION
## Summary
Add same-day review ergonomics so installed Quest repos get bounded review waits, shared anti-pattern guidance, activation announcements, and preserved review-local finding numbers.
- Keeps the review-decision taxonomy unchanged while extending canonical findings with optional `review_local_index` support.
- Archives the completed quest in `docs/quest-journal/review-ergonomics-batch_2026-04-25.md`.

## Changes
- **Skills**:
  - Add `.skills/review-anti-patterns.md` and reference it from code-reviewer, ci-code-reviewer, plan-reviewer, pr-shepherd, and fixer surfaces.
  - Add activation announcement guidance to `.skills/BOOTSTRAP.md` and review-adjacent skill/agent openers across `.skills`, `.agents`, `.claude`, and `.opencode` mirrors.
  - Add hard polling budgets to pr-shepherd CI waits and ci-code-reviewer comment-fetch waits.
- **Review intelligence runtime**:
  - Preserve optional `review_local_index` values through canonical PR intake and review markdown synthesis.
  - Parse bracketed and numbered review finding markers without making the field required.
- **Manifest and journal**:
  - Add the shared anti-pattern file to `.quest-manifest` for quest_installer propagation.
  - Add the completed quest journal entry and update the journal index.
- **Tests**:
  - Cover numbered finding extraction, validation, merge preservation, and PR intake preservation.

## Validation
- [x] Run `bash scripts/quest_validate-manifest.sh`. Expected: both manifest checks report `[OK]` with no stale entries.
- [x] Run `python3 -m pytest tests/unit/test_review_intelligence.py tests/unit/test_pr_review_cycle.py tests/unit/test_quest_select_tests.py -q`. Expected: `92 passed`.
- [ ] Review `.quest-manifest` and `.skills/review-anti-patterns.md` together. Expected: the new shared rules file is listed in the manifest so repos installed via `quest_installer` receive it.
Watch for: the runtime field is intentionally optional; existing findings without `review_local_index` should continue to validate.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>
