### PR TITLE
Add strong-typing principle to repo standards

### DIFF
--- a/.skills/code-reviewer/SKILL.md
+++ b/.skills/code-reviewer/SKILL.md
@@ -109,6 +109,23 @@ Focus on correctness of the behavior, not micro refactors.
 Review for readability, maintainability, and consistency. See AGENTS.md for coding and architecture philosophy. 
 Strive for simple code that is high quality and easy to read. SRP, DRY, KISS, YAGNI are fundamental pillars to follow.
 
+**Typing discipline**
+
+Prefer clear, concrete types over catch-all / escape-hatch types. This principle is language-agnostic: types and type checking drive quality, and escape hatches should be a deliberate, justified choice rather than a default. When a catch-all is genuinely the best option (boundary deserialization, true generic plumbing, gradual typing of legacy code), expect a one-line comment explaining why.
+
+Per-language reference:
+
+| Language    | Catch-all / escape hatch                                              | Typical concrete alternative                                          |
+|-------------|-----------------------------------------------------------------------|------------------------------------------------------------------------|
+| Python      | `Any`, untyped `dict`/`list`, missing annotations, `# type: ignore`   | precise types, `TypedDict`, `Protocol`, `dataclass`, generics          |
+| TypeScript  | `any`, `as any`, `Object`, `{}`, `Function`                           | `unknown` + narrowing, discriminated unions, generics, `Record<K,V>`   |
+| C#          | `object`, `dynamic`                                                   | concrete class/interface, generics                                     |
+| Java        | `Object`, raw `List` (no `<T>`), `@SuppressWarnings("unchecked")`     | parametric generics, sealed types                                      |
+| C++17       | `void*`, `std::any`, untyped `auto` at API boundaries                 | concrete templates, `std::variant`, strong typedefs                    |
+| Rust        | `Box<dyn Any>`, `mem::transmute`, raw pointers, `unsafe` casts        | enums, `dyn Trait` with concrete bounds, generics                      |
+
+Not all catch-alls are equally lazy. TypeScript `unknown` paired with proper narrowing, and Rust `dyn Trait` with real trait bounds, are usually fine — they preserve type-checker leverage. The lazy patterns are the ones that erase information entirely: `any` / `Any` / raw `Object` / `void*` / `dynamic`. For Python specifically, also flag untyped `dict` / `list` parameters and return types, and overuse of `# type: ignore` (each one should have a comment explaining why the checker is wrong or the fix is deferred).
+
 **Python**
 - Type hints present where expected
 - Clear naming, minimal cleverness
@@ -116,7 +133,6 @@ Strive for simple code that is high quality and easy to read. SRP, DRY, KISS, YA
 - Formatting and lint rules are respected
 
 **JavaScript/TypeScript**
-- Avoid `any` unless justified
 - Async control flow is correct
 - Consistent naming and file structure
 

--- a/.skills/implementer/SKILL.md
+++ b/.skills/implementer/SKILL.md
@@ -65,6 +65,10 @@ Avoid patterns like `getattr(obj, "method", None)` / `hasattr()` / “if callabl
 - If behavior is intentionally optional (plugin/provider boundary), detect capability **once at the boundary** and keep the rest of the code contract-driven.
 - Telemetry/metrics must be best-effort: failures in tracking should never change prompts, retries, or request logic; they should degrade to “no metrics” with clear logs/tests.
 
+### Rule 3c: Prefer concrete types over catch-alls
+
+If you're reaching for a catch-all type (`any`, `Any`, `Object`, `dynamic`, `void*`, `Box<dyn Any>`, untyped `dict` / `list`, etc.), stop and check whether a concrete type would work. If it genuinely wouldn't — boundary deserialization, true generic plumbing, gradual typing of legacy code — leave a one-line comment explaining why. Types and type checking drive quality; escape hatches are a deliberate choice, not a default. See the per-language table in `.skills/code-reviewer/SKILL.md` for what counts as a catch-all in each language.
+
 ### Rule 4: Tests map to acceptance criteria
 
 For each acceptance criterion, ensure at least one of:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ We drive with a quality mindset in everything — planning, reviewing, and build
 - **DRY** (Don't Repeat Yourself) — Extract common patterns, but not prematurely
 - **YAGNI** (You Aren't Gonna Need It) — Don't add features until they're needed
 - **SRP** (Single Responsibility Principle) — Each change, function or module should focusing on doing one thing
+- **Strong typing** — Prefer clear, concrete types over catch-all / escape-hatch types (`any`, `Any`, `Object`, `dynamic`, `void*`, etc.). Escape hatches are a deliberate, justified choice, not a default — types and type checking drive quality. See the per-language table in [`.skills/code-reviewer/SKILL.md`](.skills/code-reviewer/SKILL.md).
 
 ## Change Discipline
 


### PR DESCRIPTION
## Summary
Codify a language-agnostic principle that we prefer concrete types over catch-all / escape-hatch types ("any" and equivalents), elevating "types and type checking drive quality" to a Core Principle alongside KISS / DRY / YAGNI / SRP and giving review + writer skills concrete enforcement guidance.
- Triggered by recent Python and TypeScript code reaching for `Any` / `any` more often than warranted.
- Docs-only: no source, tests, or lint config touched. No new files.

## Changes
- **Documentation — principles**:
  - `AGENTS.md`: add a `Strong typing` bullet to the Core Principles list, linking to the per-language table in the code-reviewer skill.
- **Skills — review**:
  - `.skills/code-reviewer/SKILL.md`: add a `Typing discipline` subsection to Step 3 with a per-language reference table (Python, TypeScript, C#, Java, C++17, Rust), the "not all catch-alls are equally lazy" nuance (TS `unknown` with narrowing and Rust `dyn Trait` with real bounds are usually fine), and Python-specific callouts (untyped `dict`/`list`, overuse of `# type: ignore`). Remove the old TS-only `Avoid \`any\` unless justified` line — folded in, not duplicated.
- **Skills — implementer**:
  - `.skills/implementer/SKILL.md`: add Rule 3c "Prefer concrete types over catch-alls" with writer-facing wording, requiring a one-line justification when a catch-all is genuinely the best option (boundary deserialization, true generic plumbing, gradual typing of legacy code).

## Validation
- [ ] **Re-read the three changed files end-to-end**: Action: open `AGENTS.md`, `.skills/code-reviewer/SKILL.md`, and `.skills/implementer/SKILL.md` in a markdown previewer. Expected: the AGENTS.md Core Principles list ends with the `Strong typing` bullet (≤ 4 lines, link target resolves to `.skills/code-reviewer/SKILL.md`); the code-reviewer Step 3 has a `Typing discipline` block with a 6-row table that renders cleanly and the `Avoid \`any\` unless justified` line is absent; the implementer file has a `Rule 3c` block between Rule 3b and Rule 4.
- [x] **Confirm scope is docs-only**: Action: `git diff --stat main...HEAD`. Expected: exactly three files changed (`AGENTS.md`, `.skills/code-reviewer/SKILL.md`, `.skills/implementer/SKILL.md`), `+22 / -1` lines total, zero new files.
- [x] **Manifest validator**: Action: `./scripts/quest_validate-manifest.sh`. Expected: exits 0 with all-OK output (no Quest-tracked files were added or renamed, so no manifest update should be needed).

Watch for: anchor-link drift if the `.skills/code-reviewer/SKILL.md` filename ever moves — the AGENTS.md bullet links to it by relative path.

## Notes
- Out of scope (separate quests): adding ESLint / mypy / clippy rules to enforce the principle; refactoring existing `any` / `Any` usages in the codebase.
- Quest: `avoid-any-type-guidance_2026-04-25__2236` (solo mode, single plan reviewer + single code reviewer, both approved with no findings).

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>
