### PR TITLE
Surface Quest completion celebrations

### DIFF
--- a/.skills/celebrate/SKILL.md
+++ b/.skills/celebrate/SKILL.md
@@ -71,6 +71,8 @@ Before rendering, explicitly decide whether the celebration should show the carr
 
 **IMPORTANT: Write the celebration directly as your response text. Do NOT run a script. Do NOT wrap the entire celebration in a code block. The UI renders agent markdown beautifully, but ASCII/block-letter title art must be wrapped in a fenced code block (triple backticks) so spacing is preserved without turning the whole celebration into a code block.**
 
+When invoked from Quest completion, surface the celebration in the chat response before final status, archive-only summaries, PR creation, or shepherding. Persisted celebration files and links are supplemental; they do not count as showing the celebration.
+
 You have all the data from the artifacts. Now **create your own celebration**. Be creative. Make it feel like an achievement, not a status report.
 
 **Required sections** (present them however you like):

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -1150,7 +1150,11 @@ After plan approval, present the plan interactively before proceeding to build.
    - In non-interactive / CI environments: honor `archive_silent` (no animation); for `ask` or `celebrate`, run the celebration automatically. All paths still archive.
 
 3. **Run celebration (skill-first):**
-   - Invoke the `celebrate` skill and provide the quest ID/path so it reads artifacts and renders rich markdown directly
+   - Invoke the `celebrate` skill and provide the quest ID/path so it reads artifacts and renders rich markdown directly in the assistant response
+   - The user-visible celebration is required whenever `on_complete` is `celebrate`, the user chooses `Celebrate!`, or the user explicitly asks to celebrate
+   - Do not treat a generated journal entry, persisted celebration markdown file, command output, or artifact link as a substitute for showing the celebration in chat
+   - Render the celebration before final archive-only status, PR creation, PR shepherding, cleanup, or any other requested post-Quest follow-through
+   - If `archive_silent` is configured or the user explicitly chooses `Skip celebration`, say the celebration was intentionally skipped
    - Do NOT call the Python celebration script from this step in interactive agent flows
    - Optional fallback (non-interactive/runtime-only): `python3 scripts/quest_celebrate/celebrate.py --quest-dir .quest/<id> --style epic || true`
    - This step is fire-and-forget: if celebration fails, quest completion continues


### PR DESCRIPTION
## ⭐ Why this matters
Quest completion should not feel like it vanished into files. This makes the workflow explicit that when celebration is selected or configured, the celebration must be shown in chat before follow-through continues.

---

## Summary
Make Quest completion and celebrate skill instructions explicit that persisted artifacts do not replace a user-visible celebration.
- Clarifies that `on_complete=celebrate`, the `Celebrate!` choice, and explicit user celebration requests require rendering the celebration in the assistant response.
- Clarifies that journal entries, celebration markdown files, command output, and artifact links are supplemental evidence rather than substitutes.

## Changes
- **Skills**:
  - Update `.skills/quest/delegation/workflow.md` Step 7 to require a chat-visible celebration before archive-only status, PR creation, shepherding, cleanup, or other follow-through.
  - Update `.skills/celebrate/SKILL.md` to repeat the Quest-completion handoff rule at the rich markdown generation step.

## Validation
- [x] Run `git diff --check` from the repository root and expect no whitespace errors.
- [x] Run `bash scripts/quest_validate-manifest.sh` from the repository root and expect all Quest files to be listed with no stale entries.
- [x] Run `python3 -m pytest tests/unit/test_codex_skill_wrappers.py` from the repository root and expect all wrapper tests to pass.
Watch for: This is instruction-only; reviewers should check wording clarity rather than runtime behavior.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Codex
in collaboration with KjellKod <kjell.hedstrom@gmail.com>
</pre>
