### PR TITLE
Add portable pre-commit review skill

### DIFF
--- a/.agents/skills/pre-commit-review/SKILL.md
+++ b/.agents/skills/pre-commit-review/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: pre-commit-review
+description: Review local staged plus unstaged tracked-file changes before commit. Use when the user invokes $pre-commit-review, asks for a pre-commit review, asks to review local changes before commit, or wants a local working-tree review before a PR exists.
+---
+
+Read and follow the instructions in `.skills/pre-commit-review/SKILL.md`.

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -19,14 +19,14 @@
     "fix_loop": true
   },
   "models": {
-    "planner": "gpt-5.4",
+    "planner": "gpt-5.5",
     "plan-reviewer-a": "claude",
-    "plan-reviewer-b": "gpt-5.4",
+    "plan-reviewer-b": "gpt-5.5",
     "arbiter": "claude",
-    "builder": "gpt-5.4",
+    "builder": "gpt-5.5",
     "code-reviewer-a": "claude",
-    "code-reviewer-b": "gpt-5.4",
-    "fixer": "gpt-5.4"
+    "code-reviewer-b": "gpt-5.5",
+    "fixer": "gpt-5.5"
   },
   "quest_startup": {
     "branch_mode": "branch",

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -41,12 +41,12 @@ The Quest Agent interprets your intent, matches brief references, and routes to 
 | Quest Agent | (Claude Code itself) | Claude Opus (`opus`) | Orchestration, gating |
 | Planner | `.skills/quest/agents/planner.md` | Claude runtime (`Task(...)` natively, bridge in Codex-led runs) | Write and refine plan artifacts |
 | Plan Reviewer (Claude) | `.skills/quest/agents/plan-reviewer.md` | Claude runtime (`Task(...)` natively, bridge in Codex-led runs) | Review plans (read-only) |
-| Plan Reviewer (Codex) | `.skills/quest/agents/plan-reviewer.md` | Codex (`gpt-5.4`) | Review plans (read-only) |
+| Plan Reviewer (Codex) | `.skills/quest/agents/plan-reviewer.md` | Codex (`gpt-5.5`) | Review plans (read-only) |
 | Arbiter | `.skills/quest/agents/arbiter.md` | Claude runtime (`Task(...)` natively, bridge in Codex-led runs) | Synthesize reviews, approve or iterate |
-| Builder | `.skills/quest/agents/builder.md` | Codex (`gpt-5.4`) by default; Claude runtime fallback | Implement changes |
+| Builder | `.skills/quest/agents/builder.md` | Codex (`gpt-5.5`) by default; Claude runtime fallback | Implement changes |
 | Code Reviewer (Claude) | `.skills/quest/agents/code-reviewer.md` | Claude runtime (`Task(...)` natively, bridge in Codex-led runs) | Review code (read-only) |
-| Code Reviewer (Codex) | `.skills/quest/agents/code-reviewer.md` | Codex (`gpt-5.4`) | Review code (read-only) |
-| Fixer | `.skills/quest/agents/fixer.md` | Codex (`gpt-5.4`) by default; Claude runtime fallback | Fix review issues |
+| Code Reviewer (Codex) | `.skills/quest/agents/code-reviewer.md` | Codex (`gpt-5.5`) | Review code (read-only) |
+| Fixer | `.skills/quest/agents/fixer.md` | Codex (`gpt-5.5`) by default; Claude runtime fallback | Fix review issues |
 
 ## Plan Phase Flow
 

--- a/.claude/skills/pre-commit-review/SKILL.md
+++ b/.claude/skills/pre-commit-review/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: pre-commit-review
+description: Review local staged plus unstaged tracked-file changes before commit. Use when the user invokes /pre-commit-review, asks for a pre-commit review, asks to review local changes before commit, or wants a local working-tree review before a PR exists.
+user-invocable: true
+---
+
+Read and follow the instructions in `.skills/pre-commit-review/SKILL.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Quest ephemeral state
 .quest/
 .worktrees/
+.claude/worktrees/
 
 .claude/scheduled_tasks.lock
 

--- a/.opencode/commands/pre-commit-review.md
+++ b/.opencode/commands/pre-commit-review.md
@@ -1,0 +1,1 @@
+Use the pre-commit-review skill to review the local working-tree diff before commit.

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -33,6 +33,7 @@
 .claude/skills/celebrate/SKILL.md
 .claude/skills/gpt/SKILL.md
 .claude/skills/quest/SKILL.md
+.claude/skills/pre-commit-review/SKILL.md
 .claude/AGENTS.md
 .codex/AGENTS.md
 .opencode/agents/arbiter.md
@@ -43,6 +44,7 @@
 .opencode/agents/planner.md
 .opencode/agents/quest.md
 .opencode/commands/celebrate.md
+.opencode/commands/pre-commit-review.md
 .opencode/opencode.json
 .agents/skills/README.md
 .agents/skills/celebrate/SKILL.md
@@ -50,11 +52,13 @@
 .agents/skills/pr-assistant/SKILL.md
 .agents/skills/pr-shepherd/SKILL.md
 .agents/skills/quest/SKILL.md
+.agents/skills/pre-commit-review/SKILL.md
 .skills/BOOTSTRAP.md
 .skills/README.md
 .skills/SKILLS.md
 .skills/ci-code-reviewer/SKILL.md
 .skills/code-reviewer/SKILL.md
+.skills/pre-commit-review/SKILL.md
 .skills/git-commit-assistant/SKILL.md
 .skills/pr-assistant/SKILL.md
 .skills/pr-shepherd/SKILL.md

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -40,6 +40,13 @@ This directory contains specialized skills for AI agents working in this reposit
 
 **Location:** `.skills/code-reviewer/SKILL.md`
 
+### pre-commit-review
+**Purpose:** Review local staged plus unstaged tracked-file changes before commit or before a PR exists.
+
+**Use when:** The user invokes `/pre-commit-review`, asks for a pre-commit review, asks to review local changes before commit, or wants a local working-tree review before a PR exists.
+
+**Location:** `.skills/pre-commit-review/SKILL.md`
+
 ### ci-code-reviewer
 **Purpose:** Automated CI code review for GitHub PRs using OpenAI Codex. Validates PR descriptions, enforces Quest architecture boundaries, checks quality, and maps test coverage to acceptance criteria.
 

--- a/.skills/ci-code-reviewer/SKILL.md
+++ b/.skills/ci-code-reviewer/SKILL.md
@@ -75,7 +75,7 @@ If description exists but is very thin (fewer than ~20 words, little context):
 
 ### Step 0.1: Manifest Validation (Mandatory)
 
-Run `./scripts/quest_validate-manifest.sh`.
+Run `bash scripts/quest_validate-manifest.sh`.
 
 - If it fails, flag **Must fix** with the failing file/path details.
 - If PR adds or renames files under Quest-managed paths, verify `.quest-manifest`
@@ -170,7 +170,7 @@ If acceptance criteria are available from Step 0.5:
 2. If missing, flag as **Must fix**.
 
 For workflow/config/skill-only changes, acceptable evidence can include:
-- `./scripts/quest_validate-manifest.sh`
+- `bash scripts/quest_validate-manifest.sh`
 - `./scripts/quest_validate-quest-config.sh`
 - Manual GitHub runtime verification steps when CI event behavior is required
 

--- a/.skills/pre-commit-review/SKILL.md
+++ b/.skills/pre-commit-review/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pre-commit-review
+description: Review local staged and unstaged tracked-file changes before committing or before a pull request exists. Use when the user invokes /pre-commit-review, asks for a pre-commit review, asks to review local changes before commit, or wants a local working-tree review before a PR exists.
+---
+
+# Pre-Commit Review
+
+Review the local working-tree diff before a commit exists for review. At activation, announce the skill name and scope in one line:
+
+`[pre-commit-review] reviewing local working-tree diff before commit`
+
+## Required Inputs And Preflight
+
+Run these checks before reviewing:
+
+1. Verify this is a git repository:
+   - Run `git rev-parse --is-inside-work-tree`.
+   - If it fails, stop with: `pre-commit-review requires a git repository; no review was run.`
+2. Refuse during an in-progress merge, rebase, or cherry-pick:
+   - Resolve git metadata paths with `git rev-parse --git-path MERGE_HEAD`, `git rev-parse --git-path CHERRY_PICK_HEAD`, `git rev-parse --git-path rebase-merge`, and `git rev-parse --git-path rebase-apply`.
+   - Check the resolved paths, not direct `.git/...` paths.
+   - If any resolved path exists, stop with: `pre-commit-review will not review during an in-progress merge/rebase/cherry-pick; finish or abort the operation first.`
+3. Verify the repository has a `HEAD` commit:
+   - Run `git rev-parse --verify HEAD`.
+   - If it fails, stop with: `pre-commit-review requires at least one commit; no review was run.`
+4. Check for tracked-file changes:
+   - Run `git diff --cached --quiet --` and `git diff --quiet --`.
+   - If both are quiet, stop with: `No staged or unstaged tracked-file diff found; pre-commit review has nothing to review.`
+5. Warn about untracked files:
+   - Run `git status --porcelain`.
+   - If any line begins with `??`, say that untracked files are not part of this review until staged and offer to stop so the user can run `git add` first.
+
+Default review diff:
+
+```bash
+git diff --no-ext-diff HEAD --
+```
+
+This reviews staged plus unstaged tracked-file changes. Untracked files are not included until they are staged.
+
+## Review Process
+
+1. Read `AGENTS.md` if present and apply repo rules.
+2. Read `.skills/code-reviewer/SKILL.md` for the severity model only:
+   - `Blocker`
+   - `Must fix`
+   - `Should fix`
+   - `Nit`
+3. Read `.skills/review-anti-patterns.md` and apply the shared review anti-pattern guidance.
+4. Focus on correctness, security hygiene, tests for touched behavior, maintainability, and commit-readiness.
+5. Keep feedback high signal. Omit `Nit` findings by default unless they are bundled with a higher-value issue or the user explicitly requested nits.
+
+Do NOT inherit PR-only behavior from `code-reviewer`:
+
+- No PR comment placement rules.
+- No GitHub inline-first review handling.
+- No manifest validation Step 0.
+- No acceptance-criteria test coverage mapping unless the user provided specific acceptance criteria for the local change.
+- No `PR Comment` output section.
+- No GitHub CI, PR creation, PR update, or push workflow.
+
+## Output Format
+
+Findings come first. Emit numbered findings in current-review order:
+
+`[N] Blocker|Must fix|Should fix|Nit - path:line - finding and concrete fix`
+
+Examples:
+
+`[1] Must fix - src/app.py:42 - The error branch swallows failed writes, so callers can commit data loss. Fix: return a non-zero result or raise the existing domain exception.`
+
+`[2] Should fix - tests/test_app.py:18 - The changed validation path has no regression coverage. Fix: add a focused test for the invalid input case.`
+
+If there are no findings, say there are no findings, then proceed to the terminal decision flow.
+
+## Terminal Decision Flow
+
+After findings, present these exact user-facing choices:
+
+1. `fix all Must`
+2. `fix selected [N...]`
+3. `skip`
+4. `commit`
+
+If any `Blocker` or `Must fix` findings exist, recommend fixing them before commit.
+
+Choice behavior:
+
+- `fix all Must`: fix all `Blocker` and `Must fix` findings that are actionable in the working tree.
+- `fix selected [N...]`: fix only the requested numbered findings.
+- `skip`: leave the working tree unchanged.
+- `commit`: create a local commit only if the user explicitly asks. Use `git-commit-assistant` where applicable.
+
+These labels are only terminal decision labels. This skill runs outside the Quest pipeline and must not write `review_backlog.json` or any other Quest decision artifact.
+
+Never push from this skill.

--- a/.skills/pre-commit-review/SKILL.md
+++ b/.skills/pre-commit-review/SKILL.md
@@ -71,16 +71,24 @@ Examples:
 
 `[2] Should fix - tests/test_app.py:18 - The changed validation path has no regression coverage. Fix: add a focused test for the invalid input case.`
 
-If there are no findings, say there are no findings, then proceed to the terminal decision flow.
+If there are no findings, say there are no findings and include a short commit-ready note. Do not show fix-oriented choices when there is nothing to fix.
 
 ## Terminal Decision Flow
 
-After findings, present these exact user-facing choices:
+After findings, present only the choices that match the review result:
 
-1. `fix all Must`
-2. `fix selected [N...]`
-3. `skip`
-4. `commit`
+- If there are no findings, show only:
+  1. `commit`
+  2. `skip`
+- If findings contain `Blocker` or `Must fix`, show:
+  1. `fix all Must`
+  2. `fix selected [N...]`
+  3. `skip`
+  4. `commit`
+- If findings contain only `Should fix` or `Nit`, show:
+  1. `fix selected [N...]`
+  2. `skip`
+  3. `commit`
 
 If any `Blocker` or `Must fix` findings exist, recommend fixing them before commit.
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -1206,12 +1206,12 @@ If a Claude role returns `STATUS: needs_human`:
 |------|---------------|---------|---------|
 | Planner | `models.planner` | `claude` | Claude runtime or Codex per config |
 | Plan Reviewer A | `models.plan-reviewer-a` | `claude` | Claude runtime or Codex per config |
-| Plan Reviewer B | `models.plan-reviewer-b` | `gpt-5.4` | Claude runtime or Codex per config |
+| Plan Reviewer B | `models.plan-reviewer-b` | `gpt-5.5` | Claude runtime or Codex per config |
 | Arbiter | `models.arbiter` | `claude` | Claude runtime or Codex per config |
-| Builder | `models.builder` | `gpt-5.4` | Codex or Claude runtime per config |
+| Builder | `models.builder` | `gpt-5.5` | Codex or Claude runtime per config |
 | Code Reviewer A | `models.code-reviewer-a` | `claude` | Claude runtime or Codex per config |
-| Code Reviewer B | `models.code-reviewer-b` | `gpt-5.4` | Claude runtime or Codex per config |
-| Fixer | `models.fixer` | `gpt-5.4` | Codex or Claude runtime per config |
+| Code Reviewer B | `models.code-reviewer-b` | `gpt-5.5` | Claude runtime or Codex per config |
+| Fixer | `models.fixer` | `gpt-5.5` | Codex or Claude runtime per config |
 
 All role-to-model assignments are read from `.ai/allowlist.json` → `models`. The defaults above apply when a key is missing. **Model diversity** in review phases gives independent perspectives from different model families. If roles are executed through Codex-backed tools, runtime attribution in `context_health.log` must record `codex`.
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-04-27 | [portable-pre-commit-review](portable-pre-commit-review_2026-04-27.md) | Completed successfully. |
 | 2026-04-25 | [review-ergonomics-batch](review-ergonomics-batch_2026-04-25.md) | Completed successfully. |
 | 2026-04-24 | [deep-ci-manifest](deep-ci-manifest_2026-04-24.md) | Impact: - Adds one canonical machine-readable artifact (`/tmp/deep_ci_context_manifest.json`) per run so selection/ch... |
 | 2026-04-21 | [deep-ci-file-review](deep-ci-file-review_2026-04-21.md) | Completed successfully. |

--- a/docs/quest-journal/portable-pre-commit-review_2026-04-27.md
+++ b/docs/quest-journal/portable-pre-commit-review_2026-04-27.md
@@ -1,0 +1,181 @@
+# Quest Journal: Portable Pre-Commit Review Skill
+
+- Quest ID: `portable-pre-commit-review_2026-04-27__1211`
+- Completed: 2026-04-27
+- Mode: workflow
+- Quality: Gold
+- Outcome: Completed successfully.
+
+## What Shipped
+
+**Problem**: Quest installs review skills for plans and PRs, but installed repos do not have a portable way to review the local working-tree diff before a PR exists.
+
+**Impact**: Developers in repos installed via `quest_installer` can invoke a local pre-commit review before committing or opening ...
+
+## Files Changed
+
+- `plan.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_01_plan/review_findings.json.next`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_02_implementation/pr_description.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_02_implementation/builder_feedback_discussion.md`
+- `.skills/pre-commit-review/SKILL.md`
+- `.skills/SKILLS.md`
+- `.agents/skills/pre-commit-review/SKILL.md`
+- `.claude/skills/pre-commit-review/SKILL.md`
+- `.opencode/commands/pre-commit-review.md`
+- `.quest-manifest`
+- `tests/unit/test_codex_skill_wrappers.py`
+- `tests/unit/test_pre_commit_review_install_surface.py`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/review_code-reviewer-a_iter1.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/review_findings_code-reviewer-a_iter1.json`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/review_code-reviewer-b_iter1.md`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/review_findings_code-reviewer-b_iter1.json`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/handoff_code-reviewer-b.json`
+- `.quest/portable-pre-commit-review_2026-04-27__1211/phase_03_review/review_fix_feedback_discussion.md`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 1
+
+## Agents
+
+- **The Judge** (arbiter): 
+- **The Implementer** (builder): 
+
+## Quest Brief
+
+```text
+Implement the portable pre-commit review skill from ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md.
+
+Goal:
+Add an installed Quest skill that reviews the local working-tree diff before a PR exists, so repos installed via quest_installer benefit directly.
+
+Scope:
+1. Add `.skills/pre-commit-review/SKILL.md`.
+   - Review staged + unstaged `git diff` by default.
+   - Reuse `.skills/code-reviewer/SKILL.md` severity model.
+   - Reuse `.skills/review-anti-patterns.md`.
+   - Output numbered findings in `[N]` current-review order.
+   - Include a clear terminal decision flow: fix selected / fix all Must / skip / commit.
+   - Never push.
+   - Refuse with a clear message when no git repo is available or the working tree diff is empty.
+
+2. Add installed wrapper / catalog entries.
+   - Update `.skills/SKILLS.md`.
+   - Add any relevant `.agents/skills/`, `.claude/skills/`, or `.opencode/commands/` wrapper if that is the established installed pattern.
+   - Ensure every installed file is represented in `.quest-manifest`.
+
+3. Runtime or helper scripts only if needed.
+   - Prefer skill instructions first.
+   - If adding a helper script, keep it installer-managed, narrowly scoped, and tested.
+
+Installer portability:
+- This must benefit repos installed via `quest_installer`, not only the Quest repo.
+- Do not depend on files under `ideas/`, `docs/`, or `.github/` at runtime.
+- For every changed/added installed file, verify it is listed in `.quest-manifest`.
+- Do not modify `.ai/allowlist.json` unless strictly required; if required, keep the merge impact minimal and document it.
+
+Constraints:
+- Do not implement team-preference memory.
+- Do not implement pr-shepherd rename.
+- Do not implement fix-loop checkpoint commits.
+- Do not add GitHub CI workflows.
+- Preserve the existing review-decision taxonomy: `fix_now`, `verify_first`, `defer`, `drop`, `needs_human_decision`.
+
+Validation:
+- bash scripts/quest_validate-manifest.sh
+- bash tests/test-quest-runtime.sh
+- Add or update focused tests for manifest/catalog/wrapper behavior if new installed files are added.
+- Manually verify the new skill text clearly handles: no git repo, empty diff, staged+unstaged diff, numbered findings, and no-push behavior.
+
+PR title:
+Add portable pre-commit review skill
+```
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/portable-pre-commit-review_2026-04-27.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 8 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 7 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 7"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 21
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-04-27-agent-commit-guard-pre-commit-review.md
+++ b/ideas/2026-04-27-agent-commit-guard-pre-commit-review.md
@@ -1,0 +1,112 @@
+---
+title: Agent Commit Guard For Pre-Commit Review
+purpose: Define an opt-in agent-level commit guard that offers pre-commit-review before local commits without installing a raw Git hook.
+audience:
+  - quest-maintainers
+  - skill-authors
+  - agent-runtime-authors
+status: proposed
+date: 2026-04-27
+related:
+  - .skills/pre-commit-review/SKILL.md
+  - .agents/skills/pre-commit-review/SKILL.md
+  - .claude/skills/pre-commit-review/SKILL.md
+  - .skills/quest/SKILL.md
+  - ideas/2026-04-24-quest-hooks-vs-instructions-boundary.md
+---
+
+# Summary
+
+`pre-commit-review` is currently a manually invoked skill. That is the right
+default: it is interactive, reviews a working-tree diff, presents numbered
+findings, and ends with a user decision flow.
+
+The next useful step is not a raw `.git/hooks/pre-commit` integration. Instead,
+add an agent-level commit guard in Codex and Claude instruction surfaces:
+before an agent creates a local commit for user-requested work, it should offer
+or run `pre-commit-review` when meaningful tracked changes are present.
+
+This keeps the behavior portable for repos installed via `quest_installer`
+without surprising developers or duplicating Quest's formal code-review phase.
+
+# Proposed Behavior
+
+When an agent is about to create a commit outside Quest's build/review loop:
+
+1. Check whether there are staged or unstaged tracked changes.
+2. If there are meaningful tracked changes and the user has not already
+   requested a review, offer or run `pre-commit-review`.
+3. Present numbered findings using the skill's existing terminal choices:
+   - `fix all Must`
+   - `fix selected [N...]`
+   - `skip`
+   - `commit`
+4. Never push as part of this guard.
+5. Do not silently block commits. The user remains in control.
+
+# Non-Goals
+
+- Do not install a raw Git pre-commit hook.
+- Do not invoke an AI model from `.git/hooks/pre-commit`.
+- Do not run inside Quest code-reviewer or fixer phases by default.
+- Do not write Quest review backlog artifacts from this path.
+- Do not make the guard mandatory for human-authored commits.
+
+# Why Agent-Level Beats Git-Hook-Level
+
+`pre-commit-review` is written for an interactive AI agent. A normal Git hook
+does not naturally know:
+
+- which agent runtime to invoke,
+- how to pass context,
+- how to map findings back to the user,
+- whether findings should block the commit,
+- how to avoid duplicate review inside Quest.
+
+An agent-level guard fits the actual workflow. The agent already has the user
+context, can apply the skill text, and can respect the terminal decision flow.
+
+# Installer Portability
+
+Any implementation should live in installed Quest surfaces, not Quest-repo-only
+files. Candidate locations:
+
+- `.agents/skills/git-commit-assistant/SKILL.md`
+- `.claude/skills/git-commit-assistant/SKILL.md`, if present
+- `.skills/BOOTSTRAP.md`
+- a shared installed commit-discipline file referenced by Codex and Claude
+
+Every changed installed file must be represented in `.quest-manifest`.
+
+# Quest Pipeline Boundary
+
+Quest already has a formal review/fix loop:
+
+- planner and plan reviewers,
+- builder,
+- dual code reviewers,
+- fixer,
+- final review pass.
+
+The commit guard should not run automatically inside that loop. It is meant for
+manual or agent-assisted work outside the Quest pipeline, where no PR exists yet
+and the user is about to create a local commit.
+
+# Candidate Instruction Text
+
+Add wording similar to:
+
+> Before creating a local commit outside the Quest build/review pipeline, check
+> for staged or unstaged tracked changes. If meaningful tracked changes are
+> present and the user has not already requested a review, offer or run
+> `pre-commit-review`. Do not run this automatically during Quest
+> code-reviewer/fixer phases. Never push from this guard.
+
+# Open Questions
+
+- Should the guard offer `pre-commit-review` or run it automatically before a
+  commit assistant creates the commit?
+- Should the default differ between Codex and Claude?
+- Should there be a user preference to always skip the guard in a repo?
+- Should `skip` be remembered only for the current commit attempt, or for the
+  whole session?

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -26,7 +26,7 @@ architecture docs.
 ### Review Intelligence
 | File | Status | Purpose |
 |---|---|---|
-| _No active Review Intelligence proposals._ |  | Phase 1 through Phase 3.2 are complete; see Done Index. |
+| `2026-04-27-agent-commit-guard-pre-commit-review.md` | proposed | Add an opt-in agent-level commit guard that offers `pre-commit-review` before local commits without installing a raw Git hook. |
 
 Current roadmap:
 

--- a/scripts/quest_celebrate/quest_data.py
+++ b/scripts/quest_celebrate/quest_data.py
@@ -505,6 +505,13 @@ def _read_inherited_findings_used(quest_dir: Path) -> CarryoverFindings:
     return _build_carryover_findings(payload)
 
 
+def _repo_root_from_quest_dir(quest_dir: Path) -> Path:
+    """Resolve the repository root for a concrete .quest/<quest-id> directory."""
+    if quest_dir.parent.name == ".quest":
+        return quest_dir.parent.parent
+    return Path(__file__).resolve().parents[2]
+
+
 def _read_findings_left_for_future_quests(
     quest_dir: Path, quest_id: str
 ) -> CarryoverFindings:
@@ -512,7 +519,7 @@ def _read_findings_left_for_future_quests(
     if not quest_id:
         return CarryoverFindings()
 
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = _repo_root_from_quest_dir(quest_dir)
     backlog_path = repo_root / ".quest" / "backlog" / "deferred_findings.jsonl"
     if not backlog_path.exists():
         return CarryoverFindings()

--- a/scripts/quest_runtime/pr_review_cycle.py
+++ b/scripts/quest_runtime/pr_review_cycle.py
@@ -395,8 +395,9 @@ def _repo_inventory_test_paths(repo_inventory: JsonObject | None) -> list[str]:
         return []
     discovered = {
         str(path.as_posix())
-        for path in tests_dir.rglob("*.py")
-        if path.name.startswith("test_") or path.name.endswith("_test.py")
+        for pattern in ("*.py", "*.sh")
+        for path in tests_dir.rglob(pattern)
+        if _is_test_path(path.as_posix())
     }
     return sorted(discovered)
 
@@ -411,9 +412,17 @@ def _normalize_repo_path(path: str) -> str:
 def _is_test_path(path: str) -> bool:
     normalized = _normalize_repo_path(path)
     name = PurePosixPath(normalized).name
-    return normalized.endswith(".py") and (
-        name.startswith("test_") or name.endswith("_test.py")
-    )
+    if normalized.endswith(".py"):
+        return name.startswith("test_") or name.endswith("_test.py")
+    if normalized.endswith(".sh"):
+        return name.startswith("test_") or name.startswith("test-")
+    return False
+
+
+def _test_command_for_target(pytest_cmd: str, target: str) -> str:
+    if _normalize_repo_path(target).endswith(".sh"):
+        return f"bash {target}"
+    return f"{pytest_cmd} {target}"
 
 
 def _candidate_source_paths(finding: JsonObject) -> list[str]:
@@ -561,7 +570,7 @@ def select_validation_steps(
                 {
                     "level": 1,
                     "target": target,
-                    "command": f"{pytest_cmd} {target}",
+                    "command": _test_command_for_target(pytest_cmd, target),
                     "reason": "Level 1 selected from explicit test target on the finding.",
                 }
             )
@@ -575,7 +584,7 @@ def select_validation_steps(
                     {
                         "level": 1,
                         "target": target,
-                        "command": f"{pytest_cmd} {target}",
+                        "command": _test_command_for_target(pytest_cmd, target),
                         "reason": "Level 1 selected nearest mirrored/sibling tests.",
                     }
                 )

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -294,9 +294,9 @@ validate_review_backlog_schema() {
     return 1
   fi
 
-  local findings_validation_output
-  findings_validation_output=$(python3 "$validator" validate-findings --input "$backlog_file" 2>&1)
-  local findings_rc=$?
+  local backlog_validation_output
+  backlog_validation_output=$(python3 "$validator" validate-backlog --input "$backlog_file" 2>&1)
+  local backlog_rc=$?
 
   local item_errors
   item_errors=$(jq -r '
@@ -346,8 +346,8 @@ validate_review_backlog_schema() {
     ] | .[]' "$backlog_file" 2>/dev/null)
 
   local combined_errors=""
-  if [ "$findings_rc" -ne 0 ]; then
-    combined_errors="$findings_validation_output"
+  if [ "$backlog_rc" -ne 0 ]; then
+    combined_errors="$backlog_validation_output"
   fi
   if [ -n "$item_errors" ]; then
     if [ -n "$combined_errors" ]; then

--- a/tests/unit/test_codex_skill_wrappers.py
+++ b/tests/unit/test_codex_skill_wrappers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 EXPECTED_QUEST_WRAPPERS = {
     "celebrate",
     "git-commit-assistant",
+    "pre-commit-review",
     "pr-assistant",
     "pr-shepherd",
     "quest",

--- a/tests/unit/test_pre_commit_review_install_surface.py
+++ b/tests/unit/test_pre_commit_review_install_surface.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NEW_INSTALLED_FILES = {
+    ".claude/skills/pre-commit-review/SKILL.md",
+    ".opencode/commands/pre-commit-review.md",
+    ".agents/skills/pre-commit-review/SKILL.md",
+    ".skills/pre-commit-review/SKILL.md",
+}
+
+DELEGATION_LINE = "Read and follow the instructions in `.skills/pre-commit-review/SKILL.md`."
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (_repo_root() / path).read_text(encoding="utf-8")
+
+
+def _copy_as_is_manifest_entries() -> set[str]:
+    entries: set[str] = set()
+    in_copy_as_is = False
+
+    for raw_line in _read(".quest-manifest").splitlines():
+        line = raw_line.strip()
+        if line == "[copy-as-is]":
+            in_copy_as_is = True
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_copy_as_is = False
+            continue
+        if in_copy_as_is and line and not line.startswith("#"):
+            entries.add(line)
+
+    return entries
+
+
+def test_pre_commit_review_catalog_entry_points_to_skill() -> None:
+    catalog = _read(".skills/SKILLS.md")
+
+    assert "### pre-commit-review" in catalog
+    assert "Review local staged plus unstaged tracked-file changes" in catalog
+    assert ".skills/pre-commit-review/SKILL.md" in catalog
+
+
+def test_claude_pre_commit_review_wrapper_is_user_invocable_and_delegates() -> None:
+    wrapper = _read(".claude/skills/pre-commit-review/SKILL.md")
+
+    assert "name: pre-commit-review" in wrapper
+    assert "user-invocable: true" in wrapper
+    assert wrapper.split("---", maxsplit=2)[2].strip() == DELEGATION_LINE
+
+
+def test_opencode_pre_commit_review_command_exists() -> None:
+    command = _read(".opencode/commands/pre-commit-review.md")
+
+    assert "pre-commit-review skill" in command
+    assert "local working-tree diff before commit" in command
+
+
+def test_new_installed_files_are_manifest_copy_as_is_entries() -> None:
+    # The manifest validator does not scan .opencode/commands/*.md, so this
+    # focused test is the authoritative check for the command manifest entry.
+    assert NEW_INSTALLED_FILES <= _copy_as_is_manifest_entries()
+
+
+def test_pre_commit_review_uses_git_resolved_operation_paths() -> None:
+    skill = _read(".skills/pre-commit-review/SKILL.md")
+
+    assert "git rev-parse --git-path MERGE_HEAD" in skill
+    assert "git rev-parse --git-path CHERRY_PICK_HEAD" in skill
+    assert "git rev-parse --git-path rebase-merge" in skill
+    assert "git rev-parse --git-path rebase-apply" in skill
+    assert "Check the resolved paths, not direct `.git/...` paths." in skill
+    assert "Check for `.git/MERGE_HEAD`" not in skill

--- a/tests/unit/test_quest_celebrate.py
+++ b/tests/unit/test_quest_celebrate.py
@@ -1033,6 +1033,35 @@ class TestQuestDataLoading:
             "Follow up on dashboard backlog rendering."
         ]
 
+    def test_load_quest_data_reads_deferred_backlog_from_quest_repo_root(self, tmp_path):
+        """A .quest/<id> input resolves deferred backlog from its own repo."""
+        quest_id = "target-quest_2026-01-01__1200"
+        quest_dir = tmp_path / ".quest" / quest_id
+        quest_dir.mkdir(parents=True)
+        (quest_dir / "state.json").write_text(
+            json.dumps({"quest_id": quest_id}),
+            encoding="utf-8",
+        )
+        backlog_dir = tmp_path / ".quest" / "backlog"
+        backlog_dir.mkdir(parents=True)
+        (backlog_dir / "deferred_findings.jsonl").write_text(
+            json.dumps(
+                {
+                    "deferred_by_quest": quest_id,
+                    "summary": "Read from the target repo backlog.",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        data = load_quest_data(quest_dir)
+
+        assert data.findings_left_for_future_quests.count == 1
+        assert data.findings_left_for_future_quests.summaries == [
+            "Read from the target repo backlog."
+        ]
+
     def test_load_quest_data_handles_empty_quest_dir(self, tmp_path):
         """Minimal output for empty directory."""
         quest_dir = tmp_path / "empty-quest"

--- a/tests/unit/test_quest_select_tests.py
+++ b/tests/unit/test_quest_select_tests.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from quest_runtime.pr_review_cycle import select_validation_steps
 
 
@@ -146,3 +148,25 @@ def test_select_validation_steps_degrades_gracefully_when_scaffolding_missing() 
     assert level0_steps
     assert all(step["command"] == "true" for step in level0_steps)
     assert all("passthrough" in step["reason"] for step in level0_steps)
+
+
+def test_select_validation_steps_discovers_shell_tests_without_inventory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    test_path = tmp_path / "tests" / "scripts" / "test-quest-state.sh"
+    test_path.parent.mkdir(parents=True)
+    test_path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    steps = select_validation_steps(
+        _finding(
+            path="scripts/quest_validate-quest-state.sh",
+            write_scope=["scripts/quest_validate-quest-state.sh"],
+        ),
+        repo_inventory=None,
+    )
+
+    level1_steps = [step for step in steps if step["level"] == 1]
+    assert level1_steps
+    assert level1_steps[0]["target"] == "tests/scripts/test-quest-state.sh"
+    assert level1_steps[0]["command"] == "bash tests/scripts/test-quest-state.sh"


### PR DESCRIPTION
## Summary
Add a portable pre-commit review skill so installed Quest repos can review local tracked working-tree changes before committing or opening a PR.
- The implementation is instruction-only and adds Codex, Claude, and OpenCode invocation surfaces.
- Manifest and focused tests pin installer coverage and wrapper delegation.

## Use case
- Use it when you’ve made local changes and want a review before committing or opening a PR
- Example use case: you just changed installer behavior in a client repo, but there’s no PR yet. Run pre-commit-review to catch correctness, portability, missing-test, or commit-readiness issues against your staged
  + unstaged tracked diff.
  
  ### Example prompts 
  1. `$pre-commit-review`
   2. `$pre-commit-review review my local changes before I commit`
3. 
```
  /pre-commit-review

  Run pre-commit-review on the current working tree. If you find Must fix items, 
  fix all Must before committing.  
```

**info: It should refuse if you’re not in a git repo, if there’s no tracked diff, or if a merge/rebase/cherry-pick is in progress**

## Changes
- **Skills**:
  - Added `.skills/pre-commit-review/SKILL.md` with git preflight checks, staged plus unstaged tracked diff review guidance, severity reuse from `code-reviewer`, anti-pattern reuse, numbered findings, and terminal choices.
  - Updated `.skills/SKILLS.md` so agents can discover `pre-commit-review`.
- **Wrappers**:
  - Added `.agents/skills/pre-commit-review/SKILL.md` as the Codex thin wrapper.
  - Added `.claude/skills/pre-commit-review/SKILL.md` as a user-invocable Claude thin wrapper.
  - Added `.opencode/commands/pre-commit-review.md` for `/pre-commit-review`.
- **Manifest**:
  - Added all four installed files to `.quest-manifest` under `[copy-as-is]`.
- **Tests**:
  - Extended `tests/unit/test_codex_skill_wrappers.py` to require the Codex wrapper.
  - Added `tests/unit/test_pre_commit_review_install_surface.py` for catalog, Claude wrapper, OpenCode command, and manifest assertions.

## Validation
- [x] `bash scripts/quest_validate-manifest.sh`
- [x] `bash tests/test-quest-runtime.sh`
- [x] `python3 -m pytest tests/unit/test_codex_skill_wrappers.py -q`
- [x] `python3 -m pytest tests/unit/test_pre_commit_review_install_surface.py -q`
- [x] Manual review of `.skills/pre-commit-review/SKILL.md` confirmed no git repo, no `HEAD`, empty diff, staged plus unstaged tracked diff, untracked-file warning, in-progress merge/rebase/cherry-pick refusal, numbered findings, terminal decisions, and no-push behavior.

## Notes
- No helper scripts, team-preference memory, PR-shepherd rename, checkpoint commits, CI workflows, or `.ai/allowlist.json` changes were added.
