### PR TITLE
Generalize Quest shared symlink startup handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Quest ephemeral state
+.quest
 .quest/
+.quest_conflicts/
 .worktrees/
 .claude/worktrees/
 

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -181,11 +181,18 @@ Before creating the quest folder, present the routing classification to the user
    - Parse the JSON result
    - If `status` is `"blocked"`: show the returned `message`, do NOT create the quest folder yet, and stop for the user to resolve the git state or config
    - If `status` is `"created"` or `"skipped"`: continue and surface the returned `message` to the user
+   - Surface the returned `quest_symlink` outcome after startup:
+     - `created`: note that the worktree `.quest/` symlink was created.
+     - `present`: note that the worktree `.quest/` symlink was already present.
+     - `migrated`: tell the user that an existing worktree `.quest/` was safely migrated into the shared store.
+     - `conflict`: warn the user that same-name `.quest/` entries were preserved under `.quest_conflicts/` and need manual review.
+     - `n/a`: no linked-worktree symlink action was needed.
    - Record these fields for `state.json` initialization:
      - `vcs_available`
      - `branch`
      - `branch_mode`
      - `worktree_path` (if present)
+     - `quest_symlink`
 4. Read `quest_id_format` from `.ai/allowlist.json` using `quest_runtime.quest_ids.load_quest_id_format`; missing config defaults to `slug-first`.
 5. Create the Quest ID with `quest_runtime.quest_ids.format_quest_id(slug, datetime.now(), quest_id_format)`. Pass a `datetime.datetime` object, not a preformatted timestamp string; the helper formats date/time internally.
    - Default slug-first: `<slug>_YYYY-MM-DD__HHMM`
@@ -263,6 +270,7 @@ Before creating the quest folder, present the routing classification to the user
      "branch": "quest/<slug> or current branch",
      "branch_mode": "branch | worktree | none",
      "worktree_path": "/absolute/path/to/worktree (worktree mode only)",
+     "quest_symlink": "created | present | migrated | conflict | n/a",
      "plan_iteration": 0,
      "fix_iteration": 0,
      "created_at": "<timestamp>",
@@ -272,6 +280,7 @@ Before creating the quest folder, present the routing classification to the user
    Set `quest_mode` to the user's final selection: `"workflow"` (default) or `"solo"`. This field is read by `workflow.md` to determine agent dispatch and by `validate-quest-state.sh` for artifact checks.
    `vcs_available` must be copied directly from `scripts/quest_startup_branch.py` output. Do not infer it from `branch_mode`.
    `branch_mode` records the actual startup mode used for this quest run after no-op handling. If Quest starts on an existing feature branch, set `branch_mode` to `"none"` and record that branch in `branch`.
+   `quest_symlink` must be copied directly from `scripts/quest_startup_branch.py` output. Do not infer it from `branch_mode` or `worktree_path`.
 
 ### UI Work Propagation
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -7,6 +7,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 | Date | Quest | Outcome |
 |------|-------|---------|
 | 2026-05-31 | [pre-pr-sync](pre-pr-sync_2026-05-31.md) | implement using $quest ideas/2026-05-30-pre-pr-freshness-and-force-push-guard.md |
+| 2026-05-31 | [shared-quest-symlink](shared-quest-symlink_2026-05-31.md) | - **Agent:** Planner - **Model:** claude-opus-4-8 - **Date:** 2026-05-31 - **Quest ID:** shared-quest-symlink_2026-05... |
 | 2026-05-30 | [code-review-adjudication](code-review-adjudication_2026-05-30.md) | **Completed (PR #124).** Enforce per-slot findings JSON (fail closed) + add an impartial code-review arbiter; brought code review to plan-phase adjudication parity. |
 | 2026-05-22 | [sharpen-grounding](sharpen-grounding_2026-05-22.md) | Improve the standalone sharpen skill so its questions are grounded in repo evidence when local implementation facts m... |
 | 2026-05-18 | [orchestration-override](orchestration-override_2026-05-18.md) | 1. New per-quest config file `.quest/<id>/orchestration.json` written at quest startup. This file is the single sourc... |

--- a/docs/quest-journal/celebrations/shared-quest-symlink_2026-05-31.md
+++ b/docs/quest-journal/celebrations/shared-quest-symlink_2026-05-31.md
@@ -1,0 +1,85 @@
+<!-- quest-id: shared-quest-symlink_2026-05-31__1239 -->
+<!-- style: celebration -->
+<!-- quality-tier: Gold -->
+<!-- date: 2026-05-31 -->
+<!-- journal: ../shared-quest-symlink_2026-05-31.md -->
+<!-- origin: step7-original -->
+
+# Quest Celebration: shared-quest-symlink
+
+```text
+███████╗██╗  ██╗ █████╗ ██████╗ ███████╗██████╗ 
+██╔════╝██║  ██║██╔══██╗██╔══██╗██╔════╝██╔══██╗
+███████╗███████║███████║██████╔╝█████╗  ██║  ██║
+╚════██║██╔══██║██╔══██║██╔══██╗██╔══╝  ██║  ██║
+███████║██║  ██║██║  ██║██║  ██║███████╗██████╔╝
+╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═════╝
+
+ ██████╗ ██╗   ██╗███████╗███████╗████████╗
+██╔═══██╗██║   ██║██╔════╝██╔════╝╚══██╔══╝
+██║   ██║██║   ██║█████╗  ███████╗   ██║   
+██║▄▄ ██║██║   ██║██╔══╝  ╚════██║   ██║   
+╚██████╔╝╚██████╔╝███████╗███████║   ██║   
+ ╚══▀▀═╝  ╚═════╝ ╚══════╝╚══════╝   ╚═╝
+
+███████╗██╗   ██╗███╗   ███╗██╗     ██╗███╗   ██╗██╗  ██╗
+██╔════╝╚██╗ ██╔╝████╗ ████║██║     ██║████╗  ██║██║ ██╔╝
+███████╗ ╚████╔╝ ██╔████╔██║██║     ██║██╔██╗ ██║█████╔╝ 
+╚════██║  ╚██╔╝  ██║╚██╔╝██║██║     ██║██║╚██╗██║██╔═██╗ 
+███████║   ██║   ██║ ╚═╝ ██║███████╗██║██║ ╚████║██║  ██╗
+╚══════╝   ╚═╝   ╚═╝     ╚═╝╚══════╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝
+```
+
+---
+
+## What Started This
+
+$quest in a new worktree branch, run this quest in solo mode. "Generalize Quest's worktree .quest symlink so it's guaranteed on every quest start.
+
+## Starring Cast
+
+- **builder** ........ The Implementer
+
+## Achievements
+
+- [BUG] **Gremlin Slayer** — Tackled 5 review findings
+- [TEST] **Battle Tested** — Survived 2 reviews
+- [PLAN] **Plan Perfectionist** — Iterated plan 2 times
+- [SOLO] **Solo Adventurer** — Completed quest with a single companion
+- [WIN] **Quest Complete** — All phases finished successfully
+
+## Impact Metrics
+
+- Review findings addressed: **5**
+- Review rounds completed: **2**
+- Plan iterations: **2**
+- Fix iterations: **0**
+
+## Handoff & Reliability
+
+- Handoffs parsed: 1
+- Reviewer handoffs: 0
+- Fixer handoffs: 0
+- Review findings tracked: 5
+- Reliability signal: high
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## 🥇 Quality Tier: Gold
+
+QUALITY SCORE
+----------------------------------------
+  [██████████████████░░] 90% (Grade: A)
+
+
+## Quest Quote
+
+> "Verdict:** ✅ Approve — ready for build. All four prior findings resolved; the conscious Finding [5] deferral is consistent with the brief. Remaining notes are P3 builder hardening only."
+>
+> — Review finding
+
+## Victory Narrative
+
+$quest in a new worktree branch, run this quest in solo mode. "Generalize Quest's worktree .quest symlink so it's guaranteed on every quest start. The quest finished with 2 plan iteration(s), 0 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/shared-quest-symlink_2026-05-31.md
+++ b/docs/quest-journal/shared-quest-symlink_2026-05-31.md
@@ -1,0 +1,178 @@
+# Quest Journal: shared-quest-symlink
+
+- Quest ID: `shared-quest-symlink_2026-05-31__1239`
+- Slug: shared-quest-symlink
+- Completed: 2026-05-31
+- Mode: solo
+- Quality: Gold
+- Celebration: [`celebrations/shared-quest-symlink_2026-05-31.md`](celebrations/shared-quest-symlink_2026-05-31.md)
+- Outcome: - **Agent:** Planner - **Model:** claude-opus-4-8 - **Date:** 2026-05-31 - **Quest ID:** shared-quest-symlink_2026-05-31__1239
+
+## What Shipped
+
+- **Agent:** Planner
+- **Model:** claude-opus-4-8
+- **Date:** 2026-05-31
+- **Quest ID:** shared-quest-symlink_2026-05-31__1239
+
+## Files Changed
+
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_01_plan/plan.md`
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_02_implementation/pr_description.md`
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_03_review/review_code-reviewer-a.md`
+- `.quest/shared-quest-symlink_2026-05-31__1239/phase_03_review/review_findings_code-reviewer-a.json`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 0
+
+## Agents
+
+- **The Implementer** (builder): 
+
+## Quest Brief
+
+$quest in a new worktree branch, run this quest in solo mode. 
+"Generalize Quest's worktree .quest symlink so it's guaranteed on every quest start.
+
+  GOAL
+  Make every quest start guarantee that, when running inside a linked git worktree, the worktree's `.quest/` is a symlink to the MAIN repo's shared `.quest/` —
+  for ALL branch modes and whether Quest or a human created the worktree.
+
+  WHY / BUG (verified)
+  `.quest/` is intentionally gitignored — a single shared, per-repo run store. `scripts/quest_startup_branch.py` ALREADY symlinks `.quest/` into a worktree
+  (~lines 361–374), but ONLY in the worktree-creation path (branch_mode: worktree). When a human pre-creates a worktree and Quest runs with branch_mode: none (or
+  the 'already on branch → skipped' path), that code is never reached, so the worktree keeps its OWN real `.quest/`. Those artifacts are orphaned — not in the
+  shared store, and destroyed when the worktree is removed — which silently breaks quest_complete.py journaling, quest_backfill_journal.py, and the dashboard.
+  This caused a real incident (a completed quest left no journal entry / dashboard record).
+
+  SCOPE (targeted, thin — do not refactor unrelated parts)
+  - scripts/quest_startup_branch.py: extract the symlink-ensure into a reusable helper (e.g. ensure_shared_quest_symlink(repo_root, workdir)) and call it on
+  EVERY startup path (none, branch, worktree, and the skipped/already-on-branch path), not just worktree creation.
+  - Detect a linked worktree via `git rev-parse --git-common-dir` (≠ local .git ⇒ linked; shared store = dirname(common-dir)/.quest). In the main worktree,
+  no-op.
+  - SAFE migration (critical — NEVER lose data):
+      * `.quest` absent → create the symlink.
+      * `.quest` already a symlink → leave it.
+      * `.quest` is a REAL dir with content → MOVE/merge its quest subdirs into the shared `.quest/` first, THEN replace with the symlink. Never rmtree-and-drop.
+  If the same quest id exists in both and differs, preserve both (keep shared, move the worktree copy aside) and flag a conflict.
+  - Add a `quest_symlink` field to the JSON result: created | present | migrated | conflict | n/a.
+  - .skills/quest/SKILL.md startup (Quest Folder Creation, where it runs quest_startup_branch.py): surface the quest_symlink outcome to the human after the fact
+  — especially migrated/conflict.
+
+  CONSTRAINTS
+  - Never destroy or drop existing `.quest/` content — migrate, don't delete.
+  - Keep it targeted; add/extend tests.
+
+  ACCEPTANCE CRITERIA
+  1. ensure_shared_quest_symlink runs at quest start in ALL branch modes (incl. none and skipped/already-on-branch).
+  2. In a linked worktree, <worktree>/.quest ends as a symlink to <main-repo>/.quest: created when absent, left when already a symlink, and content-migrated with
+  NO data loss when a real dir pre-exists.
+  3. JSON result includes quest_symlink; SKILL.md surfaces it to the human.
+  4. Main (non-linked) worktree → quest_symlink: n/a, no symlink created.
+  5. Tests cover: absent→created; real-dir-with-quests→migrated (assert no quest lost); already-symlink→present/no-op; main-repo→n/a; conflicting-same-id→both
+  preserved + flagged.
+  6. SELF-VALIDATION (live, partial): this quest runs in a worktree IT creates (branch_mode: worktree). Confirm its own <worktree>/.quest is a symlink to the
+  main repo's .quest and this quest's artifacts are visible in the shared store. NOTE: this only exercises the pre-existing worktree-creation happy path — the
+  running quest used the PRE-EDIT script, so your edits take effect on FUTURE starts, not this one. The NEW generalized path (branch_mode none /
+  human-pre-created worktree) MUST be proven by the AC#5 tests, not by self-dogfooding.
+
+  OUT OF SCOPE (separate follow-ups — do NOT bundle)
+  - Making quest completion/journaling a fail-closed terminal gate (quest_complete.py as the only path to `complete`).
+  - Backfilling the missing journal entry for the already-merged code-review-adjudication quest.
+
+  WORKSPACE: create and run in a new quest/<slug> worktree branch (worktree mode)."
+
+  Two notes:
+  - I deliberately scoped this to the symlink fix only and listed the completion-gate + the journal backfill as explicit out-of-scope, so the new agent doesn't
+  sprawl (and per your own value-over-theatre rule). Those two are worth their own quest/just-do-it later.
+  - If you'd rather skip the pipeline entirely, the same text works as a "just do it" prompt — drop the /quest wrapper and the workspace line and hand it over.
+  But I'd keep it a solo quest: the migration logic is exactly where a review pass earns its keep.
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- Full celebration: [`celebrations/shared-quest-symlink_2026-05-31.md`](celebrations/shared-quest-symlink_2026-05-31.md)
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/shared-quest-symlink_2026-05-31.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "solo",
+  "agents": [
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 5 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 2 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[SOLO]",
+      "title": "Solo Adventurer",
+      "desc": "Completed quest with a single companion"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review findings: 2"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 6
+}
+```
+<!-- celebration-data-end -->

--- a/scripts/quest_startup_branch.py
+++ b/scripts/quest_startup_branch.py
@@ -203,7 +203,7 @@ def apply_quest_symlink(worktree_quest: Path, shared_quest: Path) -> str:
         return "created"
 
     if not worktree_quest.is_dir():
-        return "conflict"
+        raise RuntimeError(f"{worktree_quest} exists but is not a directory or symlink")
 
     moved_any = False
     had_conflict = False
@@ -224,8 +224,8 @@ def apply_quest_symlink(worktree_quest: Path, shared_quest: Path) -> str:
         # Empty-only removal is deliberate: never force-delete migrated state.
         worktree_quest.rmdir()
         worktree_quest.symlink_to(shared_quest)
-    except Exception:
-        return "conflict"
+    except Exception as exc:
+        raise RuntimeError(f"Unable to replace {worktree_quest} with shared symlink") from exc
 
     if had_conflict:
         return "conflict"
@@ -240,10 +240,7 @@ def ensure_shared_quest_symlink(repo_root: Path, workdir: Path) -> str:
     shared_quest = resolve_shared_quest_dir(workdir)
     if shared_quest is None:
         return "n/a"
-    try:
-        return apply_quest_symlink(workdir / ".quest", shared_quest)
-    except Exception:
-        return "conflict"
+    return apply_quest_symlink(workdir / ".quest", shared_quest)
 
 
 def combine_quest_symlink_outcomes(*outcomes: str) -> str:

--- a/scripts/quest_startup_branch.py
+++ b/scripts/quest_startup_branch.py
@@ -174,10 +174,27 @@ def _conflict_dir_for(worktree_quest: Path, shared_quest: Path) -> Path:
     return shared_quest.parent / ".quest_conflicts" / worktree_name
 
 
+def _symlink_points_to(path: Path, target: Path) -> bool:
+    link_target = path.readlink()
+    if not link_target.is_absolute():
+        link_target = path.parent / link_target
+    return link_target.resolve() == target.resolve()
+
+
 def apply_quest_symlink(worktree_quest: Path, shared_quest: Path) -> str:
     """Ensure a worktree .quest symlink with migration and no data loss."""
     if worktree_quest.is_symlink():
-        return "present"
+        if _symlink_points_to(worktree_quest, shared_quest):
+            return "present"
+        shared_quest.mkdir(parents=True, exist_ok=True)
+        conflict_dir = _conflict_dir_for(worktree_quest, shared_quest)
+        conflict_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(
+            str(worktree_quest),
+            str(_unique_destination(conflict_dir / ".quest")),
+        )
+        worktree_quest.symlink_to(shared_quest)
+        return "conflict"
 
     shared_quest.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/quest_startup_branch.py
+++ b/scripts/quest_startup_branch.py
@@ -120,6 +120,115 @@ def repo_dirty(repo_root: Path) -> bool:
     )
 
 
+def resolve_shared_quest_dir(workdir: Path) -> Path | None:
+    """Return the main repo's shared .quest dir for a linked worktree."""
+    try:
+        common_dir_raw = run_git(
+            workdir,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+            check=True,
+        )
+    except Exception:
+        try:
+            common_dir_raw = run_git(
+                workdir,
+                "rev-parse",
+                "--git-common-dir",
+                check=True,
+            )
+        except Exception:
+            return None
+
+    common_dir = Path(common_dir_raw)
+    if not common_dir.is_absolute():
+        common_dir = (workdir / common_dir).resolve()
+    else:
+        common_dir = common_dir.resolve()
+
+    main_root = common_dir.parent.resolve()
+    if main_root == workdir.resolve():
+        return None
+    return main_root / ".quest"
+
+
+def _unique_destination(path: Path) -> Path:
+    if not path.exists() and not path.is_symlink():
+        return path
+    for index in range(1, 10_000):
+        candidate = path.with_name(f"{path.name}-{index}")
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise RuntimeError(f"Unable to find unique destination for {path}")
+
+
+def _conflict_dir_for(worktree_quest: Path, shared_quest: Path) -> Path:
+    worktree_name = re.sub(
+        r"[^A-Za-z0-9_.-]+",
+        "-",
+        worktree_quest.parent.name,
+    ).strip("-")
+    if not worktree_name:
+        worktree_name = "worktree"
+    return shared_quest.parent / ".quest_conflicts" / worktree_name
+
+
+def apply_quest_symlink(worktree_quest: Path, shared_quest: Path) -> str:
+    """Ensure a worktree .quest symlink with migration and no data loss."""
+    if worktree_quest.is_symlink():
+        return "present"
+
+    shared_quest.mkdir(parents=True, exist_ok=True)
+
+    if not worktree_quest.exists():
+        worktree_quest.symlink_to(shared_quest)
+        return "created"
+
+    if not worktree_quest.is_dir():
+        return "conflict"
+
+    moved_any = False
+    had_conflict = False
+    conflict_dir = _conflict_dir_for(worktree_quest, shared_quest)
+
+    try:
+        for entry in list(worktree_quest.iterdir()):
+            destination = shared_quest / entry.name
+            if destination.exists() or destination.is_symlink():
+                conflict_dir.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(entry), str(_unique_destination(conflict_dir / entry.name)))
+                had_conflict = True
+                continue
+
+            shutil.move(str(entry), str(destination))
+            moved_any = True
+
+        # Empty-only removal is deliberate: never force-delete migrated state.
+        worktree_quest.rmdir()
+        worktree_quest.symlink_to(shared_quest)
+    except Exception:
+        return "conflict"
+
+    if had_conflict:
+        return "conflict"
+    if moved_any:
+        return "migrated"
+    return "created"
+
+
+def ensure_shared_quest_symlink(repo_root: Path, workdir: Path) -> str:
+    """Ensure linked worktrees use the main repo's shared .quest directory."""
+    del repo_root  # Signature keeps the caller contract explicit.
+    shared_quest = resolve_shared_quest_dir(workdir)
+    if shared_quest is None:
+        return "n/a"
+    try:
+        return apply_quest_symlink(workdir / ".quest", shared_quest)
+    except Exception:
+        return "conflict"
+
+
 def build_result(
     *,
     status: str,
@@ -132,6 +241,7 @@ def build_result(
     branch_created: bool,
     worktree_path: Path | None,
     message: str,
+    quest_symlink: str = "n/a",
 ) -> dict[str, Any]:
     return {
         "status": status,
@@ -143,6 +253,7 @@ def build_result(
         "default_branch": default_branch,
         "branch_created": branch_created,
         "worktree_path": str(worktree_path) if worktree_path else None,
+        "quest_symlink": quest_symlink,
         "message": message,
     }
 
@@ -241,6 +352,7 @@ def main() -> int:
         branch_name = f"{branch_prefix}{args.slug}"
 
         if current_branch != default_branch:
+            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="skipped",
                 vcs_available=True,
@@ -251,12 +363,14 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=None,
+                quest_symlink=quest_symlink,
                 message=f"Already on branch {current_branch} — skipping quest startup branch creation.",
             )
             print(json.dumps(payload, indent=2))
             return 0
 
         if requested_branch_mode == "none":
+            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="skipped",
                 vcs_available=True,
@@ -267,6 +381,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=None,
+                quest_symlink=quest_symlink,
                 message="Quest startup branch mode disabled — staying on the current branch.",
             )
             print(json.dumps(payload, indent=2))
@@ -312,6 +427,7 @@ def main() -> int:
                 return 0
 
             run_git(repo_root, "checkout", "-b", branch_name)
+            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="created",
                 vcs_available=True,
@@ -322,6 +438,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=True,
                 worktree_path=None,
+                quest_symlink=quest_symlink,
                 message=f"Created and checked out quest branch {branch_name}.",
             )
             print(json.dumps(payload, indent=2))
@@ -358,20 +475,7 @@ def main() -> int:
             default_branch,
         )
 
-        # Symlink .quest/ into the worktree so subagents can use
-        # relative .quest/<id>/... paths without special handling.
-        # git worktree checkout may create a real .quest/ dir from
-        # force-tracked files — replace it with a symlink to the
-        # main repo's .quest/ so the active quest is visible.
-        quest_link = worktree_path / ".quest"
-        quest_source = repo_root / ".quest"
-        if quest_link.is_symlink():
-            pass  # already a symlink, leave it
-        elif quest_link.is_dir():
-            shutil.rmtree(quest_link)
-            quest_link.symlink_to(quest_source)
-        elif not quest_link.exists():
-            quest_link.symlink_to(quest_source)
+        quest_symlink = ensure_shared_quest_symlink(repo_root, worktree_path)
 
         payload = build_result(
             status="created",
@@ -383,6 +487,7 @@ def main() -> int:
             default_branch=default_branch,
             branch_created=True,
             worktree_path=worktree_path,
+            quest_symlink=quest_symlink,
             message=f"Created quest worktree {worktree_path} on branch {branch_name}.",
         )
         print(json.dumps(payload, indent=2))

--- a/scripts/quest_startup_branch.py
+++ b/scripts/quest_startup_branch.py
@@ -246,6 +246,18 @@ def ensure_shared_quest_symlink(repo_root: Path, workdir: Path) -> str:
         return "conflict"
 
 
+def combine_quest_symlink_outcomes(*outcomes: str) -> str:
+    """Return the most important .quest symlink outcome to surface."""
+    priority = {
+        "n/a": 0,
+        "present": 1,
+        "created": 2,
+        "migrated": 3,
+        "conflict": 4,
+    }
+    return max(outcomes, key=lambda outcome: priority.get(outcome, 0))
+
+
 def build_result(
     *,
     status: str,
@@ -348,6 +360,8 @@ def main() -> int:
             print(json.dumps(payload, indent=2))
             return 0
 
+        current_quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
+
         current_branch = run_git(repo_root, "branch", "--show-current", check=False)
         if not current_branch:
             payload = build_result(
@@ -360,6 +374,7 @@ def main() -> int:
                 default_branch=None,
                 branch_created=False,
                 worktree_path=None,
+                quest_symlink=current_quest_symlink,
                 message="Detached HEAD detected. Quest startup branch setup requires a named branch checkout.",
             )
             print(json.dumps(payload, indent=2))
@@ -369,7 +384,6 @@ def main() -> int:
         branch_name = f"{branch_prefix}{args.slug}"
 
         if current_branch != default_branch:
-            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="skipped",
                 vcs_available=True,
@@ -380,14 +394,13 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=None,
-                quest_symlink=quest_symlink,
+                quest_symlink=current_quest_symlink,
                 message=f"Already on branch {current_branch} — skipping quest startup branch creation.",
             )
             print(json.dumps(payload, indent=2))
             return 0
 
         if requested_branch_mode == "none":
-            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="skipped",
                 vcs_available=True,
@@ -398,7 +411,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=None,
-                quest_symlink=quest_symlink,
+                quest_symlink=current_quest_symlink,
                 message="Quest startup branch mode disabled — staying on the current branch.",
             )
             print(json.dumps(payload, indent=2))
@@ -415,6 +428,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=None,
+                quest_symlink=current_quest_symlink,
                 message=(
                     f"Branch {branch_name} already exists. "
                     "Choose a different quest slug or clean up the existing branch first."
@@ -435,6 +449,7 @@ def main() -> int:
                     default_branch=default_branch,
                     branch_created=False,
                     worktree_path=None,
+                    quest_symlink=current_quest_symlink,
                     message=(
                         "Working tree is dirty on the default branch. "
                         "Commit or stash changes before Quest creates a startup branch."
@@ -444,7 +459,6 @@ def main() -> int:
                 return 0
 
             run_git(repo_root, "checkout", "-b", branch_name)
-            quest_symlink = ensure_shared_quest_symlink(repo_root, repo_root)
             payload = build_result(
                 status="created",
                 vcs_available=True,
@@ -455,7 +469,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=True,
                 worktree_path=None,
-                quest_symlink=quest_symlink,
+                quest_symlink=current_quest_symlink,
                 message=f"Created and checked out quest branch {branch_name}.",
             )
             print(json.dumps(payload, indent=2))
@@ -473,6 +487,7 @@ def main() -> int:
                 default_branch=default_branch,
                 branch_created=False,
                 worktree_path=worktree_path,
+                quest_symlink=current_quest_symlink,
                 message=(
                     f"Worktree path already exists: {worktree_path}. "
                     "Remove it or choose a different quest slug first."
@@ -492,7 +507,10 @@ def main() -> int:
             default_branch,
         )
 
-        quest_symlink = ensure_shared_quest_symlink(repo_root, worktree_path)
+        quest_symlink = combine_quest_symlink_outcomes(
+            current_quest_symlink,
+            ensure_shared_quest_symlink(repo_root, worktree_path),
+        )
 
         payload = build_result(
             status="created",

--- a/tests/unit/test_quest_startup_symlink.py
+++ b/tests/unit/test_quest_startup_symlink.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import quest_startup_branch
 from quest_startup_branch import apply_quest_symlink, ensure_shared_quest_symlink
 
@@ -182,6 +184,18 @@ def test_apply_quest_symlink_conflict_preserves_both_outside_quest(
     assert not list(shared_quest.glob("**/.quest_conflicts"))
 
 
+def test_apply_quest_symlink_non_dir_blocks_startup(tmp_path: Path) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    worktree_quest.parent.mkdir()
+    worktree_quest.write_text("not a quest dir\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="not a directory or symlink"):
+        apply_quest_symlink(worktree_quest, shared_quest)
+
+    assert worktree_quest.is_file()
+
+
 def test_ensure_shared_quest_symlink_main_repo_returns_na(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path / "repo")
 
@@ -301,6 +315,24 @@ def test_startup_worktree_mode_from_linked_worktree_migrates_current_workspace(
     assert (created_worktree / ".quest").is_symlink()
     assert _target(created_worktree / ".quest") == repo / ".quest"
     assert (repo / ".quest" / "orphaned-quest" / "state.json").read_text() == "orphan"
+
+
+def test_startup_none_mode_in_linked_worktree_blocks_when_symlink_cannot_install(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "none")
+    _git(repo, "checkout", "-b", "holder")
+    worktree = tmp_path / "main-linked"
+    _git(repo, "worktree", "add", str(worktree), "main")
+    (worktree / ".quest").write_text("not a quest dir\n", encoding="utf-8")
+
+    payload = _run_startup(worktree, allowlist, "new-quest", "none")
+
+    assert payload["status"] == "blocked"
+    assert payload["quest_symlink"] == "n/a"
+    assert "not a directory or symlink" in payload["message"]
+    assert (worktree / ".quest").is_file()
 
 
 def test_startup_main_repo_none_and_branch_report_na(tmp_path: Path) -> None:

--- a/tests/unit/test_quest_startup_symlink.py
+++ b/tests/unit/test_quest_startup_symlink.py
@@ -119,6 +119,26 @@ def test_apply_quest_symlink_existing_symlink_is_present_noop(tmp_path: Path) ->
     assert _target(worktree_quest) == shared_quest
 
 
+def test_apply_quest_symlink_wrong_symlink_preserves_and_replaces(
+    tmp_path: Path,
+) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    wrong_quest = tmp_path / "wrong" / ".quest"
+    worktree_quest.parent.mkdir()
+    shared_quest.mkdir(parents=True)
+    wrong_quest.mkdir(parents=True)
+    worktree_quest.symlink_to(wrong_quest)
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "conflict"
+
+    assert worktree_quest.is_symlink()
+    assert _target(worktree_quest) == shared_quest
+    preserved = shared_quest.parent / ".quest_conflicts" / "worktree" / ".quest"
+    assert preserved.is_symlink()
+    assert _target(preserved) == wrong_quest
+
+
 def test_apply_quest_symlink_empty_real_dir_returns_created(tmp_path: Path) -> None:
     worktree_quest = tmp_path / "worktree" / ".quest"
     shared_quest = tmp_path / "main" / ".quest"

--- a/tests/unit/test_quest_startup_symlink.py
+++ b/tests/unit/test_quest_startup_symlink.py
@@ -276,6 +276,33 @@ def test_startup_worktree_mode_creates_symlink_and_reports_created(
     assert _target(worktree / ".quest") == repo / ".quest"
 
 
+def test_startup_worktree_mode_from_linked_worktree_migrates_current_workspace(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "worktree")
+    _git(repo, "checkout", "-b", "holder")
+    current_worktree = tmp_path / "main-linked"
+    _git(repo, "worktree", "add", str(current_worktree), "main")
+    (current_worktree / ".quest" / "orphaned-quest").mkdir(parents=True)
+    (current_worktree / ".quest" / "orphaned-quest" / "state.json").write_text(
+        "orphan",
+        encoding="utf-8",
+    )
+
+    payload = _run_startup(current_worktree, allowlist, "new-quest", "worktree")
+    created_worktree = Path(payload["worktree_path"])
+
+    assert payload["status"] == "created"
+    assert payload["branch_mode"] == "worktree"
+    assert payload["quest_symlink"] == "migrated"
+    assert (current_worktree / ".quest").is_symlink()
+    assert _target(current_worktree / ".quest") == repo / ".quest"
+    assert (created_worktree / ".quest").is_symlink()
+    assert _target(created_worktree / ".quest") == repo / ".quest"
+    assert (repo / ".quest" / "orphaned-quest" / "state.json").read_text() == "orphan"
+
+
 def test_startup_main_repo_none_and_branch_report_na(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path / "repo")
     allowlist = _write_allowlist(repo, "none")

--- a/tests/unit/test_quest_startup_symlink.py
+++ b/tests/unit/test_quest_startup_symlink.py
@@ -1,0 +1,268 @@
+"""Tests for Quest startup .quest symlink handling."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import quest_startup_branch
+from quest_startup_branch import apply_quest_symlink, ensure_shared_quest_symlink
+
+
+SCRIPT = Path(quest_startup_branch.__file__).resolve()
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path: Path) -> Path:
+    subprocess.run(["git", "init", "-b", "main", str(path)], check=True)
+    _git(path, "config", "user.name", "Quest Test")
+    _git(path, "config", "user.email", "quest-test@example.com")
+    (path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-m", "init")
+    return path
+
+
+def _write_allowlist(repo: Path, branch_mode: str) -> Path:
+    allowlist = repo / ".ai" / "allowlist.json"
+    allowlist.parent.mkdir(parents=True, exist_ok=True)
+    allowlist.write_text(
+        json.dumps(
+            {
+                "quest_startup": {
+                    "branch_mode": branch_mode,
+                    "branch_prefix": "quest/",
+                    "worktree_root": ".worktrees/quest",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return allowlist
+
+
+def _run_startup(repo_root: Path, allowlist: Path, slug: str, mode: str) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo_root),
+            "--allowlist",
+            str(allowlist),
+            "--slug",
+            slug,
+            "--mode",
+            mode,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _target(path: Path) -> Path:
+    return Path(path.readlink()).resolve()
+
+
+def test_apply_quest_symlink_absent_creates_symlink(tmp_path: Path) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    worktree_quest.parent.mkdir()
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "created"
+
+    assert worktree_quest.is_symlink()
+    assert _target(worktree_quest) == shared_quest
+    assert shared_quest.is_dir()
+
+
+def test_apply_quest_symlink_real_dir_migrates_without_loss(tmp_path: Path) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    (worktree_quest / "quest-a").mkdir(parents=True)
+    (worktree_quest / "quest-a" / "state.json").write_text("a", encoding="utf-8")
+    (worktree_quest / "quest-b").mkdir()
+    (worktree_quest / "quest-b" / "state.json").write_text("b", encoding="utf-8")
+    (shared_quest / "quest-c").mkdir(parents=True)
+    (shared_quest / "quest-c" / "state.json").write_text("c", encoding="utf-8")
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "migrated"
+
+    assert worktree_quest.is_symlink()
+    assert (shared_quest / "quest-a" / "state.json").read_text() == "a"
+    assert (shared_quest / "quest-b" / "state.json").read_text() == "b"
+    assert (shared_quest / "quest-c" / "state.json").read_text() == "c"
+
+
+def test_apply_quest_symlink_existing_symlink_is_present_noop(tmp_path: Path) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    worktree_quest.parent.mkdir()
+    shared_quest.mkdir(parents=True)
+    worktree_quest.symlink_to(shared_quest)
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "present"
+    assert _target(worktree_quest) == shared_quest
+
+
+def test_apply_quest_symlink_empty_real_dir_returns_created(tmp_path: Path) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    worktree_quest.mkdir(parents=True)
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "created"
+
+    assert worktree_quest.is_symlink()
+    assert _target(worktree_quest) == shared_quest
+
+
+def test_apply_quest_symlink_conflict_preserves_both_outside_quest(
+    tmp_path: Path,
+) -> None:
+    worktree_quest = tmp_path / "worktree" / ".quest"
+    shared_quest = tmp_path / "main" / ".quest"
+    (worktree_quest / "same-id").mkdir(parents=True)
+    (worktree_quest / "same-id" / "state.json").write_text(
+        "worktree",
+        encoding="utf-8",
+    )
+    (shared_quest / "same-id").mkdir(parents=True)
+    (shared_quest / "same-id" / "state.json").write_text(
+        "shared",
+        encoding="utf-8",
+    )
+
+    assert apply_quest_symlink(worktree_quest, shared_quest) == "conflict"
+
+    assert worktree_quest.is_symlink()
+    assert (shared_quest / "same-id" / "state.json").read_text() == "shared"
+    conflict_copy = (
+        shared_quest.parent
+        / ".quest_conflicts"
+        / "worktree"
+        / "same-id"
+        / "state.json"
+    )
+    assert conflict_copy.read_text() == "worktree"
+    assert shared_quest not in conflict_copy.parents
+    assert not list(shared_quest.glob("**/.quest_conflicts"))
+
+
+def test_ensure_shared_quest_symlink_main_repo_returns_na(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+
+    assert ensure_shared_quest_symlink(repo, repo) == "n/a"
+    assert not (repo / ".quest").exists()
+    assert not (repo / ".quest").is_symlink()
+
+
+def test_ensure_shared_quest_symlink_linked_worktree_creates(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    worktree = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-b", "feature/linked", str(worktree), "main")
+
+    assert ensure_shared_quest_symlink(repo, worktree) == "created"
+    assert (worktree / ".quest").is_symlink()
+    assert _target(worktree / ".quest") == repo / ".quest"
+
+
+def test_startup_skipped_in_linked_worktree_migrates_real_quest_dir(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "branch")
+    worktree = tmp_path / "human-worktree"
+    _git(repo, "worktree", "add", "-b", "feature/human", str(worktree), "main")
+    (worktree / ".quest" / "orphaned-quest").mkdir(parents=True)
+    (worktree / ".quest" / "orphaned-quest" / "state.json").write_text(
+        "orphan",
+        encoding="utf-8",
+    )
+
+    payload = _run_startup(worktree, allowlist, "new-quest", "branch")
+
+    assert payload["status"] == "skipped"
+    assert payload["branch_mode"] == "none"
+    assert payload["quest_symlink"] == "migrated"
+    assert (worktree / ".quest").is_symlink()
+    assert _target(worktree / ".quest") == repo / ".quest"
+    assert (repo / ".quest" / "orphaned-quest" / "state.json").read_text() == "orphan"
+
+
+def test_startup_none_mode_in_linked_worktree_creates_symlink(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "none")
+    _git(repo, "checkout", "-b", "holder")
+    worktree = tmp_path / "main-linked"
+    _git(repo, "worktree", "add", str(worktree), "main")
+
+    payload = _run_startup(worktree, allowlist, "new-quest", "none")
+
+    assert payload["status"] == "skipped"
+    assert payload["branch_mode"] == "none"
+    assert payload["quest_symlink"] == "created"
+    assert (worktree / ".quest").is_symlink()
+    assert _target(worktree / ".quest") == repo / ".quest"
+
+
+def test_startup_branch_mode_in_linked_worktree_creates_symlink(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "branch")
+    _git(repo, "checkout", "-b", "holder")
+    worktree = tmp_path / "main-linked"
+    _git(repo, "worktree", "add", str(worktree), "main")
+
+    payload = _run_startup(worktree, allowlist, "new-quest", "branch")
+
+    assert payload["status"] == "created"
+    assert payload["branch_mode"] == "branch"
+    assert payload["quest_symlink"] == "created"
+    assert _git(worktree, "branch", "--show-current") == "quest/new-quest"
+    assert (worktree / ".quest").is_symlink()
+    assert _target(worktree / ".quest") == repo / ".quest"
+
+
+def test_startup_worktree_mode_creates_symlink_and_reports_created(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "worktree")
+
+    payload = _run_startup(repo, allowlist, "new-quest", "worktree")
+    worktree = Path(payload["worktree_path"])
+
+    assert payload["status"] == "created"
+    assert payload["branch_mode"] == "worktree"
+    assert payload["quest_symlink"] == "created"
+    assert (worktree / ".quest").is_symlink()
+    assert _target(worktree / ".quest") == repo / ".quest"
+
+
+def test_startup_main_repo_none_and_branch_report_na(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    allowlist = _write_allowlist(repo, "none")
+
+    none_payload = _run_startup(repo, allowlist, "no-branch", "none")
+    branch_payload = _run_startup(repo, allowlist, "with-branch", "branch")
+
+    assert none_payload["quest_symlink"] == "n/a"
+    assert branch_payload["quest_symlink"] == "n/a"
+    assert not (repo / ".quest").is_symlink()


### PR DESCRIPTION
## Why this matters
Quest artifacts should always land in the shared per-repo `.quest/` store, even when a human starts Quest from a pre-created linked worktree. This removes a silent data-loss path where completed quest artifacts could be orphaned in a disposable worktree and never appear in journaling or dashboards.

---

## Summary
Generalize Quest startup so every linked worktree path ensures `.quest/` points at the main repo shared store, with migration-safe handling for existing local content.
- Adds explicit `quest_symlink` reporting so startup can surface created, present, migrated, conflict, and n/a outcomes.
- Preserves Quest journal artifacts for this run on the feature branch.

## Changes
- **Startup behavior**:
  - Add `resolve_shared_quest_dir()`, `apply_quest_symlink()`, and `ensure_shared_quest_symlink()` in `scripts/quest_startup_branch.py`.
  - Wire shared `.quest` symlink handling into skipped/already-on-branch, `none`, `branch`, and `worktree` startup paths.
  - Replace the old worktree-only `shutil.rmtree()` path with migration-safe moves and empty-only directory removal.
  - Preserve same-name conflicts outside `.quest` under `.quest_conflicts/`.

- **Quest orchestration docs**:
  - Document `quest_symlink` surfacing and state recording in `.skills/quest/SKILL.md`.

- **Git hygiene**:
  - Ignore worktree `.quest` symlinks and `.quest_conflicts/` in `.gitignore`.

- **Tests**:
  - Add `tests/unit/test_quest_startup_symlink.py` covering absent, present, migrated, conflict, main-worktree `n/a`, and startup-path wiring.

- **Journal**:
  - Add the completed Quest journal entry and celebration artifact.

## Validation
- [x] Run `python3 -m pytest tests/unit/test_quest_startup_symlink.py -q`; expected result: all 16 startup symlink tests pass.
- [x] Run `bash tests/test-quest-runtime.sh`; expected result: all Quest runtime helper tests pass.
- [x] Run `bash scripts/quest_validate-manifest.sh`; expected result: manifest validation reports OK.
- [x] Run `python3 -m pytest tests/unit/`; expected result: all 713 unit tests pass.
- [x] Run `python3 -m compileall -q scripts/quest_startup_branch.py tests/unit/test_quest_startup_symlink.py`; expected result: command exits successfully with no output.

Watch for: conflict preservation intentionally treats any same-name `.quest` entry as a conflict and preserves the worktree copy outside `.quest`, rather than trying to compare or merge content.

## Notes
- This intentionally does not change Quest completion gating or backfill any earlier missing journal entry; both were out of scope for this Quest.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>



