### PR TITLE
Surface skipped Codex CI review instead of silent pass

### DIFF
--- a/.github/workflows/codex-ci-review.yml
+++ b/.github/workflows/codex-ci-review.yml
@@ -121,6 +121,24 @@ jobs:
           effort: high
           output-file: /tmp/review-output.json
 
+      - name: Report review completion status
+        # Runs even though AI Code Review uses continue-on-error, so a swallowed
+        # failure (commonly OpenAI quota exhaustion or a bad credential) is
+        # surfaced as an explicit "skipped" instead of an implicit clean pass.
+        if: always() && steps.check-key.outputs.skip != 'true'
+        run: |
+          if [ "${{ steps.review.outcome }}" = "success" ] && [ -s /tmp/review-output.json ]; then
+            echo "✅ Codex review completed." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning title=Codex review skipped::AI review did not complete (likely OpenAI quota exhaustion or a credential issue). This run is NOT a clean pass — the Codex reviewer did not produce findings."
+            {
+              echo "### ⚠️ Codex review skipped"
+              echo
+              echo "The AI reviewer did not complete (likely OpenAI quota exhaustion or a credential issue)."
+              echo "Treat this as **skipped**, not a clean pass — no Codex findings were produced for this run."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Post inline review
         if: always() && steps.check-key.outputs.skip != 'true'
         env:


### PR DESCRIPTION
## Summary
Make the Codex CI review report an explicit "skipped" status when it does not complete, so an OpenAI quota exhaustion or credential failure is no longer swallowed into a green, clean-looking pass.

## Changes
- **CI/Workflows**:
  - Add a `Report review completion status` step to `codex-ci-review.yml` that runs with `if: always()`. Because the `AI Code Review` step uses `continue-on-error: true`, a failed `codex-action` (commonly quota) otherwise left the empty-output path looking like a clean review. The new step emits a `::warning title=Codex review skipped::` annotation and a `$GITHUB_STEP_SUMMARY` note when the review did not complete, mirroring the existing missing-API-key skip path.

## Validation
- [ ] **Read the workflow change**: open `.github/workflows/codex-ci-review.yml` and confirm the new step sits between `AI Code Review` and `Post inline review`, guarded by `if: always() && steps.check-key.outputs.skip != 'true'`.
- [ ] **Success path**: on a PR where review runs normally, confirm the run summary shows `✅ Codex review completed.` and no skip warning.
- [ ] **Skipped path**: on a run where the review step fails or produces no output (e.g. quota), confirm the Actions summary shows the "Codex review skipped" note and the warning annotation, while the job still completes (continue-on-error preserved — quota does not block the PR).
Watch for: this is intentionally generic ("did not complete") rather than quota-specific, because `codex-action` errors are not surfaced to a later step for signature matching. It distinguishes "reviewer ran" from "reviewer did not run" — it does not diagnose why.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>