### PR TITLE
Require a value-first "Why this matters" section in PR descriptions

### DIFF
--- a/.skills/pr-assistant/SKILL.md
+++ b/.skills/pr-assistant/SKILL.md
@@ -36,6 +36,12 @@ Generate a pull request title and description from the current branch, then crea
 Use this format:
 
 ```
+## ⭐ Why this matters
+<1–3 sentences in plain language that make a busy human immediately see the VALUE — the problem this removes or the capability it unlocks — before any technical detail. Lead with impact, not mechanics.>
+<Optionally follow with 2–3 bold one-line benefit bullets.>
+
+---
+
 ## Summary
 <Single sentence capturing the full intent — what this PR does and why.>
 - Supporting bullet with additional context if needed.
@@ -60,6 +66,16 @@ Watch for: <known risk or edge case, if any>
 - Important implementation/deployment/reviewer context that is not obvious from the diff.
 - Do not repeat the Summary; only include unique, high-signal details reviewers should know.
 ```
+
+### Why this matters section (required — first thing in the body)
+
+This is the value-first executive summary. It sits at the very top so a busy human grasps **why they should care** at a glance, before any technical detail.
+
+- **Lead with impact, not mechanics.** State the problem this removes or the capability it unlocks in human terms — what was painful/risky/impossible before, and what is true now.
+- Keep it to 1–3 sentences, optionally followed by 2–3 bold one-line benefit bullets. A reader who stops after this section should still understand why the PR is worth merging.
+- Do **not** restate the file-by-file changes here (that's `## Changes`) and do **not** hedge with implementation caveats (that's `## Notes`).
+- Close the section with a `---` horizontal rule before `## Summary`.
+- Every PR gets this section. For a tiny/mechanical PR, one honest sentence is enough — never pad it.
 
 ### Summary section
 


### PR DESCRIPTION
## ⭐ Why this matters

Today our generated PR descriptions are technically thorough but bury the lede — a reviewer has to read the whole change list to figure out *why they should care*. This adds a mandatory value-first executive summary at the very top of every PR, so anyone skimming immediately sees the problem it removes or the capability it unlocks.

- 🎯 **Faster triage** — reviewers decide how deeply to engage from one glance.
- 🗣️ **Human-first framing** — impact before mechanics, with the technical detail still right below.

---

## Summary
Add a required "Why this matters" section to the `pr-assistant` body template and rules so future PRs lead with value, not file lists.

## Changes
- **Skills**:
  - `.skills/pr-assistant/SKILL.md`: prepend a `## ⭐ Why this matters` block (closed by a `---`) to the body-format template, and add a **"Why this matters section"** rule — lead with impact not mechanics, 1–3 sentences, no change-list or caveats, every PR gets it (one honest sentence for tiny PRs, never padded).
- The `.claude` / `.opencode` / `.agents` pr-assistant entries are thin pointers to this canonical skill, so no mirror edits were needed.

## Validation
- [ ] **Read the updated rule**: open `.skills/pr-assistant/SKILL.md` and confirm the body template now starts with `## ⭐ Why this matters` followed by `---` and then `## Summary`, and that the "Why this matters section" rule appears just above "Summary section".
- [ ] **Dogfood check**: this PR's own description follows the new format — the top section states the value before any file-level detail.

## Notes
- Behavioral/doc-only change to a skill; no code or tests affected.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>