### PR TITLE
Add /sharpen skill, plan presentation, and configurable Quest IDs

### DIFF
--- a/.agents/skills/sharpen/SKILL.md
+++ b/.agents/skills/sharpen/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: sharpen
+description: Adversarial interview against a plan, design, or write-up. Use when the user invokes $sharpen, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision.
+---
+
+Read and follow the instructions in `.skills/sharpen/SKILL.md`.

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -33,6 +33,7 @@
     "branch_prefix": "quest/",
     "worktree_root": ".worktrees/quest"
   },
+  "quest_id_format": "slug-first",
   "review_mode": "full",
   "fast_review_thresholds": {
     "max_files": 5,

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -30,6 +30,8 @@ Use the `/quest` command in Claude Code:
 /quest allowlist
 ```
 
+Quest IDs default to `<slug>_YYYY-MM-DD__HHMM`. Repositories may opt into date-first IDs (`YYYY-MM-DD_HHMM__<slug>`) with `quest_id_format` in `.ai/allowlist.json`; resume accepts both formats.
+
 The Quest Agent interprets your intent, matches brief references, and routes to the right phase. If unclear, it asks you — reply in plain English.
 
 **Input quality matters.** Your quest input is the spec. A rough idea works (Quest asks clarifying questions), but providing intent, constraints, and acceptance criteria upfront produces tighter plans with fewer iterations. See the README for examples at each level.

--- a/.ai/quest.md
+++ b/.ai/quest.md
@@ -61,6 +61,8 @@ The Arbiter is the gatekeeper. It enforces KISS, YAGNI, SRP. It prevents nitpick
 
 Max iterations controlled by `gates.max_plan_iterations` in allowlist.
 
+After plan approval, Quest presents a concise executive summary before build starts. You can ask for a phase-by-phase walkthrough, proceed directly, or sharpen the plan. Sharpening is an adversarial Q&A pass: Quest challenges assumptions and tradeoffs one question at a time, records what is settled, and either proceeds or sends concrete revisions back into planning. This improves the plan and also gives the orchestrator a more exact understanding of what will be built before implementation begins.
+
 ## Full Flow
 
 ```

--- a/.ai/schemas/allowlist.schema.json
+++ b/.ai/schemas/allowlist.schema.json
@@ -48,6 +48,10 @@
         "worktree_root": { "type": "string" }
       }
     },
+    "quest_id_format": {
+      "type": "string",
+      "enum": ["slug-first", "date-first"]
+    },
     "review_mode": { "type": "string", "enum": ["auto", "fast", "full"] },
     "fast_review_thresholds": {
       "type": "object",

--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -40,6 +40,7 @@ This repository uses **layered documentation** for AI agent context management.
 - **Building a feature?** → Use `.skills/implementer/` skill
 - **Reviewing an implementation plan?** → Use `.skills/plan-reviewer/` skill
 - **Reviewing code?** → Use `.skills/code-reviewer/` skill
+- **Pressure-test a plan or design?** → Use `/sharpen` command or `.skills/sharpen/` skill
 - **Commit message?** → Use `.skills/git-commit-assistant/` skill
 - **IMPORTANT: For ALL git commits, you MUST invoke the `git-commit-assistant` skill. Do NOT use built-in commit procedures or default Co-Authored-By trailers.**
 - **Create or update a PR?** → Use `.skills/pr-assistant/` skill
@@ -55,6 +56,7 @@ This repository uses **skills** for specialized workflows. Skills are automatica
 - **celebrate:** Play quest completion celebration animation with achievements, metrics, and credits
 - **plan-reviewer:** Review implementation plans and PR specifications for test coverage
 - **code-reviewer:** Review actual code for quality, security, and patterns
+- **sharpen:** Adversarial Q&A against a plan or design — one question at a time with a recommended answer — to surface contradictions and unresolved tradeoffs
 - **implementer:** Step-by-step implementation with traceability
 - **git-commit-assistant:** Generate commit messages from staged diff, match repo conventions, append Quest co-author trailer
 - **pr-assistant:** Create and update GitHub PRs in draft mode, generate title/description from branch commits

--- a/.claude/skills/sharpen/SKILL.md
+++ b/.claude/skills/sharpen/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: sharpen
+description: Adversarial interview against a plan, design, or write-up. Use when the user invokes /sharpen, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision.
+user-invocable: true
+---
+
+Read and follow the instructions in `.skills/sharpen/SKILL.md`.

--- a/.quest-checksums
+++ b/.quest-checksums
@@ -50,7 +50,7 @@ c6e6df271e4ea131bf3b11bb2ce7273ee50bdb4a60bfffee7c5e855cd8478f10  .skills/git-co
 d8aa0b101a64b82d0c440a35bb306c0b37258ed8e2744b1e7281070e513f408d  .skills/plan-maker/SKILL.md
 3fac0c21f5dfd84b5d84886302b389a7a048404b1bbd59b2224e971b4f8fb714  .skills/plan-reviewer/SKILL.md
 82b2fdc3ffc5053cd897276567a87ced79bc1902c713faaef449546364389b2d  .skills/pr-assistant/SKILL.md
-02433cc719ca508dde975e36147e16b5cf055091da08f331a6026a1344fb9b95  .skills/pr-shepherd/SKILL.md
+bbfea008c4cadcb650d72b2d981b7ef67305082cf94ae227a22ebeb03d9a8f2a  .skills/pr-shepherd/SKILL.md
 068822b36a32a2a945e646edc204920e82ad8374b8b63dcae63a19473852778a  .skills/quest/SKILL.md
 e1cef5bb261421226a8007f88aab5cac0295b16f4044735856305c155a952376  .skills/quest/agents/README.md
 69e5a590f02e66343efdfb2a8ba1090e32d3b5bbe56cf2151093b280138dc013  .skills/quest/agents/arbiter.md

--- a/.quest-checksums
+++ b/.quest-checksums
@@ -50,7 +50,7 @@ c6e6df271e4ea131bf3b11bb2ce7273ee50bdb4a60bfffee7c5e855cd8478f10  .skills/git-co
 d8aa0b101a64b82d0c440a35bb306c0b37258ed8e2744b1e7281070e513f408d  .skills/plan-maker/SKILL.md
 3fac0c21f5dfd84b5d84886302b389a7a048404b1bbd59b2224e971b4f8fb714  .skills/plan-reviewer/SKILL.md
 82b2fdc3ffc5053cd897276567a87ced79bc1902c713faaef449546364389b2d  .skills/pr-assistant/SKILL.md
-cdbb53fd2a3f685f6fcada7f131878275b57568f42c7f181463105f60055df28  .skills/pr-shepherd/SKILL.md
+02433cc719ca508dde975e36147e16b5cf055091da08f331a6026a1344fb9b95  .skills/pr-shepherd/SKILL.md
 068822b36a32a2a945e646edc204920e82ad8374b8b63dcae63a19473852778a  .skills/quest/SKILL.md
 e1cef5bb261421226a8007f88aab5cac0295b16f4044735856305c155a952376  .skills/quest/agents/README.md
 69e5a590f02e66343efdfb2a8ba1090e32d3b5bbe56cf2151093b280138dc013  .skills/quest/agents/arbiter.md

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -34,6 +34,7 @@
 .claude/skills/gpt/SKILL.md
 .claude/skills/quest/SKILL.md
 .claude/skills/pre-commit-review/SKILL.md
+.claude/skills/sharpen/SKILL.md
 .claude/AGENTS.md
 .codex/AGENTS.md
 .opencode/agents/arbiter.md
@@ -53,6 +54,7 @@
 .agents/skills/pr-shepherd/SKILL.md
 .agents/skills/quest/SKILL.md
 .agents/skills/pre-commit-review/SKILL.md
+.agents/skills/sharpen/SKILL.md
 .skills/BOOTSTRAP.md
 .skills/README.md
 .skills/SKILLS.md

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -109,11 +109,6 @@ scripts/quest_backfill_journal.py
 scripts/quest_complete.py
 scripts/quest_preflight.sh
 scripts/quest_state.py
-tests/integration/test-enforce-allowlist.sh
-tests/test-quest-preflight.sh
-tests/test-quest-runtime.sh
-tests/test-validate-handoff-contracts.sh
-tests/test-validate-quest-state.sh
 
 [user-customized]
 # These files preserve local customizations; AGENTS.md updates in place only when

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -90,6 +90,7 @@ scripts/quest_runtime/__init__.py
 scripts/quest_runtime/artifacts.py
 scripts/quest_runtime/claude_runner.py
 scripts/quest_runtime/pr_review_cycle.py
+scripts/quest_runtime/quest_ids.py
 scripts/quest_runtime/review_intelligence.py
 scripts/quest_runtime/state.py
 scripts/quest_celebrate/__init__.py

--- a/.quest-manifest
+++ b/.quest-manifest
@@ -67,6 +67,7 @@
 .skills/plan-reviewer/SKILL.md
 .skills/review-anti-patterns.md
 .skills/celebrate/SKILL.md
+.skills/sharpen/SKILL.md
 .skills/gpt/SKILL.md
 .skills/quest/SKILL.md
 .skills/quest/delegation/questioner.md

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -106,7 +106,7 @@ This directory contains specialized skills for AI agents working in this reposit
 ### sharpen
 **Purpose:** Adversarial interview against a plan, design, or write-up — one question at a time, each with a recommended answer attached — to surface contradictions, hidden assumptions, and unresolved tradeoffs before they ship.
 
-**Use when:** The user invokes `/sharpen`, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision. Also invoked from Quest's plan presentation menu (Step 3.5).
+**Use when:** The user invokes `/sharpen` or `$sharpen`, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision.
 
 **Location:** `.skills/sharpen/SKILL.md`
 

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -103,6 +103,13 @@ This directory contains specialized skills for AI agents working in this reposit
 
 **Location:** `.skills/celebrate/SKILL.md`
 
+### sharpen
+**Purpose:** Adversarial interview against a plan, design, or write-up — one question at a time, each with a recommended answer attached — to surface contradictions, hidden assumptions, and unresolved tradeoffs before they ship.
+
+**Use when:** The user invokes `/sharpen`, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision. Also invoked from Quest's plan presentation menu (Step 3.5).
+
+**Location:** `.skills/sharpen/SKILL.md`
+
 ## How Skills Work
 
 Skills use a three-level loading system:

--- a/.skills/celebrate/SKILL.md
+++ b/.skills/celebrate/SKILL.md
@@ -20,7 +20,7 @@ Play a rich, visually stunning celebration for a completed quest.
 
 If the user provides an argument:
 1. If it's a full path (starts with `/` or `.`), use it directly
-2. If it looks like a quest ID (e.g., `name-resolution_2026-03-04__1954`), look in:
+2. If it looks like a quest ID (e.g., `name-resolution_2026-03-04__1954` or `2026-03-04_1954__name-resolution`), look in:
    - `.quest/<id>/` (active quest)
    - `.quest/archive/<id>/` (archived quest)
    - `docs/quest-journal/` for a matching filename (journaled quest)

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -21,6 +21,24 @@ Use **inline-first** commenting by default.
 2. Push the branch to origin.
 3. Create a **draft** PR via `gh pr create --draft`.
 
+### Step 1.5: Commit/Push Context Guard
+Before every commit or push performed by this skill, verify that the local
+workspace still matches the PR branch:
+
+1. Run `git status --short --branch`.
+2. Run `git branch --show-current`.
+3. Run `gh pr view <PR_NUMBER> --json headRefName --jq .headRefName`.
+4. Confirm the current branch exactly matches the PR `headRefName`.
+5. If shepherding from a known worktree, verify the current directory/repo root
+   is that worktree before committing.
+6. If branch or workspace verification fails, stop and ask the user to confirm
+   the intended workspace before editing, committing, or pushing.
+
+This guard is mandatory before:
+- the initial commit/push in Step 1,
+- any CI-fix commit/push in Step 3,
+- any review-comment fix commit/push in Step 4 or Step 4.4.
+
 ### Step 2: Wait for CI
 Use a hard polling budget for CI waits:
 - `interval_seconds = 30`
@@ -34,7 +52,7 @@ Loop:
 
 ### Step 3: Evaluate CI Results
 - **All checks pass** → proceed to Step 4.
-- **Failures** → read the failing job logs (`gh run view <RUN_ID> --log-failed`), diagnose the root cause, fix it, commit, push, and loop back to Step 2.
+- **Failures** → read the failing job logs (`gh run view <RUN_ID> --log-failed`), diagnose the root cause, write a one-sentence diagnosis note naming the failing check, root cause, and intended fix, run the Step 1.5 context guard, fix it, commit, push, and loop back to Step 2.
 
 ### Step 4: Check PR Comments
 1. Fetch **inline** review comments: `gh api repos/{owner}/{repo}/pulls/{pr}/comments`
@@ -71,6 +89,7 @@ Run the review loop through the canonical review-intelligence pipeline. **Order 
 6. Execute one batch at a time:
    - Apply only that batch's `fix_now` / `verify_first` items.
    - Run validation steps in order (Level 0 → Level 1 → Level 2 when present).
+   - Before committing or pushing the batch, run the Step 1.5 context guard.
    - Push once after that batch validates.
 7. Classify loop stop after each cycle:
    - `python3 scripts/quest_review_intelligence.py classify-pr-stop --ci-state <green|failing|pending|unknown> --actionable <count> --iteration <n> --backlog <review_backlog.json>`

--- a/.skills/pr-shepherd/SKILL.md
+++ b/.skills/pr-shepherd/SKILL.md
@@ -27,8 +27,10 @@ workspace still matches the PR branch:
 
 1. Run `git status --short --branch`.
 2. Run `git branch --show-current`.
-3. Run `gh pr view <PR_NUMBER> --json headRefName --jq .headRefName`.
-4. Confirm the current branch exactly matches the PR `headRefName`.
+3. If a PR already exists, run `gh pr view <PR_NUMBER> --json headRefName --jq .headRefName`.
+4. If a PR already exists, confirm the current branch exactly matches the PR
+   `headRefName`; otherwise, before PR creation, confirm the current branch is
+   the intended branch for this PR.
 5. If shepherding from a known worktree, verify the current directory/repo root
    is that worktree before committing.
 6. If branch or workspace verification fails, stop and ask the user to confirm

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -21,7 +21,7 @@ When starting, say: "Now I understand the Quest." Then proceed.
 
 ### Step 1: Resume Check
 
-If the user provides a quest ID (matches pattern `*_YYYY-MM-DD__HHMM`):
+If the user provides a quest ID matching either supported Quest ID format (`<slug>_YYYY-MM-DD__HHMM` or `YYYY-MM-DD_HHMM__<slug>`):
 1. Read `.quest/<id>/state.json` and resume from the recorded phase
 2. Delegate to `delegation/workflow.md`
 
@@ -178,14 +178,18 @@ Before creating the quest folder, present the routing classification to the user
      - `branch`
      - `branch_mode`
      - `worktree_path` (if present)
-4. Create `.quest/<slug>_YYYY-MM-DD__HHMM/` with subfolders:
+4. Read `quest_id_format` from `.ai/allowlist.json` using `quest_runtime.quest_ids.load_quest_id_format`; missing config defaults to `slug-first`.
+5. Create the Quest ID with `quest_runtime.quest_ids.format_quest_id(slug, timestamp, quest_id_format)`:
+   - Default slug-first: `<slug>_YYYY-MM-DD__HHMM`
+   - Optional date-first: `YYYY-MM-DD_HHMM__<slug>`
+6. Create `.quest/<id>/` with subfolders:
    `phase_01_plan/`, `phase_02_implementation/`, `phase_03_review/`, `logs/`
-5. Write quest brief to `.quest/<id>/quest_brief.md` including:
+7. Write quest brief to `.quest/<id>/quest_brief.md` including:
    - User input (original prompt)
    - Questioner summary (if questioning occurred)
    - **Router classification JSON** (the final routing decision that sent the quest to workflow). This is the classification produced by the most recent router evaluation — if the router ran twice (once before questioning, once after), record the second (final) classification.
-6. Copy `.ai/allowlist.json` to `.quest/<id>/logs/allowlist_snapshot.json`
-7. Initialize `state.json`:
+8. Copy `.ai/allowlist.json` to `.quest/<id>/logs/allowlist_snapshot.json`
+9. Initialize `state.json`:
    ```json
    {
      "quest_id": "<id>",

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -554,24 +554,62 @@ After plan approval, present the plan interactively before proceeding to build.
 
 **On entry:** Transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition presenting --status in_progress --expect-phase plan_reviewed` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually.
 
-**1. Show Brief Summary:**
-   Extract a 1-3 sentence summary using this precedence:
-   - **Primary:** Extract from the plan's Overview section (the "Problem" and "Impact" lines)
-   - **Fallback 1:** If no Overview section exists, use the first non-heading paragraph of the plan (skip YAML frontmatter, skip lines starting with `#`)
-   - **Fallback 2:** If no suitable paragraph found, display: "See plan for details:"
+**1. Show Executive Summary:**
+   Extract a five-section executive summary from `.quest/<id>/phase_01_plan/plan.md`. Each section has a precedence chain — pull the first match. Omit any section whose source isn't present. Do NOT fabricate content for a missing section.
 
-   Then display:
-   - "Plan approved! Here's a brief summary:"
-   - The extracted summary (or fallback text)
-   - "Full plan available at: .quest/<id>/phase_01_plan/plan.md"
-   - Arbiter verdict summary (NEXT line only)
-   - Ask: "Would you like to see the detailed phase-by-phase walkthrough? (yes/no)"
+   a. **Problem (1–2 lines)** — pull from `## Overview` → `## Problem` → first non-heading paragraph of the plan (skip YAML frontmatter, skip lines starting with `#`).
+   b. **Approach (2–4 lines)** — pull from `## Approach` → `## Strategy` → `## Solution` → first paragraph of `## Implementation`.
+   c. **Scope (3–6 bullets)** — extract from `## Files`, the phase headers (`### Phase N:` / `## Phase N:` / `**Phase N:**`), or numbered change sections (`### Change N:` / `#### Change N:`). One bullet per file or phase title.
+   d. **Acceptance Criteria (top 3)** — first three items from `## Acceptance Criteria`. If more exist, append `+N more — see plan` as a fourth bullet.
+   e. **Risks / Open Questions (0–3 bullets)** — pull from `## Risks` → `## Open Questions` → `## Tradeoffs`. If no such section exists in the plan, omit this entire heading and append the line `Plan does not document risks — consider sharpening.` immediately after the Acceptance Criteria block.
 
-**2. Handle Response:**
-   - If user declines ("no", "n", "nope", "skip", "proceed", etc.) -> Transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition presentation_complete --status complete --expect-phase presenting` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to Step 4 (Build Phase)
-   - If user accepts ("yes", "y", "yeah", "sure", "detailed", etc.) -> Continue to phase extraction
+   Render as:
+   ```
+   ═══ Plan Summary: <quest title or slug> ═══
 
-**3. Extract Phases from Plan:**
+   Problem
+     <text>
+
+   Approach
+     <text>
+
+   Scope
+     • <bullet>
+     • ...
+
+   Acceptance Criteria (top 3)
+     • <ac>
+     • ...
+
+   Risks / Open Questions
+     • <bullet>
+     • ...
+
+   Full plan: .quest/<id>/phase_01_plan/plan.md
+   Arbiter verdict: <NEXT line from arbiter handoff>
+   ═══════════════════════════════════════════
+   ```
+   Target ~150–300 words across the five sections combined. Always print the header bar, the artifact path footer, and the arbiter NEXT line. Always print the closing bar last.
+
+**2. Offer the Plan Presentation Menu:**
+   After the executive summary, ask exactly:
+   ```
+   How would you like to proceed?
+     1. Walk me through it phase by phase
+     2. Sharpen the plan with me — I'll challenge assumptions and tradeoffs (Q&A, ~5–10 questions)
+     3. Looks good, proceed to build
+   ```
+   STOP and wait for the human to respond. Do not assume a default.
+
+**3. Handle Menu Response:**
+   - **Option 1 (walkthrough)** — also matches `walk`, `walkthrough`, `phases`, `detail`, `detailed`, `yes`: Continue to substep 4 (Phase Extraction). After the walkthrough completes (substep 7's last-phase branch), return here and re-show the menu **with option 1 removed** (only options 2 and 3 remain). Repeat handling.
+   - **Option 2 (sharpen)** — also matches `sharpen`, `grill`, `stress`, `challenge`: Invoke the `/sharpen` skill (`.skills/sharpen/SKILL.md`) against `.quest/<id>/phase_01_plan/plan.md`. When sharpen completes, read its structured exit summary (Resolved / Open / Next):
+     - If the **Next** field says `no changes needed` (or equivalent — no revisions listed): Transition state atomically `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition presentation_complete --status complete --expect-phase presenting` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to Step 4. **Sharpen completion is terminal — do not re-show the menu.**
+     - If the **Next** field lists revisions (e.g. `re-plan with these revisions: …`): Jump to substep 8 (Change Handling) using the **sharpen entry path**. Substep 8(a) is skipped; substep 8(b) writes the sharpen-format block to user_feedback.md.
+   - **Option 3 (proceed)** — also matches `proceed`, `build`, `looks good`, `ship it`, `no`, `n`, `skip`: Transition state atomically `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition presentation_complete --status complete --expect-phase presenting` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to Step 4 (Build Phase).
+   - **Unrecognized response:** Re-ask the menu once. If still unrecognized, treat as Option 3.
+
+**4. Extract Phases from Plan:**
    Parse plan.md to identify phases using these patterns (in order of precedence):
 
    a. **Explicit phase headers** - Look for:
@@ -591,7 +629,7 @@ After plan approval, present the plan interactively before proceeding to build.
       - Treat entire Implementation section as a single phase
       - Display with title "Implementation Overview"
 
-**4. Extract Per-Phase Acceptance Criteria:**
+**5. Extract Per-Phase Acceptance Criteria:**
    For each identified phase, extract acceptance criteria using these patterns:
 
    a. **Per-phase AC subheading** - Look within each phase section for:
@@ -606,39 +644,57 @@ After plan approval, present the plan interactively before proceeding to build.
       - Display global acceptance criteria from the plan's main `## Acceptance Criteria` section
       - Prefix with: "This phase contributes to the following acceptance criteria:"
 
-**5. Present Each Phase:**
+**6. Present Each Phase:**
    For each phase:
    a. Display phase title (e.g., "Phase 1: Add Presentation Logic")
    b. Display phase description/goal (first paragraph of phase section)
    c. Display key implementation details:
       - Files to change (look for file paths or "Files:" subsection)
       - Functions to add/modify (look for function names or "Key Functions:" subsection)
-   d. Display acceptance criteria for this phase (from step 4)
+   d. Display acceptance criteria for this phase (from substep 5)
    e. Ask: "Questions about this phase? Or changes you'd like to request? (continue/question/change)"
 
-**6. Handle Phase Response:**
-   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: Transition state atomically: `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition presentation_complete --status complete --expect-phase presenting` — if this fails, report the validation error to the user and STOP. Do NOT modify state.json manually. Then proceed to Step 4
+**7. Handle Phase Response:**
+   - If "continue" (or "c", "next", "ok", "looks good", etc.) -> Move to next phase, or if last phase: walkthrough is complete — return to substep 2 (the menu) **with option 1 (walkthrough) removed** (only options 2 and 3 remain). Re-render the executive summary header is NOT required; jump straight to the reduced menu.
    - If "question" (or "q", "?", user asks a question directly) -> Answer the question using plan context, then re-ask: "Any other questions, or ready to continue? (continue/question/change)"
-   - If "change" (or "modify", "revise", "update", user requests a change directly) -> Proceed to Change Handling
+   - If "change" (or "modify", "revise", "update", user requests a change directly) -> Proceed to substep 8 (Change Handling) via the walkthrough entry path.
 
-**7. Change Handling:**
-   When user requests changes:
-   a. Prompt user: "Please describe the changes you'd like:"
-   b. Record the user's response
-   c. Create or append to `.quest/<id>/phase_01_plan/user_feedback.md`:
-      ```
-      ## Change Request (Iteration <plan_iteration + 1>)
-      Date: <timestamp>
-      Phase: <current phase number or "General">
-      Request: <user's change request verbatim>
-      ```
-   d. **Update state:** `phase: plan`, `status: in_progress`
-   e. Display: "Re-running plan with your feedback..."
-   f. Return to Step 3, item 1:
-      - Planner will be invoked with user_feedback.md referenced (per Step 3, item 2 -- Planner invocation above)
+**8. Change Handling:**
+   This substep has two entry paths:
+   - **Walkthrough entry** (from substep 7's "change" branch): the user describes changes interactively.
+   - **Sharpen entry** (from substep 3's option 2 when sharpen surfaced revisions): the structured sharpen output is the change request.
+
+   Steps:
+   a. (Walkthrough entry only) Prompt the user: "Please describe the changes you'd like:" and record their response verbatim.
+   b. Append to `.quest/<id>/phase_01_plan/user_feedback.md`:
+      - **Walkthrough format:**
+        ```
+        ## Change Request (Iteration <plan_iteration + 1>)
+        Date: <timestamp>
+        Phase: <current phase number or "General">
+        Request: <user's change request verbatim>
+        ```
+      - **Sharpen format:**
+        ```
+        ## Sharpen Outcome (Iteration <plan_iteration + 1>)
+        Date: <timestamp>
+
+        Resolved:
+        <sharpen "Resolved" block verbatim>
+
+        Open:
+        <sharpen "Open" block verbatim>
+
+        Next:
+        <sharpen "Next" block verbatim>
+        ```
+   c. **Update state:** `phase: plan`, `status: in_progress`
+   d. Display: "Re-running plan with your feedback..."
+   e. Return to Step 3, item 1:
+      - Planner will be invoked with user_feedback.md referenced (per Step 3, item 2 — Planner invocation above)
       - plan_iteration increments as normal
       - Full review cycle (Claude slot A + Codex slot B + Arbiter) runs
-      - After approval, Step 3.5 presentation starts fresh from step 1
+      - After approval, Step 3.5 presentation starts fresh from substep 1
 
 ### Step 4: Build Phase
 

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -586,10 +586,10 @@ After plan approval, present the plan interactively before proceeding to build.
      • ...
 
    Full plan: .quest/<id>/phase_01_plan/plan.md
-   Arbiter verdict: <NEXT line from arbiter handoff>
+   Verdict: <workflow mode: NEXT line from arbiter handoff; solo mode: Reviewer A next after solo remapping>
    ═══════════════════════════════════════════
    ```
-   Target ~150–300 words across the five sections combined. Always print the header bar, the artifact path footer, and the arbiter NEXT line. Always print the closing bar last.
+   Target ~150–300 words across the five sections combined. Always print the header bar and the artifact path footer. In workflow mode, print the arbiter NEXT line. In solo mode, print Reviewer A's next value after solo remapping. Always print the closing bar last.
 
 **2. Offer the Plan Presentation Menu:**
    After the executive summary, ask exactly:

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -237,7 +237,7 @@ This log is how we measure whether the handoff.json pattern is working. It is di
 
 ### Step 0: Resume Check
 
-If the user provides a quest ID (matches pattern `*_YYYY-MM-DD__HHMM`):
+If the user provides a quest ID matching either supported Quest ID format (`<slug>_YYYY-MM-DD__HHMM` or `YYYY-MM-DD_HHMM__<slug>`):
 
 1. Check if `.quest/<id>/state.json` exists
 2. If yes, read it and resume from the recorded phase

--- a/.skills/sharpen/SKILL.md
+++ b/.skills/sharpen/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: sharpen
+description: Adversarial interview against a plan, design, or write-up — one question at a time, with a recommended answer attached to each — to surface contradictions, hidden assumptions, and unresolved tradeoffs before they ship. Use when the user types /sharpen, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision. Also invoked by Quest's plan presentation menu.
+user-invocable: true
+---
+
+# Skill: Sharpen
+
+Pressure-test the artifact under discussion. Walk the decision tree branch by branch. Surface contradictions, hidden assumptions, orphaned design intent, and unresolved tradeoffs before they bite at month 3.
+
+The point is shared understanding — agent and human aligned on what's actually settled, what's still soft, and what needs to change before this ships.
+
+## On entry
+
+Read the artifact (the path the user supplied, or the artifact already in context). Then:
+
+1. Estimate how many decision branches it has. Commit to a question count. Hard cap at 12.
+2. Announce: `Sharpening <artifact>. Estimated ~N questions.`
+3. Skip questions you can answer by reading the file or any other source. Don't waste the user's attention on facts already on disk.
+
+## Each question
+
+- **One at a time.** Never batch. The user must answer fully before the next one lands.
+- **Take a position.** Provide your own recommended answer with each question. The signal lives in whether the user agrees, corrects, or hesitates — not in "what do you think?".
+- **Walk the tree, don't ping-pong.** Resolve one branch fully before moving to a sibling. If the user's answer changes a downstream decision, follow that branch to its leaves before backing up.
+- **Adversarial, not flattering.** Try to break the artifact. Best questions are the ones the user doesn't want to answer.
+- **Footer every question** with `(Q<n> of ~<N>, <pct>% — <one-word topic>)` so the user sees progress and the current branch.
+- **Revise the estimate at most once** if a deep branch opens up. Say so explicitly: `(Q5 of ~9 — revised, 56% — naming)`. Don't let the count drift quietly.
+- **Track open vs locked.** When a sub-decision is resolved, name it as resolved out loud and move on. Don't re-litigate.
+
+## On exit
+
+When the tree is walked, emit a structured summary:
+
+1. **Resolved** — decisions locked, one-line rationale each.
+2. **Open** — questions that surfaced but weren't settled, ranked by importance.
+3. **Next** — one concrete action. Either `no changes needed` or `re-plan with these revisions: …` (list them).
+
+Then ask once: `Anything I missed before we wrap?` If yes, address it and re-emit the summary. If no, done.
+
+## When NOT to invoke
+
+- The user wants you to *write* the artifact, not pressure-test one — use a planning skill instead.
+- The artifact is too vague to challenge. Say so: `Not enough surface to sharpen yet — sketch the decision points first.`
+- A quick yes/no question.
+
+## Style
+
+Direct. Opinionated. No hedging. Short questions, short follow-ups. Restate the tree state periodically so the user can see what's locked and what's open.

--- a/.skills/sharpen/SKILL.md
+++ b/.skills/sharpen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sharpen
-description: Adversarial interview against a plan, design, or write-up — one question at a time, with a recommended answer attached to each — to surface contradictions, hidden assumptions, and unresolved tradeoffs before they ship. Use when the user types /sharpen, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision. Also invoked by Quest's plan presentation menu.
+description: Adversarial interview against a plan, design, or write-up - one question at a time, with a recommended answer attached to each - to surface contradictions, hidden assumptions, and unresolved tradeoffs before they ship. Use when the user invokes /sharpen or $sharpen, says "sharpen this", "stress-test this", "find the holes", "challenge my plan", or wants to confirm shared understanding before locking a decision.
 user-invocable: true
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You → Planner → Reviewers → Arbiter ──→ Builder → Reviewers → Ar
                           GATE: you approve                        GATE: you approve
 ```
 
-**Where you spend your time:** The beginning and the end. You shape the plan, approve it, then validate the built result. Most follow-up quests and v2 ideas come from this post-build validation, not from planning, because you don't fully understand a feature until you see it built. Quest handles the middle.
+**Where you spend your time:** The beginning and the end. You shape the plan, approve it, then validate the built result. Before build starts, Quest now presents a concise plan summary and can work with you to sharpen it diligently: challenging assumptions, walking tradeoffs, and locking down what will actually be built. That improves the plan and, as a useful side effect, gives the orchestrator a sharper understanding of the implementation before it hands work to the builder. Quest handles the middle.
 
 For lighter tasks, **solo mode** uses a single reviewer, same pipeline, fewer stages, faster turnaround.
 
@@ -58,7 +58,7 @@ $quest "Add a loading skeleton to the user list"
 
 
 
-That's it. Quest evaluates complexity, asks clarifying questions if needed, and routes to solo or full workflow. You approve at each gate.
+That's it. Quest evaluates complexity, asks clarifying questions if needed, and routes to solo or full workflow. Before implementation, you get a plan summary menu: walk through the phases, sharpen the plan with adversarial Q&A, or proceed to build. You approve at each gate.
 
 **Recommended:** Add [Codex CLI](https://developers.openai.com/codex/cli/) for dual-model reviews. See the [Setup Guide](docs/guides/quest_setup.md) for full instructions including Codex as orchestrator (BETA). To use Quest as a global Codex skill outside a specific repo, see [Installing Quest for Codex](docs/guides/codex-quest-install.md).
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Say **"just go with it"** anytime to skip questions and proceed with assumptions
 /quest feature-x_2026-02-04__1430
 /quest feature-x_2026-02-04__1430 "re-plan using only claude"
 /quest feature-x_2026-02-04__1430 "re-plan using gpt-5.2"
+/quest 2026-02-04_1430__feature-x
 
 # Point to specs, tickets, or docs
 /quest "implement docs/specs/notifications.md"
@@ -95,6 +96,8 @@ Say **"just go with it"** anytime to skip questions and proceed with assumptions
 /quest "migrate to SQLite, zero-downtime, dual-write pattern"
 /quest "migrate to SQLite, minimal changes, feature-flag cutover"
 ```
+
+Quest IDs default to `feature-x_2026-02-04__1430`; set `quest_id_format` to `date-first` in `.ai/allowlist.json` to create new IDs like `2026-02-04_1430__feature-x`. Resume accepts both formats.
 
 Abort anytime, resume later. State persists in `.quest/<id>/state.json`.
 

--- a/docs/guides/quest_analysis.md
+++ b/docs/guides/quest_analysis.md
@@ -54,6 +54,7 @@ Quest isn't a black box you kick off and hope for the best:
 ```bash
 # Resume a quest from where you left off
 /quest feature-x_2026-02-04__1430
+/quest 2026-02-04_1430__feature-x
 
 # Resume and give new direction
 /quest feature-x_2026-02-04__1430 "skip codex, only use claude for reviews"

--- a/docs/guides/quest_input_routing.md
+++ b/docs/guides/quest_input_routing.md
@@ -25,7 +25,7 @@ This guide explains the routing logic, what the questioning phase looks like, ho
 
 ### Path 1: Resume an Existing Quest
 
-If your argument looks like a quest ID (e.g., `feature-x_2026-02-04__1430`), Quest picks up where you left off. It reads the saved state and jumps to the right phase — whether that's planning, building, reviewing, or showing a completed summary.
+If your argument looks like a quest ID (e.g., `feature-x_2026-02-04__1430` or `2026-02-04_1430__feature-x`), Quest picks up where you left off. It reads the saved state and jumps to the right phase — whether that's planning, building, reviewing, or showing a completed summary.
 
 ### Path 2: Detailed Input — Complexity Routing
 

--- a/docs/guides/quest_presentation.md
+++ b/docs/guides/quest_presentation.md
@@ -263,6 +263,8 @@ Quest state survives conversation restarts:
 
 Resume with: `/quest feature-x_2026-02-02__1430`
 
+Quest resume accepts both supported ID formats: `<slug>_YYYY-MM-DD__HHMM` and `YYYY-MM-DD_HHMM__<slug>`.
+
 ### Audit Trail
 
 All artifacts preserved in `.quest/<id>/`:

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -196,8 +196,11 @@ Key sections to customize:
 | `role_permissions.*.bash` | Shell commands each role can run (test runners, build tools) |
 | `auto_approve_phases` | Which phases run without human confirmation |
 | `models.arbiter` | Set to `"claude"` or `"gpt-5.4"` to choose arbiter runtime |
+| `quest_id_format` | `slug-first` (default) or `date-first`; affects only new Quest folder names |
 | `review_mode` | `auto` (default), `fast`, or `full` for Codex reviews |
 | `fast_review_thresholds` | File/LOC thresholds used when `review_mode: auto` |
+
+Quest IDs use `<slug>_YYYY-MM-DD__HHMM` by default. Set `"quest_id_format": "date-first"` to create new quests as `YYYY-MM-DD_HHMM__<slug>` for chronological `.quest/` sorting. Existing folders are not renamed, and resume accepts both formats in mixed repositories.
 
 
 ### 2. Gitignore

--- a/ideas/2026-04-29-research-fanout-skill.md
+++ b/ideas/2026-04-29-research-fanout-skill.md
@@ -32,11 +32,12 @@ to justify fan-out.
 Create a standalone `research` or `quest-research` skill that:
 
 1. Accepts a topic, source list, and optional lenses.
-2. Dispatches bounded read-only research agents in parallel.
-3. Requires each agent to write a concise memo with explicit claims and
+2. Clarifies the scope and direction before dispatching agents.
+3. Dispatches bounded read-only research agents in parallel.
+4. Requires each agent to write a concise memo with explicit claims and
    evidence.
-4. Runs a reconciler after all memos finish.
-5. Writes a recommendation artifact that the user or Quest planner can consume.
+5. Runs a reconciler after all memos finish.
+6. Writes a recommendation artifact that the user or Quest planner can consume.
 
 The planner should not freely spawn unbounded subagents. It should either:
 
@@ -45,6 +46,27 @@ The planner should not freely spawn unbounded subagents. It should either:
 
 This keeps the planner focused on producing a plan while the skill owns
 fan-out discipline, artifact paths, reconciliation, and reporting.
+
+# Scope Clarification
+
+Before spawning research agents, the skill should ask questions until it has a
+reasonable understanding of the requested scope and direction.
+
+Rules:
+
+- Ask at least one clarifying question for every research invocation.
+- Continue asking follow-up questions while the answers materially affect
+  lens choice, source selection, comparison criteria, or recommendation shape.
+- Prefer one focused question at a time unless batching two or three questions
+  clearly reduces back-and-forth without making the prompt harder to answer.
+- Stop asking once the skill can state the research goal, boundaries, likely
+  lenses, and expected decision output in concrete terms.
+- Hard cap: 5 clarification questions. At the cap, summarize the current
+  understanding and ask whether to continue clarifying or start research with
+  explicit assumptions.
+
+This mirrors Quest's interactive planning posture: clarify enough to avoid
+wasted work, but do not let research setup become an unbounded interview.
 
 # Example Invocation
 

--- a/ideas/2026-04-29-research-fanout-skill.md
+++ b/ideas/2026-04-29-research-fanout-skill.md
@@ -1,0 +1,232 @@
+---
+title: Research Fan-Out Skill
+purpose: Define a reusable research skill that can be invoked directly by users or by Quest planners when planning depends on parallel investigation.
+audience:
+  - quest-maintainers
+  - skill-authors
+  - quest-users
+status: proposed
+date: 2026-04-29
+related:
+  - .skills/quest/agents/planner.md
+  - .skills/quest/delegation/workflow.md
+  - docs/quest-journal/thin-orchestrator_2026-02-09.md
+  - ideas/2026-04-15-subagent-path-constraints-hardening.md
+---
+
+# Summary
+
+Quest planning sometimes depends on research that is naturally parallel:
+reviewing external docs, reading local markdown, comparing sibling repos,
+mapping dependency surfaces, surveying migration costs, or pressure-testing a
+proposal from multiple perspectives.
+
+Today the planner is effectively one research/planning agent. That keeps the
+pipeline simple, but it underuses parallelism on research-heavy quests. The
+better direction is a reusable research skill: humans can invoke it directly,
+and the Quest planner can request it when research lanes are independent enough
+to justify fan-out.
+
+# Proposal
+
+Create a standalone `research` or `quest-research` skill that:
+
+1. Accepts a topic, source list, and optional lenses.
+2. Dispatches bounded read-only research agents in parallel.
+3. Requires each agent to write a concise memo with explicit claims and
+   evidence.
+4. Runs a reconciler after all memos finish.
+5. Writes a recommendation artifact that the user or Quest planner can consume.
+
+The planner should not freely spawn unbounded subagents. It should either:
+
+- invoke the research skill with a bounded set of lenses, or
+- ask the orchestrator to run the research skill before final plan synthesis.
+
+This keeps the planner focused on producing a plan while the skill owns
+fan-out discipline, artifact paths, reconciliation, and reporting.
+
+# Example Invocation
+
+```text
+I want to evaluate [TOPIC]. Spawn 6 parallel research subagents with these
+distinct lenses: (1) security/threat-model auditor, (2)
+performance/scalability skeptic, (3) developer ergonomics advocate, (4)
+competitive landscape analyst, (5) migration-cost estimator, (6)
+maintenance-burden forecaster. Each writes a 500-word memo to
+.research/<lens>.md with explicit claims and evidence. Then run a 7th
+'reconciler' agent that reads all six, identifies points of agreement,
+surfaces contradictions as numbered DECISIONS_NEEDED, and produces
+RECOMMENDATION.md with a confidence score. Don't ask me anything until the
+reconciler has run.
+```
+
+# Artifact Layout
+
+Standalone use:
+
+```text
+.research/<topic-slug>/
+  manifest.json
+  security.md
+  performance.md
+  ergonomics.md
+  competitive-landscape.md
+  migration-cost.md
+  maintenance-burden.md
+  RECOMMENDATION.md
+```
+
+Quest use:
+
+```text
+.quest/<id>/phase_01_plan/research/
+  manifest.json
+  <lens>.md
+  RECOMMENDATION.md
+```
+
+# Manifest Contract
+
+```json
+{
+  "topic": "short topic",
+  "mode": "standalone | quest",
+  "requested_lenses": ["security", "performance"],
+  "agents_spawned": 2,
+  "reconciler_ran": true,
+  "artifacts": [
+    ".quest/<id>/phase_01_plan/research/security.md",
+    ".quest/<id>/phase_01_plan/research/performance.md",
+    ".quest/<id>/phase_01_plan/research/RECOMMENDATION.md"
+  ],
+  "decisions_needed": 1,
+  "confidence": "low | medium | high"
+}
+```
+
+# Research Memo Contract
+
+Each lens memo should be short and structured:
+
+```markdown
+# <Lens> Memo
+
+## Claims
+- [claim with evidence source/path]
+
+## Evidence
+- [file path, URL, repo path, command output summary, or explicit observation]
+
+## Risks
+- [risk or uncertainty]
+
+## Recommendation
+[one paragraph]
+```
+
+Default target length: 300-700 words. Long raw notes should be avoided; link to
+source files or URLs instead.
+
+# Reconciler Contract
+
+`RECOMMENDATION.md` should include:
+
+- `## Executive Recommendation`
+- `## Points of Agreement`
+- `## Contradictions`
+- `## DECISIONS_NEEDED`
+- `## Confidence`
+- `## Sources`
+
+Contradictions that require human judgment should be numbered:
+
+```markdown
+## DECISIONS_NEEDED
+1. [decision] — why it matters, which memos disagree
+```
+
+# Planner Integration
+
+The Quest planner may request research fan-out when all are true:
+
+- the quest has meaningful research uncertainty,
+- the research lanes are independent,
+- the result will materially change the plan,
+- the added latency is justified by risk or scope.
+
+The planner should avoid research fan-out for:
+
+- simple bug fixes,
+- narrow refactors with obvious local context,
+- tasks where one repo search is enough,
+- questions that require immediate human clarification instead of research.
+
+When used inside Quest, the final `plan.md` should include:
+
+```markdown
+## Research Inputs
+- .quest/<id>/phase_01_plan/research/RECOMMENDATION.md
+- .quest/<id>/phase_01_plan/research/security.md
+- .quest/<id>/phase_01_plan/research/performance.md
+
+Summary: [how the research changed the plan]
+```
+
+Step 7 completion should mention:
+
+- number of research agents spawned,
+- whether a reconciler ran,
+- path to `RECOMMENDATION.md`,
+- count of `DECISIONS_NEEDED`.
+
+# Defaults And Limits
+
+- Default lenses: choose 3 based on the topic.
+- Common lenses: security, performance, developer ergonomics, migration cost,
+  maintenance burden, dependency mapping, competitive landscape, test strategy.
+- Default max agents: 3.
+- Soft cap: 6 agents when the user or planner provides clear lenses.
+- Hard cap: 8 agents unless the user explicitly overrides.
+- Research agents are read-only except for their assigned memo path.
+- Reconciler is the only writer for `RECOMMENDATION.md`.
+- The orchestrator should retain paths and one-line summaries, not full memo
+  content, preserving the thin-orchestrator rule.
+
+# Risks
+
+| Risk | Mitigation |
+|---|---|
+| Research sprawl | Require a bounded lens list and concise memo contract. |
+| Duplicated work | Planner/orchestrator assigns non-overlapping lenses. |
+| Context bloat | Store memos on disk; pass paths, not full content. |
+| Wrong artifact paths | Use fixed output paths and post-run path validation. |
+| Weak synthesis | Always run a reconciler; planner consumes `RECOMMENDATION.md`, not six raw memos alone. |
+| Slower planning | Use only when research uncertainty materially affects the plan. |
+
+# Implementation Sketch
+
+1. Add `.skills/research/SKILL.md` with the workflow above.
+2. Register it in `.skills/SKILLS.md`.
+3. Add lightweight wrappers for `.agents/skills/research/SKILL.md` and
+   `.claude/skills/research/SKILL.md` if this should be installed across
+   runtimes.
+4. Update `.quest-manifest` and `.quest-checksums` for installed skill files.
+5. Update `.skills/quest/agents/planner.md` to say the planner may request the
+   research skill for research-heavy planning, but should not run unbounded
+   ad hoc fan-out.
+6. Update `.skills/quest/delegation/workflow.md` to report research fan-out
+   artifacts in completion summaries when present.
+7. Add path-compliance checks for `.quest/<id>/phase_01_plan/research/**`
+   before the planner consumes the research output.
+
+# Open Questions
+
+- Should the first implementation be standalone-only before Quest planner
+  integration?
+- Should web browsing be an explicit per-invocation permission, or simply a
+  source type the skill can use when the runtime supports it?
+- Should `DECISIONS_NEEDED` block plan creation, or should the planner make
+  explicit assumptions and continue?
+- Should research outputs be archived into `docs/quest-journal/` or remain only
+  in the quest archive?

--- a/ideas/2026-04-29-research-fanout-skill.md
+++ b/ideas/2026-04-29-research-fanout-skill.md
@@ -54,11 +54,11 @@ distinct lenses: (1) security/threat-model auditor, (2)
 performance/scalability skeptic, (3) developer ergonomics advocate, (4)
 competitive landscape analyst, (5) migration-cost estimator, (6)
 maintenance-burden forecaster. Each writes a 500-word memo to
-.research/<lens>.md with explicit claims and evidence. Then run a 7th
-'reconciler' agent that reads all six, identifies points of agreement,
+.research/<topic-slug>/<lens>.md with explicit claims and evidence. Then run a
+7th 'reconciler' agent that reads all six, identifies points of agreement,
 surfaces contradictions as numbered DECISIONS_NEEDED, and produces
-RECOMMENDATION.md with a confidence score. Don't ask me anything until the
-reconciler has run.
+.research/<topic-slug>/RECOMMENDATION.md with a confidence score. Don't ask me
+anything until the reconciler has run.
 ```
 
 # Artifact Layout

--- a/ideas/2026-04-29-test-driven-bug-fix-loops.md
+++ b/ideas/2026-04-29-test-driven-bug-fix-loops.md
@@ -1,0 +1,181 @@
+---
+title: Test-Driven Bug-Fix Iteration Loops
+purpose: Define a safer Quest bug-fix mode that proves reproduction first, tries bounded distinct strategies, and preserves failed-attempt evidence without destructive rollback.
+audience:
+  - quest-maintainers
+  - skill-authors
+  - quest-users
+status: proposed
+date: 2026-04-29
+related:
+  - AGENTS.md
+  - .skills/quest/agents/fixer.md
+  - .skills/implementer/SKILL.md
+  - ideas/2026-04-22-review-ergonomics-and-team-preference-memory.md
+  - ideas/2026-04-15-claude-insights-priorities.md
+---
+
+# Summary
+
+Quest already has the core bug-fix rule:
+
+> Bug fixes: add a test that reproduces the bug (fails first), fix the code
+> without changing that test, then re-run it to verify it passes.
+
+The suggested improvement is a stronger bug-fix loop for hard bugs:
+
+1. Convert the bug report into a failing test first.
+2. Generate a small set of distinct fix strategies before editing production
+   code.
+3. Try strategies one at a time against the same failing test.
+4. Preserve failed-attempt evidence.
+5. Stop after a hard cap instead of endlessly tweaking the same approach.
+
+This is valuable, but should not be implemented with automatic
+`git reset --hard`. Quest routinely works in dirty user worktrees and
+multi-agent worktrees; destructive rollback can erase unrelated work. Use
+explicit checkpoints, isolated worktrees, or patch snapshots instead.
+
+# Value
+
+High for ambiguous or recurring bugs where agents tend to loop on near-miss
+patches.
+
+Medium or low for simple, obvious bug fixes where the existing failing-test
+rule is enough.
+
+This mode improves:
+
+- proof that the bug was reproduced before fixing,
+- auditability of failed attempts,
+- avoidance of same-strategy thrash,
+- final PR confidence because the reproduction test stays stable.
+
+# Risks
+
+| Risk | Mitigation |
+|---|---|
+| Overhead on simple bugs | Trigger only for explicit bug reports, reproduced failures, or when the fixer fails once. |
+| Test encodes the wrong behavior | Require the test to quote or reference the bug report and fail for the observed misbehavior. |
+| Strategy theater | Limit to 2-3 materially different strategies with one-sentence rationales. |
+| Destructive rollback | Do not use `git reset --hard`; use worktrees, commits, or patch snapshots. |
+| Hiding useful partial progress | Preserve attempt notes, test output, and diffs before discarding a failed strategy. |
+| Infinite loops | Hard cap attempts and stop with evidence when all fail. |
+
+# Recommended Behavior
+
+Add an optional bug-fix mode for Quest fixer/builder flows:
+
+1. Confirm the task is a bug fix.
+2. Write or identify the narrow failing test that reproduces the bug.
+3. Run only the reproduction test and record the failing output.
+4. Generate up to three distinct strategy candidates before editing production
+   code.
+5. Try each strategy in sequence.
+6. After each attempt:
+   - run the reproduction test,
+   - record pass/fail,
+   - if it fails, preserve the diff and test output,
+   - revert only the attempted changes using a safe mechanism.
+7. When the reproduction test passes:
+   - run targeted related tests,
+   - run the broader validation suite required by the plan,
+   - record the winning strategy and tests in the handoff.
+8. If all attempts fail, stop and report:
+   - failing test path,
+   - output per strategy,
+   - hypothesis for why strategies failed,
+   - suggested next question or diagnostic.
+
+# Safe Rollback Options
+
+Preferred options, in order:
+
+1. **Dedicated worktree per attempt** for larger or riskier bugs.
+2. **Temporary checkpoint commit** before each attempt, reverted with normal
+   Git operations after preserving evidence.
+3. **Patch snapshot** using `git diff > .quest/<id>/phase_03_review/attempts/<strategy>.patch`
+   plus explicit file restoration only for files touched by that attempt.
+
+Avoid:
+
+- `git reset --hard` in shared or dirty worktrees,
+- deleting untracked files automatically,
+- changing the reproduction test after production-code attempts begin.
+
+# Artifact Layout
+
+```text
+.quest/<id>/phase_03_review/bug_fix_attempts/
+  reproduction.md
+  strategies.md
+  strategy_a.patch
+  strategy_a_test_output.txt
+  strategy_b.patch
+  strategy_b_test_output.txt
+  strategy_c.patch
+  strategy_c_test_output.txt
+  summary.md
+```
+
+`reproduction.md` should include:
+
+- bug report excerpt or source,
+- expected behavior,
+- observed behavior,
+- test path,
+- initial failing command and output summary.
+
+`strategies.md` should include:
+
+```markdown
+## Strategy A
+Rationale: ...
+
+## Strategy B
+Rationale: ...
+
+## Strategy C
+Rationale: ...
+```
+
+`summary.md` should include:
+
+- winning strategy, or `none`,
+- attempts made,
+- test commands run,
+- remaining uncertainty,
+- files changed.
+
+# Integration Points
+
+Minimal first step:
+
+- Update `.skills/quest/agents/fixer.md` to expand the existing bug-fix
+  responsibility into a bounded prove-it loop when the fix is non-trivial.
+- Update `.skills/implementer/SKILL.md` with a bug-fix mode subsection.
+
+Larger later step:
+
+- Add helper script support for attempt directories and patch snapshots.
+- Add completion-summary reporting for bug-fix attempts.
+- Consider a standalone `bug-fix-loop` skill only if the pattern proves useful
+  outside Quest.
+
+# Non-Goals
+
+- Do not make every bug fix use three strategies.
+- Do not require commits for every attempt in normal Quest runs.
+- Do not auto-open PRs from this mode.
+- Do not bypass Quest review/fix loops.
+- Do not use destructive rollback.
+
+# Open Questions
+
+- Should the loop trigger immediately for every explicit bug report, or only
+  after the first ordinary fix attempt fails?
+- Should attempt artifacts live under phase 02 for builder-discovered bugs and
+  phase 03 for reviewer/fixer bugs?
+- Should a passing reproduction test be allowed if the broader suite still
+  fails for unrelated reasons?
+- Should the strategy cap be 2 or 3 by default?

--- a/ideas/2026-04-29-test-driven-bug-fix-loops.md
+++ b/ideas/2026-04-29-test-driven-bug-fix-loops.md
@@ -1,6 +1,6 @@
 ---
-title: Test-Driven Bug-Fix Iteration Loops
-purpose: Define a safer Quest bug-fix mode that proves reproduction first, tries bounded distinct strategies, and preserves failed-attempt evidence without destructive rollback.
+title: Test-Driven Bug-Fix Loop Skill
+purpose: Define a dedicated bug-fix-loop skill that proves reproduction first, tries bounded distinct strategies, and preserves failed-attempt evidence without destructive rollback.
 audience:
   - quest-maintainers
   - skill-authors
@@ -22,7 +22,12 @@ Quest already has the core bug-fix rule:
 > Bug fixes: add a test that reproduces the bug (fails first), fix the code
 > without changing that test, then re-run it to verify it passes.
 
-The suggested improvement is a stronger bug-fix loop for hard bugs:
+The suggested improvement should be a dedicated `bug-fix-loop` skill, not only
+extra prose inside the Quest fixer. It should be independently invokable by a
+human, Codex, Claude, or the Quest workflow whenever a bug fix needs a tighter
+test-driven loop.
+
+The skill owns a stronger bug-fix process for hard bugs:
 
 1. Convert the bug report into a failing test first.
 2. Generate a small set of distinct fix strategies before editing production
@@ -35,6 +40,27 @@ This is valuable, but should not be implemented with automatic
 `git reset --hard`. Quest routinely works in dirty user worktrees and
 multi-agent worktrees; destructive rollback can erase unrelated work. Use
 explicit checkpoints, isolated worktrees, or patch snapshots instead.
+
+# Skill Shape
+
+Add a standalone skill, likely `.skills/bug-fix-loop/SKILL.md`, with thin
+wrappers for each runtime that should expose it:
+
+- `.agents/skills/bug-fix-loop/SKILL.md`
+- `.claude/skills/bug-fix-loop/SKILL.md` if Claude-side invocation is needed
+
+The skill should be usable in three ways:
+
+- **Direct human invocation:** "Use bug-fix-loop for this bug report."
+- **Agent invocation:** Codex or Claude may invoke it when a bug fix is
+  ambiguous, recurring, or has already failed once.
+- **Quest workflow invocation:** Quest builder/fixer can call the skill when a
+  plan item or review finding is a bug fix and the normal one-pass fix path is
+  likely to thrash.
+
+The skill should not auto-open PRs, auto-merge, or bypass Quest review gates.
+It produces code changes plus artifacts; the caller remains responsible for the
+normal commit, PR, CI, and review flow.
 
 # Value
 
@@ -64,7 +90,7 @@ This mode improves:
 
 # Recommended Behavior
 
-Add an optional bug-fix mode for Quest fixer/builder flows:
+The `bug-fix-loop` skill should:
 
 1. Confirm the task is a bug fix.
 2. Write or identify the narrow failing test that reproduces the bug.
@@ -105,6 +131,8 @@ Avoid:
 
 # Artifact Layout
 
+Quest invocation:
+
 ```text
 .quest/<id>/phase_03_review/bug_fix_attempts/
   reproduction.md
@@ -117,6 +145,29 @@ Avoid:
   strategy_c_test_output.txt
   summary.md
 ```
+
+Standalone invocation:
+
+```text
+.bug-fix-loop/<bug-slug>_<YYYY-MM-DD_HHMM>/
+  reproduction.md
+  strategies.md
+  strategy_a.patch
+  strategy_a_test_output.txt
+  strategy_b.patch
+  strategy_b_test_output.txt
+  strategy_c.patch
+  strategy_c_test_output.txt
+  summary.md
+```
+
+Recommendation: use `.quest/<id>/...` when an active Quest exists, because the
+bug-fix evidence belongs with the plan/review/build history. If there is no
+active Quest, use `.bug-fix-loop/<bug-slug>_<timestamp>/` at the repo root. That
+keeps standalone runs discoverable without pretending they are Quest phases.
+If the project later wants a single global artifact root, `.worktrees/` and
+`.research/` should remain separate; bug-fix attempts have different lifecycle
+and cleanup expectations.
 
 `reproduction.md` should include:
 
@@ -151,16 +202,25 @@ Rationale: ...
 
 Minimal first step:
 
-- Update `.skills/quest/agents/fixer.md` to expand the existing bug-fix
-  responsibility into a bounded prove-it loop when the fix is non-trivial.
-- Update `.skills/implementer/SKILL.md` with a bug-fix mode subsection.
+- Add `.skills/bug-fix-loop/SKILL.md` with the workflow above.
+- Register it in `.skills/SKILLS.md`.
+- Add runtime wrappers for `.agents/skills/bug-fix-loop/SKILL.md` and, if
+  needed, `.claude/skills/bug-fix-loop/SKILL.md`.
+- Update `.quest-manifest` and `.quest-checksums` for installed skill files.
+- Update `.skills/quest/agents/fixer.md` so Quest fixer may invoke the
+  `bug-fix-loop` skill for non-trivial bug fixes or after one failed ordinary
+  fix attempt.
+- Update `.skills/implementer/SKILL.md` to point bug-fix work at the
+  standalone skill instead of duplicating the whole loop.
+- Update `.skills/quest/delegation/workflow.md` so build/fix handoffs mention
+  bug-fix-loop artifacts when the skill was used.
 
 Larger later step:
 
 - Add helper script support for attempt directories and patch snapshots.
 - Add completion-summary reporting for bug-fix attempts.
-- Consider a standalone `bug-fix-loop` skill only if the pattern proves useful
-  outside Quest.
+- Add optional cleanup/listing commands for standalone `.bug-fix-loop/*`
+  artifacts once usage patterns are clear.
 
 # Non-Goals
 
@@ -179,3 +239,5 @@ Larger later step:
 - Should a passing reproduction test be allowed if the broader suite still
   fails for unrelated reasons?
 - Should the strategy cap be 2 or 3 by default?
+- Should standalone `.bug-fix-loop/*` artifacts be gitignored by default, or
+  committed when they provide useful review evidence?

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -42,6 +42,7 @@ Current roadmap:
 | File | Status | Purpose |
 |---|---|---|
 | `2026-04-24-quest-hooks-vs-instructions-boundary.md` | proposed | Define the boundary between instruction files, hooks, and scripts for Quest, with Claude-first enforcement and Codex-aware adapter guidance. |
+| `2026-04-29-research-fanout-skill.md` | proposed | Add a reusable research fan-out skill for human-triggered and planner-requested parallel investigation with reconciled findings. |
 | `dual-model-planning.md` | proposed | Explore parallel plan generation with arbiter synthesis instead of a single planner output. |
 | `2026-04-13-codex-companion-runtime.md` | proposed | Phased prove-it roadmap for a shared Codex runtime serving both the human `/gpt` command surface and Quest orchestration, with strict go/no-go criteria after the minimum slice. |
 | `2026-04-13-feedback-intent-routing.md` | proposed | Canonical feedback-routing proposal: classify live quest feedback by intent and route to clarify, replan, second-opinion, or escalation paths deliberately. |
@@ -71,6 +72,7 @@ Current roadmap:
 | `2026-04-15-precommit-status-diffstat-discipline.md` | proposed | Pre-commit staging verification discipline with optional bounded hook. |
 | `2026-04-15-subagent-path-constraints-hardening.md` | proposed | Hardening plan for sub-agent path constraints and output-path validation. |
 | `2026-04-15-tool-failure-two-attempt-cap.md` | proposed | Two-attempt cap rule for failing tool investigations to limit rabbit-holing. |
+| `2026-04-29-test-driven-bug-fix-loops.md` | proposed | Safer bug-fix mode: failing test first, bounded distinct strategies, preserved attempt evidence, and no destructive rollback. |
 | `2026-04-15-autonomous-pr-shepherd-headless.md` | idea | Long-horizon autonomous PR shepherd design with strict safety boundaries. |
 
 ### Graduated

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ Build and utility scripts for the Quest repository.
 | `quest_runtime/` | Python package with Quest orchestration helpers (state updates, Claude bridge runner, handoff polling). |
 | `quest_runtime/review_intelligence.py` | Canonical review-finding schema validation, dedupe/merge helpers, decision backlog policy, deferred JSONL append, and planner backlog scan matching. |
 | `quest_runtime/pr_review_cycle.py` | PR-cycle helpers for canonical intake normalization, actionable batch construction, validation-step selection, loop-stop classification, and cap retagging. |
-| `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running Quest validators plus the shipped smoke-test surface. |
+| `quest_checks/` | Python package that provides the installed `quest-checks` CLI for running Quest validators. |
 | `quest_claude_bridge.py` | Thin transport bridge from the current host into Claude CLI for Codex-led Claude-designated Quest roles. |
 | `quest_preflight.sh` | Checks second-model readiness before quest routing. Codex-led Claude probes now retain a recent successful host probe under `.quest/cache/` so later quest starts can reuse it. |
 | `quest_claude_probe.py` | Probes the Claude bridge by requiring a real artifact write and `handoff.json` under the quest logs directory. |

--- a/scripts/quest_celebrate/animations.py
+++ b/scripts/quest_celebrate/animations.py
@@ -25,6 +25,7 @@ from quest_celebrate.progress import (
     scroll_credits,
 )
 from quest_celebrate.quest_data import QUALITY_TIERS, QuestData, load_quest_data
+from quest_runtime.quest_ids import parse_quest_id
 
 
 @dataclass
@@ -71,12 +72,14 @@ def load_quest_stats(quest_dir: Path) -> QuestStats:
             stats.plan_iterations = state.get("plan_iteration", 0)
             stats.fix_iterations = state.get("fix_iteration", 0)
 
-            # Parse quest_id to get quest name
-            if stats.quest_id:
-                # Format: quest-name_YYYY-MM-DD__HHMM
-                parts = stats.quest_id.split("_")
-                if parts:
-                    stats.name = parts[0].replace("-", " ").title()
+            # Prefer explicit state slug, then parse supported quest IDs.
+            if stats.slug:
+                stats.name = stats.slug.replace("-", " ").title()
+            elif stats.quest_id:
+                parsed = parse_quest_id(stats.quest_id)
+                slug = parsed.slug if parsed is not None else stats.quest_id.split("_")[0]
+                if slug:
+                    stats.name = slug.replace("-", " ").title()
 
         except json.JSONDecodeError:
             # Graceful degradation - use defaults

--- a/scripts/quest_celebrate/quest-celebrate.sh
+++ b/scripts/quest_celebrate/quest-celebrate.sh
@@ -24,8 +24,11 @@ for ((i=1; i<=$#; i++)); do
             quest_path="${!next}"
             # Extract last directory component and parse quest name
             quest_dir=$(basename "$quest_path")
-            # Format: quest-name_YYYY-MM-DD__HHMM
-            QUEST_NAME=$(echo "$quest_dir" | sed 's/_.*//' | tr '-' ' ')
+            if [[ "$quest_dir" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{4}__(.+)$ ]]; then
+                QUEST_NAME="${BASH_REMATCH[1]//-/ }"
+            else
+                QUEST_NAME=$(echo "$quest_dir" | sed 's/_.*//' | tr '-' ' ')
+            fi
         fi
         break
     fi

--- a/scripts/quest_celebrate/quest_data.py
+++ b/scripts/quest_celebrate/quest_data.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from quest_runtime.quest_ids import parse_quest_id
+
 
 @dataclass
 class AgentInfo:
@@ -162,6 +164,18 @@ def _map_agent_role_title(agent_name: str) -> str:
         if pattern in lower:
             return title
     return agent_name.replace("-", " ").title()
+
+
+def _slug_from_quest_id_or_legacy(quest_id: str) -> str:
+    """Return a quest slug from supported IDs, preserving legacy fallback."""
+    parsed = parse_quest_id(quest_id)
+    if parsed is not None:
+        return parsed.slug
+    return quest_id.split("_")[0]
+
+
+def _display_name_from_slug(slug: str) -> str:
+    return slug.replace("-", " ").title()
 
 
 def _phase_from_path(rel_path: str) -> str:
@@ -1003,9 +1017,9 @@ def load_quest_data_from_journal(journal_path: Path) -> QuestData:
 
     data.quest_id = _extract_metadata(content, "quest id")
     if data.quest_id:
-        parts = data.quest_id.split("_")
-        if parts:
-            data.slug = parts[0]
+        data.slug = _extract_metadata(content, "slug") or _slug_from_quest_id_or_legacy(
+            data.quest_id
+        )
 
     # Title from heading
     title = _extract_journal_title(content)
@@ -1077,11 +1091,13 @@ def load_quest_data(quest_dir: Path) -> QuestData:
     data.created_at = state.get("created_at")
     data.updated_at = state.get("updated_at")
 
-    # Derive name from quest_id if needed
-    if data.quest_id:
-        parts = data.quest_id.split("_")
-        if parts:
-            data.name = parts[0].replace("-", " ").title()
+    # Derive name from state slug first, then quest_id if needed.
+    if data.slug:
+        data.name = _display_name_from_slug(data.slug)
+    elif data.quest_id:
+        slug = _slug_from_quest_id_or_legacy(data.quest_id)
+        if slug:
+            data.name = _display_name_from_slug(slug)
 
     # 2. quest_brief.md
     brief_name, brief_summary, brief_body, brief_source = _read_quest_brief(quest_dir)

--- a/scripts/quest_checks/cli.py
+++ b/scripts/quest_checks/cli.py
@@ -1,4 +1,4 @@
-"""Run the installed Quest validation and smoke-test commands."""
+"""Run validation commands available in installed Quest projects."""
 
 from __future__ import annotations
 
@@ -10,17 +10,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 COMMANDS: list[tuple[str, list[str]]] = [
     ("validate quest config", ["bash", "scripts/quest_validate-quest-config.sh"]),
     ("validate manifest", ["bash", "scripts/quest_validate-manifest.sh"]),
-    (
-        "allowlist integration tests",
-        ["bash", "tests/integration/test-enforce-allowlist.sh"],
-    ),
-    ("quest preflight shell tests", ["bash", "tests/test-quest-preflight.sh"]),
-    ("quest runtime shell tests", ["bash", "tests/test-quest-runtime.sh"]),
-    (
-        "handoff contract shell tests",
-        ["bash", "tests/test-validate-handoff-contracts.sh"],
-    ),
-    ("quest state shell tests", ["bash", "tests/test-validate-quest-state.sh"]),
 ]
 
 

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -30,6 +30,7 @@ from quest_celebrate.quest_data import (
     friendly_model_name,
     load_quest_data,
 )
+from quest_runtime.quest_ids import parse_quest_id
 
 
 def _today() -> date:
@@ -176,6 +177,8 @@ def build_journal_entry(
 
     # Metadata
     lines.append(f"- Quest ID: `{data.quest_id}`")
+    if data.slug:
+        lines.append(f"- Slug: {data.slug}")
     lines.append(f"- Completed: {completion_date.isoformat()}")
     if data.quest_mode:
         lines.append(f"- Mode: {data.quest_mode}")
@@ -286,6 +289,13 @@ def _archive_quest(quest_dir: Path) -> Path:
     return dest
 
 
+def _slug_from_quest_dir(quest_dir: Path) -> str:
+    parsed = parse_quest_id(quest_dir.name)
+    if parsed is not None:
+        return parsed.slug
+    return quest_dir.name.split("_")[0]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Complete a quest: journal + archive")
     parser.add_argument("--quest-dir", required=True, help="Path to quest directory")
@@ -322,7 +332,8 @@ def main() -> int:
         return 1
 
     # Determine slug and outcome
-    slug = data.slug or state.get("slug", quest_dir.name.split("_")[0])
+    slug = data.slug or state.get("slug", _slug_from_quest_dir(quest_dir))
+    data.slug = slug
     if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug):
         print(f"Error: invalid slug '{slug}'. Must match [a-z0-9][a-z0-9-]*", file=sys.stderr)
         return 1

--- a/scripts/quest_dashboard/loaders.py
+++ b/scripts/quest_dashboard/loaders.py
@@ -19,6 +19,7 @@ from quest_celebrate.quest_data import (
     extract_metadata_value as _extract_metadata,
     friendly_model_name as _friendly_model_name,
 )
+from quest_runtime.quest_ids import parse_quest_id
 
 from .models import ActiveQuest, DashboardData, JournalEntry
 
@@ -142,8 +143,11 @@ def _parse_journal_entry(journal_path: Path, repo_root: Path) -> JournalEntry:
     )
     quest_id = quest_id.strip("`")
 
-    # Extract slug (fallback to quest_id)
-    slug = _extract_metadata(content, "slug") or quest_id
+    # Extract slug (fallback to parsing supported quest IDs, then quest_id)
+    parsed_quest_id = parse_quest_id(quest_id)
+    slug = _extract_metadata(content, "slug") or (
+        parsed_quest_id.slug if parsed_quest_id is not None else quest_id
+    )
 
     # Extract title
     title = _extract_title(content) or _humanize_filename(journal_path.stem)

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -133,7 +133,12 @@ OLD_SCRIPT_NAMES=(
   "scripts/validate-quest-state.sh"
 )
 
-LEGACY_INSTALLED_SOURCE_ONLY_TESTS=(
+LEGACY_INSTALLED_TESTS=(
+  "tests/integration/test-enforce-allowlist.sh"
+  "tests/test-quest-preflight.sh"
+  "tests/test-quest-runtime.sh"
+  "tests/test-validate-handoff-contracts.sh"
+  "tests/test-validate-quest-state.sh"
   "tests/unit/test_allowlist_matcher.py"
   "tests/unit/test_codex_skill_wrappers.py"
   "tests/unit/test_review_intelligence.py"
@@ -779,14 +784,14 @@ cleanup_removed_managed_files() {
   done
 }
 
-cleanup_legacy_source_only_tests() {
+cleanup_legacy_installed_tests() {
   local filepath
   local stored_checksum
   local current_checksum
   local upstream_checksum
   local temp_file
 
-  for filepath in "${LEGACY_INSTALLED_SOURCE_ONLY_TESTS[@]}"; do
+  for filepath in "${LEGACY_INSTALLED_TESTS[@]}"; do
     remove_updated_checksum "$filepath"
     if [ ! -e "$filepath" ]; then
       continue
@@ -796,7 +801,7 @@ cleanup_legacy_source_only_tests() {
 
     if stored_checksum=$(get_stored_checksum "$filepath" 2>/dev/null); then
       if [ "$current_checksum" != "$stored_checksum" ]; then
-        log_warn "Leaving modified legacy Quest source-only test in place for manual cleanup: $filepath"
+        log_warn "Leaving modified legacy Quest-installed test in place for manual cleanup: $filepath"
         continue
       fi
     else
@@ -811,18 +816,18 @@ cleanup_legacy_source_only_tests() {
       rm -f "$temp_file"
 
       if [ "$current_checksum" != "$upstream_checksum" ]; then
-        log_warn "Leaving locally modified legacy Quest source-only test in place for manual cleanup: $filepath"
+        log_warn "Leaving locally modified legacy Quest-installed test in place for manual cleanup: $filepath"
         continue
       fi
     fi
 
     if $DRY_RUN; then
-      log_action "Remove legacy Quest source-only test: $filepath"
+      log_action "Remove legacy Quest-installed test: $filepath"
       continue
     fi
 
     rm -f "$filepath"
-    log_success "Removed legacy Quest source-only test: $filepath"
+    log_success "Removed legacy Quest-installed test: $filepath"
   done
 }
 
@@ -1884,7 +1889,7 @@ run_install() {
   migrate_legacy_validation_hook
   cleanup_renamed_scripts
   cleanup_removed_managed_files
-  cleanup_legacy_source_only_tests
+  cleanup_legacy_installed_tests
 
   # Set executable bits
   set_executable_bits

--- a/scripts/quest_runtime/__init__.py
+++ b/scripts/quest_runtime/__init__.py
@@ -9,13 +9,35 @@ from .artifacts import (
     is_workspace_local,
     prepare_artifact_files,
 )
+from .quest_ids import (
+    DATE_FIRST,
+    DEFAULT_QUEST_ID_FORMAT,
+    SLUG_FIRST,
+    VALID_QUEST_ID_FORMATS,
+    ParsedQuestId,
+    format_quest_id,
+    is_quest_id,
+    load_quest_id_format,
+    normalize_quest_id_format,
+    parse_quest_id,
+)
 
 __all__ = [
+    "DATE_FIRST",
+    "DEFAULT_QUEST_ID_FORMAT",
+    "SLUG_FIRST",
     "ROLE_ARTIFACTS",
+    "VALID_QUEST_ID_FORMATS",
+    "ParsedQuestId",
     "any_artifact_missing_or_empty",
     "check_artifact_paths",
     "default_quest_dir",
     "expected_artifacts_for_role",
+    "format_quest_id",
+    "is_quest_id",
     "is_workspace_local",
+    "load_quest_id_format",
+    "normalize_quest_id_format",
+    "parse_quest_id",
     "prepare_artifact_files",
 ]

--- a/scripts/quest_runtime/quest_ids.py
+++ b/scripts/quest_runtime/quest_ids.py
@@ -1,0 +1,106 @@
+"""Quest ID formatting and parsing helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+SLUG_FIRST = "slug-first"
+DATE_FIRST = "date-first"
+DEFAULT_QUEST_ID_FORMAT = SLUG_FIRST
+VALID_QUEST_ID_FORMATS = (SLUG_FIRST, DATE_FIRST)
+
+_SLUG_PATTERN = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_SLUG_FIRST_RE = re.compile(
+    rf"^(?P<slug>{_SLUG_PATTERN})_(?P<date>\d{{4}}-\d{{2}}-\d{{2}})__(?P<time>\d{{4}})$"
+)
+_DATE_FIRST_RE = re.compile(
+    rf"^(?P<date>\d{{4}}-\d{{2}}-\d{{2}})_(?P<time>\d{{4}})__(?P<slug>{_SLUG_PATTERN})$"
+)
+
+
+@dataclass(frozen=True)
+class ParsedQuestId:
+    """Structured fields extracted from a supported Quest ID."""
+
+    slug: str
+    date: str
+    time: str
+    quest_id_format: str
+
+
+def normalize_quest_id_format(value: str | None) -> str:
+    """Return a known quest ID format or raise for invalid config values."""
+    if value is None:
+        return DEFAULT_QUEST_ID_FORMAT
+    if value in VALID_QUEST_ID_FORMATS:
+        return value
+    allowed = ", ".join(VALID_QUEST_ID_FORMATS)
+    raise ValueError(f"Invalid quest_id_format: {value!r}. Expected one of: {allowed}.")
+
+
+def format_quest_id(
+    slug: str,
+    when: datetime,
+    quest_id_format: str = DEFAULT_QUEST_ID_FORMAT,
+) -> str:
+    """Format a quest ID using the selected supported format."""
+    normalized = normalize_quest_id_format(quest_id_format)
+    if not re.fullmatch(_SLUG_PATTERN, slug):
+        raise ValueError("Invalid slug. Expected lowercase letters, numbers, and hyphens.")
+
+    date_part = when.strftime("%Y-%m-%d")
+    time_part = when.strftime("%H%M")
+    if normalized == DATE_FIRST:
+        return f"{date_part}_{time_part}__{slug}"
+    return f"{slug}_{date_part}__{time_part}"
+
+
+def parse_quest_id(value: str) -> ParsedQuestId | None:
+    """Parse either supported Quest ID format, returning None for non-matches."""
+    slug_first = _SLUG_FIRST_RE.fullmatch(value)
+    if slug_first:
+        return ParsedQuestId(
+            slug=slug_first.group("slug"),
+            date=slug_first.group("date"),
+            time=slug_first.group("time"),
+            quest_id_format=SLUG_FIRST,
+        )
+
+    date_first = _DATE_FIRST_RE.fullmatch(value)
+    if date_first:
+        return ParsedQuestId(
+            slug=date_first.group("slug"),
+            date=date_first.group("date"),
+            time=date_first.group("time"),
+            quest_id_format=DATE_FIRST,
+        )
+
+    return None
+
+
+def is_quest_id(value: str) -> bool:
+    """Return whether the value is a supported Quest ID."""
+    return parse_quest_id(value) is not None
+
+
+def load_quest_id_format(allowlist_path: Path) -> str:
+    """Load quest_id_format from allowlist JSON, defaulting when missing."""
+    try:
+        data = json.loads(allowlist_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return DEFAULT_QUEST_ID_FORMAT
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {allowlist_path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid allowlist.json: expected object at {allowlist_path}.")
+
+    value = data.get("quest_id_format")
+    if value is not None and not isinstance(value, str):
+        allowed = ", ".join(VALID_QUEST_ID_FORMATS)
+        raise ValueError(f"Invalid quest_id_format: {value!r}. Expected one of: {allowed}.")
+    return normalize_quest_id_format(value)

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -72,6 +72,19 @@ get_manifest_files() {
 
 MANIFEST_FILES=$(get_manifest_files | sort)
 
+TEST_MANIFEST_FILES=$(echo "$MANIFEST_FILES" | grep '^tests/' || true)
+if [ -n "$TEST_MANIFEST_FILES" ]; then
+  log_error "Repo tests do not belong in .quest-manifest or the Quest installer."
+  echo ""
+  echo "Remove these test-only paths from .quest-manifest:"
+  echo "$TEST_MANIFEST_FILES" | while read -r f; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "Installed projects should receive Quest runtime files only, not this repo's test suite."
+  exit 1
+fi
+
 # Define which directories/patterns should be in the manifest
 # These are the Quest framework files that the installer ships
 EXPECTED_PATTERNS=(
@@ -107,11 +120,6 @@ EXPECTED_PATTERNS=(
   "scripts/quest_validate-quest-state.sh"
   "scripts/quest_checks/*.py"
   "scripts/quest_runtime/*.py"
-  "tests/integration/test-enforce-allowlist.sh"
-  "tests/test-quest-preflight.sh"
-  "tests/test-quest-runtime.sh"
-  "tests/test-validate-handoff-contracts.sh"
-  "tests/test-validate-quest-state.sh"
 )
 
 # Find all files matching our patterns

--- a/scripts/quest_validate-quest-config.sh
+++ b/scripts/quest_validate-quest-config.sh
@@ -173,15 +173,14 @@ validate_quest_id_format() {
   fi
 
   if command -v jq &>/dev/null; then
-    local value
-    if ! value=$(jq -r '.quest_id_format // empty' "$json_file" 2>/dev/null); then
+    if ! jq -e '
+      (has("quest_id_format") | not) or
+      (.quest_id_format == "slug-first" or .quest_id_format == "date-first")
+    ' "$json_file" >/dev/null 2>&1; then
+      fail "Invalid quest_id_format in allowlist.json. Expected one of: $allowed."
       return
     fi
-    if [ -z "$value" ] || [ "$value" = "slug-first" ] || [ "$value" = "date-first" ]; then
-      pass "quest_id_format is valid"
-    else
-      fail "Invalid quest_id_format in allowlist.json. Expected one of: $allowed."
-    fi
+    pass "quest_id_format is valid"
     return
   fi
 
@@ -200,8 +199,7 @@ allowed = {"slug-first", "date-first"}
 with open(path, encoding="utf-8") as f:
     data = json.load(f)
 
-value = data.get("quest_id_format")
-if value is None or value in allowed:
+if "quest_id_format" not in data or data["quest_id_format"] in allowed:
     raise SystemExit(0)
 
 print("Invalid quest_id_format in allowlist.json. Expected one of: slug-first, date-first.")

--- a/scripts/quest_validate-quest-config.sh
+++ b/scripts/quest_validate-quest-config.sh
@@ -164,6 +164,56 @@ validate_schema() {
   fi
 }
 
+validate_quest_id_format() {
+  local json_file="$REPO_ROOT/.ai/allowlist.json"
+  local allowed="slug-first, date-first"
+
+  if [ ! -f "$json_file" ]; then
+    return
+  fi
+
+  if command -v jq &>/dev/null; then
+    local value
+    if ! value=$(jq -r '.quest_id_format // empty' "$json_file" 2>/dev/null); then
+      return
+    fi
+    if [ -z "$value" ] || [ "$value" = "slug-first" ] || [ "$value" = "date-first" ]; then
+      pass "quest_id_format is valid"
+    else
+      fail "Invalid quest_id_format in allowlist.json. Expected one of: $allowed."
+    fi
+    return
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    fail "python3 is required to validate quest_id_format when jq is unavailable."
+    return
+  fi
+
+  local output
+  if output=$(python3 - "$json_file" 2>&1 <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+allowed = {"slug-first", "date-first"}
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+
+value = data.get("quest_id_format")
+if value is None or value in allowed:
+    raise SystemExit(0)
+
+print("Invalid quest_id_format in allowlist.json. Expected one of: slug-first, date-first.")
+raise SystemExit(1)
+PY
+  ); then
+    pass "quest_id_format is valid"
+  else
+    fail "$output"
+  fi
+}
+
 # Validate role markdown files have required sections
 validate_roles() {
   local quest_roles_dir="$REPO_ROOT/.skills/quest/agents"
@@ -238,6 +288,7 @@ echo ""
 check_gitignore
 validate_json "$REPO_ROOT/.ai/allowlist.json"
 validate_schema
+validate_quest_id_format
 validate_roles
 
 echo ""

--- a/scripts/quest_validate-quest-state.sh
+++ b/scripts/quest_validate-quest-state.sh
@@ -61,7 +61,7 @@ Usage: $SCRIPT_NAME <quest-dir> <target-phase>
 Validates quest state prerequisites before a phase transition.
 
 Arguments:
-  quest-dir     Path to the quest directory (e.g., .quest/feature-x_2026-02-15__1430)
+  quest-dir     Path to the quest directory (e.g., .quest/feature-x_2026-02-15__1430 or .quest/2026-02-15_1430__feature-x)
   target-phase  The phase to transition to
 
 Exit codes:

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -929,7 +929,7 @@ test_installer_skips_unsafe_removed_managed_file_path() {
   return $rc
 }
 
-test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream() {
+test_installer_prunes_untracked_legacy_installed_test_matching_upstream() {
   local tmpdir
   tmpdir=$(mktemp -d)
 
@@ -962,7 +962,7 @@ test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstr
     log_action() { :; }
     clear_progress() { :; }
 
-    cleanup_legacy_source_only_tests
+    cleanup_legacy_installed_tests
 
     [ ! -e tests/unit/test_allowlist_matcher.py ]
   )
@@ -971,7 +971,7 @@ test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstr
   return $rc
 }
 
-test_installer_preserves_modified_untracked_legacy_installed_source_only_test() {
+test_installer_preserves_modified_untracked_legacy_installed_test() {
   local tmpdir
   tmpdir=$(mktemp -d)
 
@@ -1004,7 +1004,7 @@ test_installer_preserves_modified_untracked_legacy_installed_source_only_test() 
     log_action() { :; }
     clear_progress() { :; }
 
-    cleanup_legacy_source_only_tests
+    cleanup_legacy_installed_tests
 
     [ -e tests/unit/test_allowlist_matcher.py ]
   )
@@ -1038,7 +1038,7 @@ test_installer_preserves_unowned_source_only_test_path() {
     log_action() { :; }
     clear_progress() { :; }
 
-    cleanup_legacy_source_only_tests
+    cleanup_legacy_installed_tests
 
     [ -e tests/unit/test_quest_complete.py ]
   )
@@ -1055,18 +1055,8 @@ test_manifest_lists_prefixed_scripts() {
     grep -q '^scripts/quest_validate-quest-state.sh$' "$MANIFEST_FILE"
 }
 
-test_manifest_lists_installed_quest_smoke_tests() {
-  grep -q '^tests/integration/test-enforce-allowlist.sh$' "$MANIFEST_FILE" &&
-    grep -q '^tests/test-quest-preflight.sh$' "$MANIFEST_FILE" &&
-    grep -q '^tests/test-quest-runtime.sh$' "$MANIFEST_FILE" &&
-    grep -q '^tests/test-validate-handoff-contracts.sh$' "$MANIFEST_FILE" &&
-    grep -q '^tests/test-validate-quest-state.sh$' "$MANIFEST_FILE"
-}
-
-test_manifest_excludes_source_only_unit_tests() {
-  ! grep -q '^tests/unit/test_allowlist_matcher.py$' "$MANIFEST_FILE" &&
-    ! grep -q '^tests/unit/test_review_intelligence.py$' "$MANIFEST_FILE" &&
-    ! grep -q '^tests/unit/test_codex_skill_wrappers.py$' "$MANIFEST_FILE"
+test_manifest_excludes_repo_tests() {
+  ! grep -q '^tests/' "$MANIFEST_FILE"
 }
 
 test_manifest_validator_allows_custom_skills_in_installed_mode() {
@@ -1137,6 +1127,31 @@ EOF
     fi
     grep -q 'Unknown option: --bogus' output.txt &&
       grep -q 'Usage: scripts/quest_validate-manifest.sh' output.txt
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_manifest_validator_rejects_test_paths() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p scripts tests/integration
+    cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    touch tests/integration/test-enforce-allowlist.sh
+    cat > .quest-manifest <<'EOF'
+[copy-as-is]
+scripts/quest_validate-manifest.sh
+tests/integration/test-enforce-allowlist.sh
+EOF
+
+    if bash scripts/quest_validate-manifest.sh > output.txt 2>&1; then
+      exit 1
+    fi
+    grep -q "Repo tests do not belong in .quest-manifest or the Quest installer" output.txt &&
+      grep -q "tests/integration/test-enforce-allowlist.sh" output.txt
   )
   local rc=$?
   rm -rf "$tmpdir"
@@ -1740,15 +1755,15 @@ run_test test_installer_prunes_pristine_removed_managed_files
 run_test test_installer_preserves_modified_removed_managed_files_for_manual_cleanup
 run_test test_load_local_checksums_skips_unsafe_paths
 run_test test_installer_skips_unsafe_removed_managed_file_path
-run_test test_installer_prunes_untracked_legacy_installed_source_only_test_matching_upstream
-run_test test_installer_preserves_modified_untracked_legacy_installed_source_only_test
+run_test test_installer_prunes_untracked_legacy_installed_test_matching_upstream
+run_test test_installer_preserves_modified_untracked_legacy_installed_test
 run_test test_installer_preserves_unowned_source_only_test_path
 run_test test_manifest_lists_prefixed_scripts
-run_test test_manifest_lists_installed_quest_smoke_tests
-run_test test_manifest_excludes_source_only_unit_tests
+run_test test_manifest_excludes_repo_tests
 run_test test_manifest_validator_allows_custom_skills_in_installed_mode
 run_test test_manifest_validator_strict_mode_catches_unmanifested_skills
 run_test test_manifest_validator_rejects_unknown_option
+run_test test_manifest_validator_rejects_test_paths
 run_test test_validation_hook_script_accepts_legacy_symlink_target
 run_test test_quest_claude_runner_polls_handoff_and_logs_runtime
 run_test test_quest_claude_probe_requires_real_artifacts

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -116,6 +116,37 @@ EOF
     printf '%s' "$output" | grep -q "date-first"
 }
 
+test_quest_validate_config_rejects_empty_quest_id_format_with_jq() {
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || return 1
+  write_minimal_config_validation_files "$tmpdir"
+  cat > "$tmpdir/.ai/allowlist.json" <<'EOF'
+{
+  "quest_id_format": ""
+}
+EOF
+
+  local fake_bin cmd
+  fake_bin="$tmpdir/bin"
+  mkdir -p "$fake_bin"
+  for cmd in basename find git grep head jq sort tail; do
+    ln -s "$(command -v "$cmd")" "$fake_bin/$cmd" || return 1
+  done
+
+  local output rc
+  output=$(cd "$tmpdir" && PATH="$fake_bin" /bin/bash "$CONFIG_SCRIPT" 2>&1)
+  rc=$?
+  rm -rf "$tmpdir"
+
+  [ "$rc" -ne 0 ] &&
+    printf '%s' "$output" | grep -q "quest_id_format" &&
+    printf '%s' "$output" | grep -q "slug-first" &&
+    printf '%s' "$output" | grep -q "date-first"
+}
+
 test_quest_docs_resume_pattern_accepts_slug_first_and_date_first() {
   grep -q '<slug>_YYYY-MM-DD__HHMM' "$REPO_ROOT/.skills/quest/SKILL.md" &&
     grep -q 'YYYY-MM-DD_HHMM__<slug>' "$REPO_ROOT/.skills/quest/SKILL.md" &&
@@ -1685,6 +1716,7 @@ run_test test_quest_state_transition_valid
 run_test test_quest_state_transition_invalid_leaves_state_unchanged
 run_test test_quest_state_transition_rejects_plan_reviewed_to_building
 run_test test_quest_validate_config_rejects_invalid_quest_id_format_without_jq_or_ajv
+run_test test_quest_validate_config_rejects_empty_quest_id_format_with_jq
 run_test test_quest_docs_resume_pattern_accepts_slug_first_and_date_first
 run_test test_quest_startup_branch_defaults_to_branch_checkout
 run_test test_quest_startup_branch_skips_when_already_on_feature_branch

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -5,6 +5,7 @@
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 STATE_SCRIPT="$REPO_ROOT/scripts/quest_state.py"
 STARTUP_BRANCH_SCRIPT="$REPO_ROOT/scripts/quest_startup_branch.py"
+CONFIG_SCRIPT="$REPO_ROOT/scripts/quest_validate-quest-config.sh"
 CLAUDE_RUNNER="$REPO_ROOT/scripts/quest_claude_runner.py"
 CLAUDE_PROBE="$REPO_ROOT/scripts/quest_claude_probe.py"
 INSTALLER_SCRIPT="$REPO_ROOT/scripts/quest_installer.sh"
@@ -53,6 +54,73 @@ write_allowlist() {
   }
 }
 EOF
+}
+
+write_minimal_config_validation_files() {
+  local dir="$1"
+  mkdir -p "$dir/.ai/schemas" "$dir/.ai/roles" "$dir/.skills/quest/agents"
+  printf '.quest/\n.worktrees/\n' > "$dir/.gitignore"
+  printf '{}\n' > "$dir/.ai/schemas/allowlist.schema.json"
+  cat > "$dir/.skills/quest/agents/builder.md" <<'EOF'
+## Role
+Builder
+## Tool
+Codex
+## Context Required
+Plan
+## Output Contract
+Handoff
+## Responsibilities
+Build
+## Allowed Actions
+Edit
+EOF
+  cat > "$dir/.ai/roles/quest_agent.md" <<'EOF'
+## Role
+Quest Agent
+## Tool
+Claude
+## Context Required
+Prompt
+## Output Contract
+Route
+EOF
+}
+
+test_quest_validate_config_rejects_invalid_quest_id_format_without_jq_or_ajv() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || return 1
+  write_minimal_config_validation_files "$tmpdir"
+  cat > "$tmpdir/.ai/allowlist.json" <<'EOF'
+{
+  "quest_id_format": "date_slug"
+}
+EOF
+
+  local fake_bin cmd
+  fake_bin="$tmpdir/bin"
+  mkdir -p "$fake_bin"
+  for cmd in basename find git grep head python3 sort tail; do
+    ln -s "$(command -v "$cmd")" "$fake_bin/$cmd" || return 1
+  done
+
+  local output rc
+  output=$(cd "$tmpdir" && PATH="$fake_bin" /bin/bash "$CONFIG_SCRIPT" 2>&1)
+  rc=$?
+  rm -rf "$tmpdir"
+
+  [ "$rc" -ne 0 ] &&
+    printf '%s' "$output" | grep -q "quest_id_format" &&
+    printf '%s' "$output" | grep -q "slug-first" &&
+    printf '%s' "$output" | grep -q "date-first"
+}
+
+test_quest_docs_resume_pattern_accepts_slug_first_and_date_first() {
+  grep -q '<slug>_YYYY-MM-DD__HHMM' "$REPO_ROOT/.skills/quest/SKILL.md" &&
+    grep -q 'YYYY-MM-DD_HHMM__<slug>' "$REPO_ROOT/.skills/quest/SKILL.md" &&
+    grep -q '<slug>_YYYY-MM-DD__HHMM' "$WORKFLOW_FILE" &&
+    grep -q 'YYYY-MM-DD_HHMM__<slug>' "$WORKFLOW_FILE"
 }
 
 load_installer_functions() {
@@ -1616,6 +1684,8 @@ run_test test_quest_state_updates_phase_and_timestamp
 run_test test_quest_state_transition_valid
 run_test test_quest_state_transition_invalid_leaves_state_unchanged
 run_test test_quest_state_transition_rejects_plan_reviewed_to_building
+run_test test_quest_validate_config_rejects_invalid_quest_id_format_without_jq_or_ajv
+run_test test_quest_docs_resume_pattern_accepts_slug_first_and_date_first
 run_test test_quest_startup_branch_defaults_to_branch_checkout
 run_test test_quest_startup_branch_skips_when_already_on_feature_branch
 run_test test_quest_startup_branch_blocks_dirty_default_branch_checkout

--- a/tests/unit/test_codex_skill_wrappers.py
+++ b/tests/unit/test_codex_skill_wrappers.py
@@ -9,6 +9,7 @@ EXPECTED_QUEST_WRAPPERS = {
     "pr-assistant",
     "pr-shepherd",
     "quest",
+    "sharpen",
 }
 
 

--- a/tests/unit/test_quest_celebrate.py
+++ b/tests/unit/test_quest_celebrate.py
@@ -528,6 +528,24 @@ class TestQuestStatsLoading:
         assert stats.plan_iterations == 2
         assert stats.fix_iterations == 1
 
+    def test_load_quest_stats_uses_state_slug_for_date_first_id(self, tmp_path):
+        """Date-first IDs display the slug, not the date prefix."""
+        quest_dir = tmp_path / "2026-04-29_1430__portable-pre-commit-review"
+        quest_dir.mkdir()
+        (quest_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "quest_id": "2026-04-29_1430__portable-pre-commit-review",
+                    "slug": "portable-pre-commit-review",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        stats = load_quest_stats(quest_dir)
+
+        assert stats.name == "Portable Pre Commit Review"
+
     def test_load_quest_stats_from_brief(self, tmp_path):
         """Load quest name from quest_brief.md."""
         quest_dir = tmp_path / "my-quest_2026-01-01__1200"
@@ -843,6 +861,25 @@ class TestQuestDataLoading:
         assert data.fix_iterations == 1
         assert data.status == "complete"
         assert data.created_at == "2026-01-01T12:00:00Z"
+
+    def test_load_quest_data_uses_state_slug_for_date_first_id(self, tmp_path):
+        """Date-first active quest names come from state slug."""
+        quest_dir = tmp_path / "2026-04-29_1430__portable-pre-commit-review"
+        quest_dir.mkdir()
+        (quest_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "quest_id": "2026-04-29_1430__portable-pre-commit-review",
+                    "slug": "portable-pre-commit-review",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        data = load_quest_data(quest_dir)
+
+        assert data.slug == "portable-pre-commit-review"
+        assert data.name == "Portable Pre Commit Review"
 
     def test_load_quest_data_reads_handoff_agents(self, tmp_path):
         """Verifies agent names and models extracted from handoff JSON."""
@@ -1633,6 +1670,24 @@ class TestJournalCelebrationData:
         assert data.quality_tier == "Silver"
         # No agents or achievements from legacy
         assert len(data.agents) == 0
+
+    def test_load_quest_data_from_journal_parses_date_first_id_slug_when_slug_missing(
+        self, tmp_path
+    ):
+        journal = textwrap.dedent(
+            """\
+            # Quest Journal: Portable Pre Commit Review
+
+            - Quest ID: `2026-04-29_1430__portable-pre-commit-review`
+            - Completed: 2026-04-29
+            """
+        )
+        journal_path = tmp_path / "portable-pre-commit-review_2026-04-29.md"
+        journal_path.write_text(journal, encoding="utf-8")
+
+        data = load_quest_data_from_journal(journal_path)
+
+        assert data.slug == "portable-pre-commit-review"
 
     def test_load_quest_data_from_journal_supports_existing_journal_formats(
         self, tmp_path

--- a/tests/unit/test_quest_complete.py
+++ b/tests/unit/test_quest_complete.py
@@ -210,6 +210,68 @@ def test_generate_journal_entry_includes_empty_carryover_status_when_absent():
     assert "## Inherited Findings Used" not in entry
 
 
+def test_generate_journal_entry_includes_slug_metadata():
+    data = QuestData(
+        quest_id="2026-04-29_1430__portable-pre-commit-review",
+        slug="portable-pre-commit-review",
+        name="Portable Pre Commit Review",
+    )
+
+    entry = build_journal_entry(
+        data,
+        date(2026, 4, 29),
+        Path("docs/quest-journal/portable-pre-commit-review_2026-04-29.md"),
+    )
+
+    assert "- Slug: portable-pre-commit-review" in entry
+
+
+def test_complete_date_first_quest_uses_parsed_slug(tmp_path, monkeypatch, capsys):
+    repo_root = tmp_path
+    journal_dir = repo_root / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+    (journal_dir / "README.md").write_text(
+        "| Date | Quest | Outcome |\n|------|-------|---------|\n",
+        encoding="utf-8",
+    )
+    quest_dir = repo_root / ".quest" / "2026-04-29_1430__portable-pre-commit-review"
+    quest_dir.mkdir(parents=True)
+    (quest_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "quest_id": "2026-04-29_1430__portable-pre-commit-review",
+                "status": "complete",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (quest_dir / "quest_brief.md").write_text(
+        "# Quest Brief: Portable Pre Commit Review\n\n## User Input\n\nDone.",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "quest_complete.py",
+            "--quest-dir",
+            str(quest_dir),
+            "--skip-archive",
+            "--date",
+            "2026-04-29",
+        ],
+    )
+
+    assert quest_complete.main() == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    journal = journal_dir / "portable-pre-commit-review_2026-04-29.md"
+    assert payload["slug"] == "portable-pre-commit-review"
+    assert journal.exists()
+    assert "- Slug: portable-pre-commit-review" in journal.read_text(encoding="utf-8")
+
+
 def test_main_reports_invalid_date(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_quest_dashboard_loaders.py
+++ b/tests/unit/test_quest_dashboard_loaders.py
@@ -89,6 +89,46 @@ Legacy-style journal entry.
     assert entry.status == "Abandoned"
 
 
+def test_journal_date_first_quest_uses_slug_metadata(tmp_path):
+    """Date-first journals prefer explicit slug metadata."""
+    journal_dir = tmp_path / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+
+    journal_content = """# Quest Journal: Portable Pre Commit Review
+
+- Quest ID: `2026-04-29_1430__portable-pre-commit-review`
+- Slug: portable-pre-commit-review
+- Completed: 2026-04-29
+"""
+
+    journal_path = journal_dir / "portable-pre-commit-review.md"
+    journal_path.write_text(journal_content, encoding="utf-8")
+
+    entry = _parse_journal_entry(journal_path, tmp_path)
+
+    assert entry.slug == "portable-pre-commit-review"
+    assert entry.title == "Portable Pre Commit Review"
+
+
+def test_journal_date_first_quest_parses_slug_when_slug_metadata_missing(tmp_path):
+    """Date-first journals without Slug metadata still derive the display slug."""
+    journal_dir = tmp_path / "docs" / "quest-journal"
+    journal_dir.mkdir(parents=True)
+
+    journal_content = """# Quest Journal: Portable Pre Commit Review
+
+- Quest ID: `2026-04-29_1430__portable-pre-commit-review`
+- Completed: 2026-04-29
+"""
+
+    journal_path = journal_dir / "portable-pre-commit-review.md"
+    journal_path.write_text(journal_content, encoding="utf-8")
+
+    entry = _parse_journal_entry(journal_path, tmp_path)
+
+    assert entry.slug == "portable-pre-commit-review"
+
+
 def test_journal_elevator_pitch_from_summary_section(tmp_path):
     """Test that elevator pitch is extracted from Summary section, not title."""
     journal_dir = tmp_path / "docs" / "quest-journal"
@@ -299,6 +339,35 @@ Some requirements here.
         == "This is the elevator pitch from the original prompt section."
     )
     assert len(quest_warnings) == 0
+
+
+def test_active_date_first_quest_uses_explicit_slug(tmp_path):
+    """Active date-first quests keep explicit slug/title values."""
+    quest_dir = tmp_path / ".quest" / "2026-04-29_1430__portable-pre-commit-review"
+    quest_dir.mkdir(parents=True)
+    (quest_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "quest_id": "2026-04-29_1430__portable-pre-commit-review",
+                "slug": "portable-pre-commit-review",
+                "phase": "plan",
+                "status": "in_progress",
+                "updated_at": "2026-04-29T14:30:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (quest_dir / "quest_brief.md").write_text(
+        "# Quest Brief: Portable Pre Commit Review\n\n## User Input\n\nBuild it.",
+        encoding="utf-8",
+    )
+
+    quest, warnings = _parse_active_quest(quest_dir / "state.json")
+
+    assert quest is not None
+    assert quest.slug == "portable-pre-commit-review"
+    assert quest.title == "Portable Pre Commit Review"
+    assert warnings == []
 
 
 def test_active_quest_pitch_supports_original_request_variant(tmp_path):

--- a/tests/unit/test_quest_ids.py
+++ b/tests/unit/test_quest_ids.py
@@ -1,0 +1,107 @@
+"""Unit tests for Quest ID formatting and parsing."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from quest_runtime.quest_ids import (
+    DATE_FIRST,
+    DEFAULT_QUEST_ID_FORMAT,
+    SLUG_FIRST,
+    format_quest_id,
+    is_quest_id,
+    load_quest_id_format,
+    normalize_quest_id_format,
+    parse_quest_id,
+)
+
+
+def test_format_quest_id_defaults_to_slug_first() -> None:
+    when = datetime(2026, 4, 29, 14, 30)
+
+    assert format_quest_id("portable-pre-commit-review", when) == (
+        "portable-pre-commit-review_2026-04-29__1430"
+    )
+
+
+def test_format_quest_id_supports_date_first() -> None:
+    when = datetime(2026, 4, 29, 14, 30)
+
+    assert format_quest_id("portable-pre-commit-review", when, DATE_FIRST) == (
+        "2026-04-29_1430__portable-pre-commit-review"
+    )
+
+
+def test_parse_quest_id_accepts_slug_first() -> None:
+    parsed = parse_quest_id("portable-pre-commit-review_2026-04-29__1430")
+
+    assert parsed is not None
+    assert parsed.slug == "portable-pre-commit-review"
+    assert parsed.date == "2026-04-29"
+    assert parsed.time == "1430"
+    assert parsed.quest_id_format == SLUG_FIRST
+
+
+def test_parse_quest_id_accepts_date_first() -> None:
+    parsed = parse_quest_id("2026-04-29_1430__portable-pre-commit-review")
+
+    assert parsed is not None
+    assert parsed.slug == "portable-pre-commit-review"
+    assert parsed.date == "2026-04-29"
+    assert parsed.time == "1430"
+    assert parsed.quest_id_format == DATE_FIRST
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "Portable_2026-04-29__1430",
+        "portable_2026-04-29_1430",
+        "2026-04-29__1430__portable",
+        "2026-04-29_1430__portable_quest",
+        "-portable_2026-04-29__1430",
+    ],
+)
+def test_parse_quest_id_rejects_non_ids(value: str) -> None:
+    assert parse_quest_id(value) is None
+
+
+def test_is_quest_id_accepts_both_formats() -> None:
+    assert is_quest_id("portable-pre-commit-review_2026-04-29__1430")
+    assert is_quest_id("2026-04-29_1430__portable-pre-commit-review")
+    assert not is_quest_id("portable-pre-commit-review")
+
+
+def test_normalize_quest_id_format_defaults_when_missing() -> None:
+    assert normalize_quest_id_format(None) == DEFAULT_QUEST_ID_FORMAT
+
+
+def test_load_quest_id_format_defaults_when_file_missing(tmp_path: Path) -> None:
+    assert load_quest_id_format(tmp_path / "missing.json") == SLUG_FIRST
+
+
+def test_load_quest_id_format_defaults_when_key_missing(tmp_path: Path) -> None:
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text(json.dumps({"version": 2}), encoding="utf-8")
+
+    assert load_quest_id_format(allowlist) == SLUG_FIRST
+
+
+def test_load_quest_id_format_reads_date_first(tmp_path: Path) -> None:
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text(json.dumps({"quest_id_format": DATE_FIRST}), encoding="utf-8")
+
+    assert load_quest_id_format(allowlist) == DATE_FIRST
+
+
+def test_load_quest_id_format_rejects_invalid_value(tmp_path: Path) -> None:
+    allowlist = tmp_path / "allowlist.json"
+    allowlist.write_text(json.dumps({"quest_id_format": "date_slug"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="quest_id_format.*slug-first.*date-first"):
+        load_quest_id_format(allowlist)

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -37,26 +37,27 @@ def _validator_patterns() -> list[str]:
     return patterns
 
 
-def test_manifest_installs_shell_smoke_tests_not_source_unit_tests() -> None:
+def test_manifest_does_not_install_repo_tests() -> None:
     entries = set(_manifest_entries())
 
-    expected_installed_tests = {
+    excluded_tests = {
         "tests/integration/test-enforce-allowlist.sh",
         "tests/test-quest-preflight.sh",
         "tests/test-quest-runtime.sh",
         "tests/test-validate-handoff-contracts.sh",
         "tests/test-validate-quest-state.sh",
-    }
-    assert expected_installed_tests <= entries
-
-    excluded_source_tests = {
         "tests/unit/test_allowlist_matcher.py",
         "tests/unit/test_review_intelligence.py",
         "tests/unit/test_codex_skill_wrappers.py",
         "tests/unit/test_quest_checks_cli.py",
         "tests/unit/test_quest_manifest.py",
     }
-    assert excluded_source_tests.isdisjoint(entries)
+    leaked_tests = sorted(entry for entry in entries if entry.startswith("tests/"))
+    assert leaked_tests == [], (
+        "Repo tests do not belong in .quest-manifest or the Quest installer: "
+        + ", ".join(leaked_tests)
+    )
+    assert excluded_tests.isdisjoint(entries)
 
 
 def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
@@ -69,11 +70,6 @@ def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
         "scripts/quest_celebrate/celebrate.py",
         "scripts/quest_celebrate/quest-celebrate.sh",
         "scripts/quest_runtime/quest_ids.py",
-        "tests/integration/test-enforce-allowlist.sh",
-        "tests/test-quest-preflight.sh",
-        "tests/test-quest-runtime.sh",
-        "tests/test-validate-handoff-contracts.sh",
-        "tests/test-validate-quest-state.sh",
     }
 
     uncovered = sorted(
@@ -83,3 +79,13 @@ def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
     )
 
     assert uncovered == []
+
+
+def test_manifest_validator_does_not_scan_repo_tests() -> None:
+    patterns = _validator_patterns()
+
+    leaked_patterns = sorted(pattern for pattern in patterns if pattern.startswith("tests/"))
+    assert leaked_patterns == [], (
+        "The manifest validator must not require repo tests to be installed: "
+        + ", ".join(leaked_patterns)
+    )

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -68,6 +68,7 @@ def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
         "scripts/quest_state.py",
         "scripts/quest_celebrate/celebrate.py",
         "scripts/quest_celebrate/quest-celebrate.sh",
+        "scripts/quest_runtime/quest_ids.py",
         "tests/integration/test-enforce-allowlist.sh",
         "tests/test-quest-preflight.sh",
         "tests/test-quest-runtime.sh",

--- a/tests/unit/test_sharpen_install_surface.py
+++ b/tests/unit/test_sharpen_install_surface.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NEW_INSTALLED_FILES = {
+    ".agents/skills/sharpen/SKILL.md",
+    ".claude/skills/sharpen/SKILL.md",
+    ".skills/sharpen/SKILL.md",
+}
+
+DELEGATION_LINE = "Read and follow the instructions in `.skills/sharpen/SKILL.md`."
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (_repo_root() / path).read_text(encoding="utf-8")
+
+
+def _copy_as_is_manifest_entries() -> set[str]:
+    entries: set[str] = set()
+    in_copy_as_is = False
+
+    for raw_line in _read(".quest-manifest").splitlines():
+        line = raw_line.strip()
+        if line == "[copy-as-is]":
+            in_copy_as_is = True
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_copy_as_is = False
+            continue
+        if in_copy_as_is and line and not line.startswith("#"):
+            entries.add(line)
+
+    return entries
+
+
+def test_sharpen_catalog_entry_points_to_skill() -> None:
+    catalog = _read(".skills/SKILLS.md")
+
+    assert "### sharpen" in catalog
+    assert "Adversarial interview against a plan, design, or write-up" in catalog
+    assert ".skills/sharpen/SKILL.md" in catalog
+
+
+def test_sharpen_canonical_skill_is_standalone() -> None:
+    skill = _read(".skills/sharpen/SKILL.md")
+
+    assert "name: sharpen" in skill
+    assert "Quest" not in skill
+
+
+def test_claude_sharpen_wrapper_is_user_invocable_and_delegates() -> None:
+    wrapper = _read(".claude/skills/sharpen/SKILL.md")
+
+    assert "name: sharpen" in wrapper
+    assert "user-invocable: true" in wrapper
+    assert wrapper.split("---", maxsplit=2)[2].strip() == DELEGATION_LINE
+
+
+def test_codex_sharpen_wrapper_delegates() -> None:
+    wrapper = _read(".agents/skills/sharpen/SKILL.md")
+
+    assert "name: sharpen" in wrapper
+    assert wrapper.split("---", maxsplit=2)[2].strip() == DELEGATION_LINE
+
+
+def test_sharpen_installed_files_are_manifest_copy_as_is_entries() -> None:
+    assert NEW_INSTALLED_FILES <= _copy_as_is_manifest_entries()


### PR DESCRIPTION
## Summary
Bundle three Quest tooling improvements: a configurable Quest ID format (slug-first or date-first), a new portable `/sharpen` skill for adversarial plan stress-testing, and a refreshed plan-presentation flow with a five-section executive summary and three-way menu. Plus two idea proposals: research fan-out and test-driven bug-fix loops.
- `/sharpen` is reusable outside Quest and wired into Step 3.5 as one menu option (asymmetric: walkthrough → re-asks reduced menu; sharpen → terminal).
- Quest IDs become opt-in via `.ai/allowlist.json` — repos can pick chronological sorting.

## Changes

- **Skills**:
  - Added `.skills/sharpen/SKILL.md` — one question at a time with a recommended answer, progress footer with at-most-once revision, structured Resolved/Open/Next exit.
  - Updated `.skills/quest/delegation/workflow.md` Step 3.5 — five-section executive summary, three-way menu, dual-entry change-handling (walkthrough or sharpen → existing `user_feedback.md` re-plan loop).
  - Tightened `.skills/pr-shepherd/SKILL.md` — branch/workspace verification before commits and pushes; diagnosis note before CI-fix edits.
  - Touched `.skills/celebrate/SKILL.md` and `.skills/quest/SKILL.md` for the new Quest ID format.
  - Registered sharpen in `.skills/SKILLS.md`, `.claude/AGENTS.md` (via `CLAUDE.md` symlink), and `.quest-manifest`.
- **Config / Schemas**:
  - Added `quest_id_format` to `.ai/allowlist.json`, `.ai/quest.md`, `.ai/schemas/allowlist.schema.json` — defaults to `slug-first`.
- **Quest Runtime**:
  - New module `scripts/quest_runtime/quest_ids.py` — `format_quest_id()` and `load_quest_id_format()`.
  - `scripts/quest_celebrate/`, `quest_complete.py`, `quest_dashboard/loaders.py` parse both ID formats.
  - New `scripts/quest_validate-quest-config.sh`.
- **Documentation**:
  - `README.md` and `docs/guides/*` updated for the Quest ID option.
  - `ideas/2026-04-29-research-fanout-skill.md` — bounded parallel investigation skill proposal.
  - `ideas/2026-04-29-test-driven-bug-fix-loops.md` — failed-attempt-preserving bug-fix loop proposal.
- **Tests**:
  - `tests/unit/test_quest_ids.py` (107 LOC) — both formats, validation errors.
  - Extended `test_quest_celebrate.py`, `test_quest_complete.py`, `test_quest_dashboard_loaders.py`.
  - `tests/test-quest-runtime.sh` (70 LOC) — runtime integration.

## Validation

- [ ] **Walkthrough — date-first quest ID**: Prerequisites: clean working tree. Action: edit `.ai/allowlist.json` to set `"quest_id_format": "date-first"`, run `bash scripts/quest_validate-quest-config.sh` — confirm validation passes. Start `/quest "test feature"` and verify the created `.quest/<id>/` uses `YYYY-MM-DD_HHMM__<slug>` format. Then run `/quest <date-first-id>` to resume — confirm the resume path parses it. Watch for: legacy slug-first IDs still resume in parallel.
- [ ] **Walkthrough — invoke `/sharpen` standalone**: Prerequisites: any markdown plan in the working tree. Action: `/sharpen on path/to/plan.md`. Expected: agent announces estimate (`Sharpening <artifact>. Estimated ~N questions.`), asks one question at a time with a recommended answer and progress footer (`Q3 of ~7, 43% — naming`), emits Resolved/Open/Next on exit. Edge case: invoke on a stub — expect `Not enough surface to sharpen yet — sketch the decision points first.`
- [ ] **Walkthrough — Quest plan presentation menu**: Prerequisites: a quest at the `presenting` phase (resume one with `/quest <id>` or run a small fresh quest). Action: at the menu, choose option `2` (sharpen). Expected: five-section executive summary renders before the menu; sharpen runs; on exit, Quest either transitions to `presentation_complete` (no revisions) or appends a `## Sharpen Outcome` block to `.quest/<id>/phase_01_plan/user_feedback.md` and re-runs the planner. Negative: choose option `1`, complete the walkthrough — expect the menu to re-show with option 1 removed (sharpen + proceed only).
- [ ] **Run unit tests**: `python3 -m pytest tests/unit/` and `bash tests/test-quest-runtime.sh`. Expected: all green.

Watch for: existing `presenting` / `presentation_complete` state phases still cover the new menu flow — no `state.json` schema change. Older plans without `## Overview` and `## Acceptance Criteria` sections will render a partial executive summary (intentional, not a regression).

## Notes
- Branch named for `configurable-quest-id-format` but landed scope is broader — `/sharpen` and the plan-presentation overhaul co-evolved during the same session.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>