### PR TITLE
[SCEPTICAL --- REVIEW THIS WITH YAGNI MINDSET] Add agent skill context guardrails

### DIFF
--- a/ideas/2026-04-13-quest-memory-architecture.md
+++ b/ideas/2026-04-13-quest-memory-architecture.md
@@ -125,6 +125,48 @@ Important KISS rule:
 - do best-effort extraction from existing quest artifacts first
 - add small structured sidecars later only if rebuild-based extraction is too weak or too expensive
 
+## 3A. Per-Quest File Anatomy Index
+
+Add one generated file index per quest:
+
+`.quest/<quest_id>/anatomy.md`
+
+This is not a second memory system. It is a cheap spatial map that helps fresh agents decide what to read.
+
+Minimum contents:
+
+- relative path
+- file size or rough token estimate
+- one-line description from the leading docstring, module comment, package metadata, or a simple fallback
+- `generated_at`
+- `git_sha`
+- `modified_since_generation: true|false` when the file changed after the index was written
+
+Example:
+
+```markdown
+| Path | Estimate | Description | Freshness |
+|---|---:|---|---|
+| scripts/quest_memory_query.py | ~900 tokens | Query local quest memory JSONL records. | fresh |
+| .skills/quest/SKILL.md | ~4,300 tokens | Quest orchestration skill and phase sequence. | changed |
+```
+
+Generation should stay deliberately boring:
+
+1. Use `git ls-files` as the source of truth.
+2. Skip ignored, binary, generated, lock, secret-like, and oversized files.
+3. Extract at most the first useful comment/docstring block.
+4. Fall back to directory and filename hints when no description exists.
+5. Regenerate on quest init and at the Plan -> Build transition.
+
+Agent usage rule:
+
+- Agents may use `anatomy.md` to choose files.
+- Agents must read the actual file before changing it, reviewing it, or relying on subtle behavior.
+- If `modified_since_generation` is true, the anatomy entry is only a routing hint.
+
+This should replace repeated broad tree scans, not code reading. The realistic success target is fewer irrelevant file reads and faster orientation across multi-agent handoffs, not a dramatic universal token-savings claim.
+
 ## 4. Retrieval Rules
 
 Memory is for questions like:
@@ -198,6 +240,7 @@ Start with one small local CLI:
 
 Initial commands:
 
+- `file-anatomy`
 - `similar-quests`
 - `quest-summary`
 - `findings`
@@ -213,6 +256,14 @@ Initial ranking should stay simple:
 - resolved and accepted outcomes ranked above blocked and incomplete ones
 
 Do not build a more complex retrieval layer in the first pass.
+
+Add one anatomy-specific command before any semantic retrieval work:
+
+```text
+python3 scripts/quest_memory_query.py file-anatomy --quest <id> --paths "src/**" --changed-only
+```
+
+This command should print matching anatomy rows and freshness flags. Keep it as a direct local query before adding any heavier retrieval layer.
 
 ## 7. Reflective Summaries
 

--- a/ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
+++ b/ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
@@ -105,11 +105,14 @@ New file: `.quest/memory/team_preferences.jsonl`, append-only. One JSON object p
 {
   "id": "tp_2026-04-22_001",
   "created_at": "2026-04-22T11:00:00Z",
+  "last_seen_at": "2026-04-22T11:00:00Z",
   "source": "user_correction | arbiter_dismissed | reviewer_repeat",
   "confidence": "high | medium | low",
   "pattern": "We prefer functional composition over class hierarchies in src/pipeline/",
   "example_finding_id": "f_2026-04-20_abc",
   "path_glob": "src/pipeline/**",
+  "supporting_quest_ids": ["quest_2026_04_20_pipeline"],
+  "evidence_count": 1,
   "superseded_by": null
 }
 ```
@@ -122,6 +125,16 @@ New file: `.quest/memory/team_preferences.jsonl`, append-only. One JSON object p
 
 Never auto-promote. Never store a preference without a linked originating finding or explicit user command.
 
+#### Update rules
+
+Keep the update path mechanical and auditable:
+
+- If a new event matches an existing active preference, update `last_seen_at`, append the quest id if missing, and increment `evidence_count`.
+- Promote `low -> medium` only after repeated evidence from separate quests or two independent reviewers in one quest.
+- Promote anything to `high` only from explicit user confirmation.
+- Never create a preference from generated prose alone; it needs either a user statement or a structured review/arbiter artifact.
+- Never use preferences to create background "self-improvement" tasks.
+
 #### Read (consumed by every review skill)
 
 `plan-reviewer`, `code-reviewer`, and `ci-code-reviewer` read `team_preferences.jsonl` at start and filter by `path_glob` against files in scope. They render the matching entries into context with hedge language:
@@ -132,6 +145,9 @@ Explicit rendering rules — each SKILL.md body must include:
 
 - **"Render preferences as tendencies, not rules. Never open a review with a preference-only blocker."**
 - **"If a preference contradicts the current plan's stated direction, note it as context, not as a finding."**
+- **"Load at most 5 matching preferences by default, ranked by confidence, evidence_count, and recency."**
+- **"A low-confidence preference can only produce a question or optional note, not a Must-fix finding."**
+- **"A high-confidence preference still needs code evidence before it becomes a blocker."**
 
 #### Prune
 
@@ -140,6 +156,19 @@ Quarterly (or on-demand via `/prune-preferences`), an explicit command walks `te
 #### Why soft preferences
 
 The worst failure mode of any institutional-memory system is turning one grumpy review into eternal gospel. The hedge-language render + confidence scoring + explicit user-promote gate are the anti-dogmatism wiring. Every design decision here should ask "does this make the preference more or less likely to be treated as absolute" and favor less.
+
+#### Measurement
+
+Do not claim preference memory is saving time or tokens until it is measured.
+
+Minimum evaluation for the first implementation:
+
+- Count how many preferences were loaded per review.
+- Count how many loaded preferences produced a finding, question, or no action.
+- Count how many preference-derived findings the arbiter accepted, downgraded, or dismissed.
+- Sample at least 10 reviews before deciding whether to widen capture sources.
+
+The desired outcome is fewer repeated corrections from the user and fewer repeated low-value findings, not a larger memory file.
 
 ### 8. Evaluate fix-loop commit checkpointing  (evaluation — no code yet)
 

--- a/ideas/2026-04-24-quest-hooks-vs-instructions-boundary.md
+++ b/ideas/2026-04-24-quest-hooks-vs-instructions-boundary.md
@@ -250,12 +250,51 @@ Examples:
 - hook blocks an out-of-policy bash command
 - validator proves artifacts and state transitions are still consistent
 
+## Recommendation 7: Keep Hook Features Local And Explicit
+
+The first implementation should stay inside the same local, explicit workflow model Quest already uses:
+
+- explicit commands
+- short hook adapters
+- shared policy scripts
+- append-only local artifacts
+- validators that can be run in CI or by a human
+
+This keeps the runtime easy to inspect and reason about:
+
+1. Policy decisions stay in reviewable scripts and artifacts.
+2. State changes stay tied to visible quest phases.
+3. Warnings, blocks, and validator failures remain distinct in logs.
+
+If a future feature needs a more persistent runtime shape, it should come with a separate design note, an opt-in setup path, and a documented reason a one-shot command is insufficient.
+
+## Recommendation 8: Benchmark Warnings Separately From Enforcement
+
+Hooks that warn are useful, but a warning is not the same as a block.
+
+Any token or efficiency claim must distinguish:
+
+- hook fired
+- agent saw the warning
+- agent changed behavior because of the warning
+- resulting file reads, retries, or review loops were actually reduced
+
+For Quest, the first acceptable measurement is simple:
+
+1. Record broad file reads before and after adding `anatomy.md`.
+2. Record repeated reads of unchanged files within one quest.
+3. Record stale-anatomy cases where the agent had to re-read anyway.
+4. Report observed ranges, not headline percentages.
+
+This keeps the feature honest. It is fine if the first version mainly improves orientation and review focus.
+
 # Suggested Implementation Sequence
 
 ## Phase A: Hook The Low-Risk, High-Signal Guards
 
 1. Branch/directory visibility hook for `Edit|Write`
 2. Allowlist enforcement activation, once role identification and tests are ready
+3. Optional anatomy freshness warning when an agent reads a file marked changed since index generation
 
 ## Phase B: Hook The Strong Path Guard
 

--- a/ideas/2026-04-27-agent-skill-development-guardrails.md
+++ b/ideas/2026-04-27-agent-skill-development-guardrails.md
@@ -1,0 +1,87 @@
+---
+title: Agent Skill Development Guardrails
+purpose: Define the minimum quality bar for new agent skills that read repo context, write local artifacts, or influence tool behavior.
+audience:
+  - quest-maintainers
+  - skill-authors
+scope: Agent skills, hook adapters, generated memory, local indexes, and validation helpers maintained in this repo.
+status: proposed
+date: 2026-04-27
+related:
+  - 2026-04-13-quest-memory-architecture.md
+  - 2026-04-22-review-ergonomics-and-team-preference-memory.md
+  - 2026-04-24-quest-hooks-vs-instructions-boundary.md
+---
+
+# Summary
+
+New agent skills should be small, auditable, and easy to remove.
+
+The default shape is:
+
+1. one clear skill purpose,
+2. explicit local commands,
+3. generated artifacts that can be inspected in a text editor,
+4. tests for any code that mutates state,
+5. measured outcomes before broadening scope.
+
+# Development Rules
+
+Before adding a skill or hook-backed helper:
+
+- Define the user-visible workflow it improves.
+- Keep generated state in a predictable repo-local path.
+- Pin any runtime assumptions to a documented version or capability.
+- Treat prompt templates as executable behavior and review them like code.
+- Separate warnings from enforcement in logs and docs.
+- Add tests for generated memory, hook state, or repo-artifact mutation.
+- Prefer one-shot commands until repeated manual use proves automation is worth it.
+- Keep the first version narrow enough to delete without disrupting unrelated workflows.
+
+# Measurement Rules
+
+Do not claim token, time, or review-quality improvements without a reproducible check.
+
+Minimum evidence:
+
+- benchmark tasks or sample workflows are checked in,
+- baseline and changed behavior are both recorded,
+- warning counts are measured separately from behavior changes,
+- estimator formulas are documented,
+- the result reports a range and caveats, not just a headline percentage.
+
+For the current memory and context proposals, useful first metrics are modest:
+
+- fewer irrelevant file reads,
+- fewer repeated reads of unchanged files,
+- fewer repeated user corrections,
+- fewer repeated low-value review findings.
+
+# Good First Patterns
+
+These fit the current Quest architecture:
+
+- per-quest file anatomy index for agent orientation,
+- confidence-scored team-preference memory,
+- deterministic hook adapters over shared policy scripts,
+- explicit scan and validation commands.
+
+These should remain outside the first version unless a concrete workflow proves the need:
+
+- broad heuristic bug detectors that create noisy findings,
+- runtime-specific behavior without validator backstops,
+- generated reflections that are not tied to a user action or review artifact,
+- expanded UI or reporting surfaces before the artifact files prove useful.
+
+# Acceptance Criteria
+
+This idea is useful when future skill proposals answer these questions before implementation:
+
+1. What exact workflow gets better?
+2. What local files or state does the skill read or write?
+3. What runtime capability does it rely on?
+4. What test proves artifact mutation is correct?
+5. What benchmark or sample workflow proves the claimed benefit?
+6. What is intentionally out of scope for the first version?
+
+If those answers are missing, the proposal is not ready to build.

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -20,6 +20,7 @@ architecture docs.
 | File | Status | Purpose |
 |---|---|---|
 | `quest-policy-canonicalization-and-enforcement-roadmap.md` | in-progress | Canonical plan to reduce policy drift and convert rules into enforced checks. |
+| `2026-04-27-agent-skill-development-guardrails.md` | proposed | Minimum quality, measurement, and scope bar for new repo-local agent skills and hook-backed helpers. |
 | `codex-review-severity-emoji.md` | proposed | Add severity emoji to Codex review inline comments for faster scanning in PR threads. |
 | `handoff-validation-and-failure-ux.md` | in-progress | Add actionable diagnostics when handoff fallback occurs. |
 


### PR DESCRIPTION
## Summary
Adds concrete, repo-local guardrails for agent skill context, memory, and hook-backed helper development.
- Expands existing memory and hook proposals with file anatomy indexing, preference evidence rules, and measurement expectations.
- Adds a focused agent skill development guardrails proposal without tying it to external-tool adoption.

## Changes
- **Memory**:
  - Adds a per-quest file anatomy index proposal to `ideas/2026-04-13-quest-memory-architecture.md`, including freshness metadata and a direct local query command.
  - Clarifies that anatomy entries guide file selection but do not replace reading files before edits or review.
- **Review Preferences**:
  - Adds `last_seen_at`, `supporting_quest_ids`, and `evidence_count` fields to team preference memory.
  - Adds confidence promotion, bounded loading, and measurement rules for preference-derived review behavior.
- **Hooks and Skills**:
  - Reframes hook guidance around local explicit workflows, shared policy scripts, and validator-backed behavior.
  - Adds `ideas/2026-04-27-agent-skill-development-guardrails.md` for small, auditable skill development.

## Validation
- [ ] Run `scripts/quest_validate-manifest.sh`. Expected: all Quest files are listed and no stale manifest entries are reported.
- [ ] Run `git diff --check main...HEAD`. Expected: no whitespace errors.
- [ ] Review `ideas/2026-04-27-agent-skill-development-guardrails.md` and confirm it is framed around repo-local skill development, not external-tool adoption.
Watch for: this is documentation-only; the follow-up implementation work should stay scoped to explicit commands, generated artifacts, and validators before adding broader automation.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>