### PR TITLE
Add configurable quest completion behavior via on_complete

### DIFF
--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -3,7 +3,7 @@
   "description": "Creator-managed permissions for quest orchestration. Edit this file to pre-approve or restrict quest agent actions. Changes take effect on next quest run.",
   "quest_completion": {
     "enabled": true,
-    "on_complete": "ask",
+    "on_complete": "celebrate",
     "animation_style": "epic",
     "show_end_credits": true,
     "show_progress_bars": true,

--- a/.ai/allowlist.json
+++ b/.ai/allowlist.json
@@ -3,6 +3,7 @@
   "description": "Creator-managed permissions for quest orchestration. Edit this file to pre-approve or restrict quest agent actions. Changes take effect on next quest run.",
   "quest_completion": {
     "enabled": true,
+    "on_complete": "ask",
     "animation_style": "epic",
     "show_end_credits": true,
     "show_progress_bars": true,

--- a/.ai/schemas/allowlist.schema.json
+++ b/.ai/schemas/allowlist.schema.json
@@ -22,6 +22,7 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "on_complete": { "type": "string", "enum": ["ask", "celebrate", "archive_silent"] },
         "animation_style": { "type": "string" },
         "show_end_credits": { "type": "boolean" },
         "show_progress_bars": { "type": "boolean" },

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -1065,11 +1065,16 @@ After plan approval, present the plan interactively before proceeding to build.
 
 1. **Update state:** `phase: complete`, `status: complete`
 
-2. **Ask user before celebrating:**
-   - Prompt: "Quest is complete! What would you like to do?"
-     - **Celebrate!** — proceed to step 3 (run the celebration animation)
-     - **Skip celebration** — go straight to step 4 (journal + summary, no animation)
-   - In non-interactive / CI environments, skip the prompt and run the celebration automatically
+2. **Celebration behavior (read `quest_completion.on_complete` from allowlist; default `ask`):**
+   `on_complete` controls **only the prompt and the animation**. Every path
+   still continues through step 4 onward (journal + summary + archive) — the
+   quest always journals, summarizes, and archives regardless of this setting.
+   - **`ask`** (default — current behavior): Prompt "Quest is complete! What would you like to do?"
+     - **Celebrate!** — proceed to step 3 (run the celebration animation), then step 4
+     - **Skip celebration** — go straight to step 4 (journal + summary + archive, no animation)
+   - **`celebrate`**: skip the prompt and proceed directly to step 3 (run the celebration animation), then step 4 (journal + summary + archive).
+   - **`archive_silent`**: skip the prompt and skip the animation; go straight to step 4 (journal + summary + archive). No celebration.
+   - In non-interactive / CI environments: honor `archive_silent` (no animation); for `ask` or `celebrate`, run the celebration automatically. All paths still archive.
 
 3. **Run celebration (skill-first):**
    - Invoke the `celebrate` skill and provide the quest ID/path so it reads artifacts and renders rich markdown directly

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -1065,14 +1065,14 @@ After plan approval, present the plan interactively before proceeding to build.
 
 1. **Update state:** `phase: complete`, `status: complete`
 
-2. **Celebration behavior (read `quest_completion.on_complete` from allowlist; default `ask`):**
+2. **Celebration behavior (read `quest_completion.on_complete` from allowlist; default `celebrate`):**
    `on_complete` controls **only the prompt and the animation**. Every path
    still continues through step 4 onward (journal + summary + archive) — the
    quest always journals, summarizes, and archives regardless of this setting.
-   - **`ask`** (default — current behavior): Prompt "Quest is complete! What would you like to do?"
+   - **`celebrate`** (default): skip the prompt and proceed directly to step 3 (run the celebration animation), then step 4 (journal + summary + archive).
+   - **`ask`**: Prompt "Quest is complete! What would you like to do?"
      - **Celebrate!** — proceed to step 3 (run the celebration animation), then step 4
      - **Skip celebration** — go straight to step 4 (journal + summary + archive, no animation)
-   - **`celebrate`**: skip the prompt and proceed directly to step 3 (run the celebration animation), then step 4 (journal + summary + archive).
    - **`archive_silent`**: skip the prompt and skip the animation; go straight to step 4 (journal + summary + archive). No celebration.
    - In non-interactive / CI environments: honor `archive_silent` (no animation); for `ask` or `celebrate`, run the celebration automatically. All paths still archive.
 


### PR DESCRIPTION
## Summary
Add a `quest_completion.on_complete` allowlist setting controlling quest-completion behavior, defaulting to `celebrate` (auto-run the celebration animation without prompting).

> [!NOTE]
> This changes interactive behavior: quests now auto-celebrate on completion instead of prompting. Set `on_complete` to `ask` to restore the previous prompt, or `archive_silent` to skip the animation entirely.

## Changes
- **Config**:
  - Add `on_complete` to the `quest_completion` block in `.ai/allowlist.json`, default `"celebrate"`.
  - Add the matching property to `.ai/schemas/allowlist.schema.json` with an enum (`ask`, `celebrate`, `archive_silent`) so config validation stays in lockstep.
- **Behavior**:
  - Wire Step 7 of `workflow.md` to read `on_complete`: `celebrate` (default) skips the prompt and runs the animation, `ask` shows the prompt, `archive_silent` skips both prompt and animation. All three paths still journal, summarize, and archive — the setting controls only the prompt and the animation, never whether the quest archives.

## Validation
- [x] **Schema accepts all values**: run `bash scripts/quest_validate-quest-config.sh` and confirm it passes with `on_complete` set to each of `ask`, `celebrate`, `archive_silent`, and rejects an invalid value (e.g. `"never"`). Verified locally with both `ajv` and Python `jsonschema`.
- [x] **Default behavior**: with `on_complete` = `"celebrate"` (the new default), confirm Step 7 skips the prompt and runs the celebration animation, then journals/summarizes/archives.
- [x] **Opt back into prompt**: set `on_complete` to `"ask"` and confirm Step 7 shows "Quest is complete! What would you like to do?".
Watch for: the celebrate script (`scripts/quest_celebrate/config.py`) intentionally ignores `on_complete` — it is an orchestrator-level gate, not an animation setting, so no celebrate-script change is needed.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>