### PR TITLE
Fix installer update branch collisions

### DIFF
--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-05-02 | [installer-branch-conflict](installer-branch-conflict_2026-05-02.md) | `$quest https://github.com/KjellKod/quest/issues/110 fix this.` Issue: https://github.com/KjellKod/quest/issues/110 T... |
 | 2026-04-27 | [portable-pre-commit-review](portable-pre-commit-review_2026-04-27.md) | Completed successfully. |
 | 2026-04-25 | [review-ergonomics-batch](review-ergonomics-batch_2026-04-25.md) | Completed successfully. |
 | 2026-04-24 | [deep-ci-manifest](deep-ci-manifest_2026-04-24.md) | Impact: - Adds one canonical machine-readable artifact (`/tmp/deep_ci_context_manifest.json`) per run so selection/ch... |

--- a/docs/quest-journal/installer-branch-conflict_2026-05-02.md
+++ b/docs/quest-journal/installer-branch-conflict_2026-05-02.md
@@ -1,0 +1,156 @@
+# Quest Journal: Installer Branch Conflict
+
+- Quest ID: `2026-05-01_1836__installer-branch-conflict`
+- Completed: 2026-05-02
+- Mode: solo
+- Quality: Diamond
+- Outcome: Fixed issue #110 so repeated same-day installer upgrades no longer fail when the default `quest-update-YYYYMMDD` branch already exists locally.
+
+## What Shipped
+
+**Problem**: During an upgrade from `main` or `master`, `scripts/quest_installer.sh` prompts to create a Quest update branch and always uses `quest-update-$(date +%Y%m%d)`. A second upgrade on the same day fails with `fatal: a branch named 'quest-update-YYYYMMDD' already exists`.
+
+**Impact**: Users can accept the installer branch prompt repeatedly on the same day without deleting or reusing existing local update branches.
+
+## Files Changed
+
+- `.ai/allowlist.json`
+- `scripts/quest_installer.sh`
+- `tests/test-quest-runtime.sh`
+- `docs/quest-journal/README.md`
+- `docs/quest-journal/installer-branch-conflict_2026-05-02.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_01_plan/plan.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_02_implementation/pr_description.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_03_review/review_code-reviewer-a.md`
+- `.quest/2026-05-01_1836__installer-branch-conflict/phase_03_review/review_findings_code-reviewer-a.json`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 0
+
+## Agents
+
+- **The Planner** (planner): Codex
+- **The A Plan Critic** (plan-reviewer-a): Codex
+- **The Implementer** (builder): Codex
+- **The A Code Critic** (code-reviewer-a): Codex
+
+## Quest Brief
+
+`$quest https://github.com/KjellKod/quest/issues/110 fix this.`
+
+Issue: https://github.com/KjellKod/quest/issues/110
+
+Title: quest installer fails if you upgrade twice the same day ... and old branch still exists locally
+
+Body excerpt:
+
+```text
+Quest Installer (latest release: 1.4.2)
+[INFO] Using upstream branch: quest/configurable-quest-id-format
+...
+[INFO] Updating Quest from 1c7d6954 to 376f0791
+Create a new branch for Quest changes? [Y/n] y
+fatal: a branch named 'quest-update-20260501' already exists
+```
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/installer-branch-conflict_2026-05-02.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {
+      "name": "planner",
+      "model": "Codex",
+      "role": "The Planner"
+    },
+    {
+      "name": "plan-reviewer-a",
+      "model": "Codex",
+      "role": "The A Plan Critic"
+    },
+    {
+      "name": "builder",
+      "model": "Codex",
+      "role": "The Implementer"
+    },
+    {
+      "name": "code-reviewer-a",
+      "model": "Codex",
+      "role": "The A Code Critic"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[FIX]",
+      "title": "Same-Day Upgrade Unblocked",
+      "desc": "Repeated installer upgrades no longer fail on an existing update branch"
+    },
+    {
+      "icon": "[REF]",
+      "title": "Local-Ref Precision",
+      "desc": "Branch collision checks target local refs/heads only"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Refined validation before build"
+    },
+    {
+      "icon": "[REVIEW]",
+      "title": "Zero-Finding Finish",
+      "desc": "Final code review found no issues"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "🧪",
+      "label": "Runtime tests: 42 passed, 0 failed"
+    },
+    {
+      "icon": "📝",
+      "label": "Final review findings: 0"
+    }
+  ],
+  "quality": {
+    "tier": "Diamond",
+    "grade": "A+"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": 42,
+  "tests_added": 4,
+  "files_changed": 5
+}
+```
+<!-- celebration-data-end -->

--- a/scripts/quest_installer.sh
+++ b/scripts/quest_installer.sh
@@ -216,6 +216,19 @@ log_action() {
   fi
 }
 
+next_available_update_branch_name() {
+  local base_name="$1"
+  local candidate="$base_name"
+  local suffix=2
+
+  while git show-ref --verify --quiet "refs/heads/$candidate"; do
+    candidate="${base_name}-${suffix}"
+    suffix=$((suffix + 1))
+  done
+
+  printf '%s\n' "$candidate"
+}
+
 # Show a markdown file with best available local renderer.
 show_markdown_file() {
   local filepath="$1"
@@ -1870,7 +1883,8 @@ run_install() {
 
     if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
       if prompt_yn "Create a new branch for Quest changes?" "y"; then
-        local branch_name="quest-update-$(date +%Y%m%d)"
+        local branch_name
+        branch_name=$(next_available_update_branch_name "quest-update-$(date +%Y%m%d)")
         git checkout -b "$branch_name"
         log_success "Created branch: $branch_name"
       fi

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -163,6 +163,45 @@ load_installer_functions() {
   rm -f "$loader_tmp"
 }
 
+stub_installer_run_install_steps() {
+  check_prerequisites() { :; }
+  detect_repo_state() {
+    IS_GIT_REPO="${TEST_INSTALLER_IS_GIT_REPO:-true}"
+    HAS_QUEST=true
+    LOCAL_VERSION="oldsha"
+  }
+  confirm_install_source() { :; }
+  fetch_upstream_version() {
+    UPSTREAM_SHA="newsha"
+    LATEST_RELEASE="test"
+  }
+  load_manifest() { :; }
+  load_upstream_checksums() { :; }
+  load_local_checksums() { :; }
+  init_updated_checksums() { :; }
+  check_self_update() { :; }
+  create_directories() { :; }
+  install_copy_as_is() { :; }
+  install_user_customized() { :; }
+  install_merge_carefully() { :; }
+  migrate_legacy_validation_hook() { :; }
+  cleanup_renamed_scripts() { :; }
+  cleanup_removed_managed_files() { :; }
+  cleanup_legacy_source_only_tests() { :; }
+  set_executable_bits() { :; }
+  update_gitignore() { :; }
+  save_checksums() { :; }
+  update_version_marker() { :; }
+  run_validation() { :; }
+  offer_codex_setup() { :; }
+  print_next_steps() { :; }
+  log_info() { :; }
+  log_warn() { :; }
+  log_success() { :; }
+  log_action() { :; }
+  clear_progress() { :; }
+}
+
 test_quest_state_updates_phase_and_timestamp() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -649,6 +688,219 @@ test_workflow_documents_arbiter_validate_build_publish_contract() {
     grep -Fq 'os.replace(".quest/<id>/phase_01_plan/arbiter_verdict.md.next", ".quest/<id>/phase_01_plan/arbiter_verdict.md")' "$WORKFLOW_FILE" &&
     grep -Fq 'If arbiter handoff says `next: planner`' "$WORKFLOW_FILE" &&
     grep -Fq 'Do **not** call `quest_state.py --transition plan_reviewed`.' "$WORKFLOW_FILE"
+}
+
+test_installer_update_branch_uses_base_name_when_free() {
+  local tmpdir
+  local base_name
+  tmpdir=$(mktemp -d)
+  base_name="quest-update-$(date +%Y%m%d)"
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+
+    run_install >/dev/null 2>&1
+
+    [ "$(git branch --show-current)" = "$base_name" ] &&
+      git show-ref --verify --quiet "refs/heads/$base_name"
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_update_branch_uses_suffix_when_date_branch_exists() {
+  local tmpdir
+  local base_name
+  tmpdir=$(mktemp -d)
+  base_name="quest-update-$(date +%Y%m%d)"
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  git -C "$tmpdir" branch "$base_name" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+
+    run_install >/dev/null 2>&1
+
+    [ "$(git branch --show-current)" = "${base_name}-2" ] &&
+      git show-ref --verify --quiet "refs/heads/$base_name" &&
+      git show-ref --verify --quiet "refs/heads/${base_name}-2"
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_update_branch_skips_occupied_suffixes() {
+  local tmpdir
+  local base_name
+  tmpdir=$(mktemp -d)
+  base_name="quest-update-$(date +%Y%m%d)"
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  git -C "$tmpdir" branch "$base_name" &&
+    git -C "$tmpdir" branch "${base_name}-2" &&
+    git -C "$tmpdir" branch "${base_name}-3" || {
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+
+    run_install >/dev/null 2>&1
+
+    [ "$(git branch --show-current)" = "${base_name}-4" ] &&
+      git show-ref --verify --quiet "refs/heads/${base_name}-4"
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_installer_update_branch_selection_respects_skip_gates() {
+  local tmpdir
+  local base_name
+  base_name="quest-update-$(date +%Y%m%d)"
+
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  git -C "$tmpdir" checkout -b feature >/dev/null 2>&1 || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+    next_available_update_branch_name() { return 99; }
+    run_install >/dev/null 2>&1
+    [ "$(git branch --show-current)" = "feature" ] &&
+      ! git show-ref --verify --quiet "refs/heads/$base_name"
+  ) || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  rm -rf "$tmpdir"
+
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+    DRY_RUN=false
+    FORCE_MODE=true
+    prompt_yn() { return 0; }
+    next_available_update_branch_name() { return 99; }
+    run_install >/dev/null 2>&1
+    [ "$(git branch --show-current)" = "main" ] &&
+      ! git show-ref --verify --quiet "refs/heads/$base_name"
+  ) || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  rm -rf "$tmpdir"
+
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+    DRY_RUN=true
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+    next_available_update_branch_name() { return 99; }
+    run_install >/dev/null 2>&1
+    [ "$(git branch --show-current)" = "main" ] &&
+      ! git show-ref --verify --quiet "refs/heads/$base_name"
+  ) || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  rm -rf "$tmpdir"
+
+  tmpdir=$(mktemp -d)
+  init_git_repo "$tmpdir" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 1; }
+    next_available_update_branch_name() { return 99; }
+    run_install >/dev/null 2>&1
+    [ "$(git branch --show-current)" = "main" ] &&
+      ! git show-ref --verify --quiet "refs/heads/$base_name"
+  ) || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  rm -rf "$tmpdir"
+
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    load_installer_functions
+    stub_installer_run_install_steps
+    TEST_INSTALLER_IS_GIT_REPO=false
+    DRY_RUN=false
+    FORCE_MODE=false
+    prompt_yn() { return 0; }
+    next_available_update_branch_name() { return 99; }
+    run_install >/dev/null 2>&1
+    [ ! -d .git ]
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
 }
 
 test_installer_cleans_up_renamed_scripts() {
@@ -1747,6 +1999,10 @@ run_test test_plan_review_retry_harness_preserves_canonical_artifacts_until_publ
 run_test test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish
 run_test test_workflow_documents_no_vcs_review_path
 run_test test_workflow_documents_arbiter_validate_build_publish_contract
+run_test test_installer_update_branch_uses_base_name_when_free
+run_test test_installer_update_branch_uses_suffix_when_date_branch_exists
+run_test test_installer_update_branch_skips_occupied_suffixes
+run_test test_installer_update_branch_selection_respects_skip_gates
 run_test test_installer_cleans_up_renamed_scripts
 run_test test_installer_updates_pristine_agents_file_in_place
 run_test test_installer_records_checksum_for_new_agents_file


### PR DESCRIPTION
## Summary
Fix Quest installer update branch creation so repeated same-day upgrades do not fail when the default update branch already exists locally.
- The installer keeps `quest-update-YYYYMMDD` when it is free.
- Existing local branch collisions now use deterministic suffixes starting at `-2`.

## Changes
- **Installer behavior**:
  - Add `next_available_update_branch_name()` in `scripts/quest_installer.sh` to find the first free local `refs/heads/*` branch name.
  - Use the helper inside the existing update branch prompt flow before `git checkout -b`.
- **Tests**:
  - Add runtime coverage for base branch preservation, first suffix selection, occupied suffix skipping, and branch-creation skip gates in `tests/test-quest-runtime.sh`.
- **Quest archive**:
  - Add the completed quest journal entry and index row for the issue #110 fix.

## Validation
- [ ] Run `scripts/quest_validate-manifest.sh` from the repository root. Expected: manifest validation completes with all Quest files listed and no stale entries.
- [ ] Run `bash tests/test-quest-runtime.sh` from the repository root. Expected: all runtime tests pass; current branch result is `Tests run: 45`, `Passed: 45`, `Failed: 0`.
- [ ] Manual branch collision walkthrough: Prerequisites: use a disposable git repo on `main` with an existing local branch named `quest-update-$(date +%Y%m%d)`. Action: run the installer, accept `Create a new branch for Quest changes?`. Expected: the installer creates and checks out `quest-update-$(date +%Y%m%d)-2`, while the original local branch remains present.

Watch for: branch selection intentionally checks only local `refs/heads/*`; matching remote branch names do not force suffixes.

## Notes
- Fixes https://github.com/KjellKod/quest/issues/110.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>
