### PR TITLE
Add idea: Codex-driven interactive Claude relay

### DIFF
--- a/ideas/2026-05-31-codex-driven-interactive-claude-relay.md
+++ b/ideas/2026-05-31-codex-driven-interactive-claude-relay.md
@@ -1,6 +1,6 @@
-# Codex-Driven Interactive Claude Relay
+# Codex-Driven Background-Agent Claude Relay
 
-Date: 2026-05-31
+Date: 2026-05-31 (revised 2026-05-31 after verifying official surfaces)
 Status: `proposed`
 Related: `claude-cli-login-context.md`, `codex_calls_claude.sh`,
 `2026-05-26-native-runtime-dispatch.md`, `2026-04-13-codex-companion-runtime.md`,
@@ -18,120 +18,157 @@ the terminal stays on the normal subscription pool, unaffected.**
 Quest's Codex-led Claude roles run through `scripts/quest_claude_bridge.py`, which
 shells out to `claude --print` (`quest_claude_bridge.py:132`). After June 15 that
 path is API-priced. We want Codex-orchestrated quests to keep using Claude roles
-**on the subscription pool**, without API cost, while honoring the *intent* of the
-change (Claude as an interactive, human-supervisable runtime).
+**on the subscription pool**, without API cost.
 
 Source: Anthropic Help Center, "Use the Claude Agent SDK with your Claude plan"
-(support.claude.com/en/articles/15036540...); The New Stack, "Anthropic splits
-billing again" (2026). Retrieved 2026-05-31.
+(support.claude.com/en/articles/15036540...). Retrieved 2026-05-31.
 
-## Key insight
+## Key finding: background agents are an official, subscription-billed surface
 
-The billing boundary is the **entry mode** (`-p`/SDK vs. interactive session),
-**not** whether a human typed. So a `claude` process started *without* `-p` is an
-interactive session billed to the subscription pool — regardless of who launched
-it or whether anyone is watching. Quest's cross-model contract is already
-file-based (every role writes an artifact + `handoff.json`; the orchestrator polls
-files in `quest_claude_runner.py`), so we never need the interactive session's
-stdout — only a way to (a) hand it a prompt and (b) detect when the files appear.
+Claude Code ships **background agents** + a **per-user supervisor** — full Claude
+Code sessions (not `-p`, not the Agent SDK) that run detached from any terminal and
+are dispatched and managed from the shell. Verified against the installed CLI
+(v2.1.159) and the canonical doc `code.claude.com/docs/en/agent-view.md`.
 
-## Approach: an interactive relay behind a hard switch
+**Billing (verbatim, agent-view.md → Limitations):**
+> "Rate limits apply: background sessions consume your subscription usage the same
+> as interactive sessions, so running ten agents in parallel uses quota roughly ten
+> times as fast as running one."
 
-Add a hard transport switch (config value consumed by the runner/preflight, **not**
-a prose rule in `workflow.md`), in `.ai/allowlist.json` and copied into
+**Supervisor auth (verbatim):**
+> "The supervisor and its sessions authenticate with the same credentials as your
+> interactive sessions and make no additional network connections beyond the model
+> API."
+
+So background agents draw from the **subscription pool**, not the Agent-SDK credit
+pool. This is the cheap, sanctioned path — it replaces the earlier tmux + `/loop`
+prototype this note originally proposed.
+
+### Verified shell surface (Claude Code v2.1.159)
+
+```bash
+claude --bg "<prompt>"                       # dispatch a background session
+claude --bg --agent <name> --name <label> \  # role + display name
+       --model <m> --effort <e> --permission-mode <mode> --add-dir <dir> "<prompt>"
+# prints: "backgrounded · <shortID> · <name>" plus the management commands:
+claude agents --json     # live sessions as JSON (pid, cwd, kind, startedAt, sessionId, name, status); no TTY
+claude attach <id>       # open in this terminal
+claude logs <id>         # print recent output
+claude stop <id>         # stop (alias: kill); claude respawn <id>; claude rm <id>
+claude daemon status     # per-user supervisor health
+```
+State: `~/.claude/jobs/<id>/state.json`, roster `~/.claude/daemon/roster.json`.
+
+## Approach: a background-agent transport behind a hard switch
+
+Add a hard transport switch (a config value consumed by the runner/preflight,
+**not** a prose rule in `workflow.md`), in `.ai/allowlist.json`, copied into
 `.quest/<id>/orchestration.json` at startup:
 
 ```jsonc
-"claude_role_transport": "bridge"             // default: existing claude --print path
+"claude_role_transport": "bridge"            // default: existing claude --print path (API-metered after Jun 15)
 // or
-"claude_role_transport": "interactive-relay"  // this proposal: subscription-pool path
+"claude_role_transport": "background-agent"  // this proposal: subscription-pool path
 ```
 
-`bridge` is the honest, headless, API-metered default (works in CI / locked
-sandboxes). `interactive-relay` is the opt-in subscription-pool path for
-Codex-led quests that want cheap Claude roles and run where a persistent TTY is
-available.
+`bridge` stays the honest, headless, API-metered default (works in CI / locked
+sandboxes with an API key). `background-agent` is the opt-in subscription-pool path
+for Codex-led quests on a host with a logged-in Claude subscription.
 
-### Mechanism (self-bootstrapping)
+### Mechanism (self-bootstrapping; no tmux, no keystroke injection)
 
 Auth persists on disk after a one-time `claude login` / `claude setup-token`, so a
-fresh `claude` process is already authenticated — **Codex can open and own the
-session itself**; no human is required at launch. (Per
+fresh background session is already authenticated — **Codex dispatches and manages
+sessions itself**; no human is required per dispatch. (Per
 `claude-cli-login-context.md`: auth is a property of the *execution context* — the
-session must run under the same HOME/user that completed login, and
-`claude auth status` must report `loggedIn: true` in that context.)
+dispatch must run under the same HOME/user that completed login, with
+`claude auth status` reporting `loggedIn: true` in that context.)
 
 ```
-# one-time, ever, per machine (human, browser OAuth — the only step Codex cannot do):
-claude login            # creds persisted to ~/.claude
+# one-time, ever, per machine (human): the only steps Codex cannot do
+claude login                                    # creds persisted to ~/.claude
+claude --permission-mode bypassPermissions ...  # one interactive acceptance of bypass mode
 
-# preflight for an interactive-relay quest (Codex, via its exec tool):
-tmux has-session -t quest-claude 2>/dev/null \
-  || { tmux new-session -d -s quest-claude 'claude'; \
-       tmux send-keys -t quest-claude '/loop 20s /quest-claude-relay' Enter; }
-
-# per Claude role (Codex orchestrator):
-1. write request → .quest/<id>/inbox/<role>.req.json   (prompt + prepared artifact paths)
-2. (optional) tmux send-keys -t quest-claude '' Enter   (wake the loop immediately)
-3. poll .quest/<id>/phase_xx/handoff_<role>.json        (the EXISTING contract)
+# per Claude role (Codex orchestrator, via its exec tool):
+1. dispatch:
+   claude --bg --name "<quest>-<role>" --model <m> --effort <e> \
+          --permission-mode bypassPermissions --add-dir <quest_dir> \
+          "Read <files>. Write <artifact> + handoff.json. Non-interactive contract."
+   # capture printed <shortID>
+2. detect completion: poll .quest/<id>/.../handoff_<role>.json   (EXISTING contract, reused verbatim)
+   #   and/or `claude agents --json` for state (working / needs input / completed / failed)
+3. on "needs input": route to the human gate (maps to quest's needs_human)
+4. teardown: claude rm <shortID>
 ```
 
-- The session runs in **interactive mode** (no `-p`) → subscription pool.
-- The `/loop` skill (already in this repo) re-invokes a new **`/quest-claude-relay`**
-  skill on a timer; that skill drains the inbox: read oldest request, run the role
-  against the named files, write the artifact + `handoff.json`, delete the request.
-  So Codex never scripts keystrokes into the TUI — the large/multiline prompt
-  travels by file; `send-keys` is only an optional latency nudge.
-- Result detection reuses `quest_claude_runner.py` file polling verbatim.
+- Sessions run as full Claude Code sessions (not `-p`) → subscription pool.
+- Result detection reuses `quest_claude_runner.py` handoff polling unchanged.
+- `claude logs <id>` gives diagnostics; `claude agents --json` gives structured state.
 
 ### Preflight + fallback (keeps the switch honest)
 
-`scripts/quest_preflight.sh` for `interactive-relay`:
-1. Detect persisted Claude auth (`claude auth status` → `loggedIn: true`) in the
-   execution context; if missing, instruct the user to run `claude login` once.
-2. Ensure the relay session is live (`tmux has-session`); bootstrap it if not.
-3. If neither auth nor a TTY/tmux environment is available, **fall back to
-   `bridge`** and record the downgrade — never silently block.
+`scripts/quest_preflight.sh` for `background-agent`:
+1. `claude auth status` → require `loggedIn: true` in the execution context; if not,
+   instruct the user to run `claude login` once.
+2. `claude daemon status` → confirm the supervisor is reachable (it autostarts on
+   first dispatch).
+3. If auth is missing, or the CLI/version lacks agent view, **fall back to `bridge`**
+   and record the downgrade — never silently block.
 
 ## Reused vs. net-new
 
-- **Reused:** `/loop` skill; `quest_claude_runner.py` handoff polling;
-  `prepare_artifact_files` / `expected_artifacts_for_role`; preflight's
-  cache/availability pattern.
-- **Net-new:** the `/quest-claude-relay` inbox-drain skill; the
-  `claude_role_transport` key + dispatch branch; the preflight liveness/auth probe
-  and `tmux` bootstrap; a trusted-workspace `settings.json` allowed-tools list for
-  the session (interactive equivalent of the bridge's `bypassPermissions`).
+- **Reused:** `quest_claude_runner.py` handoff polling; `prepare_artifact_files` /
+  `expected_artifacts_for_role`; preflight's cache/availability pattern. **No tmux,
+  no `/loop`, no relay skill, no keystroke injection** — those were dropped.
+- **Net-new:** the `claude_role_transport` key + a `background-agent` dispatch branch
+  in the runner (`claude --bg` + ID capture + `claude rm` teardown); the preflight
+  `auth status` / `daemon status` probes; a `needs input` → `needs_human` mapping.
 
-## Constraints (do not paper over)
+## Constraints (do not paper over) — from agent-view.md
 
-1. **One-time human login** per machine; Codex cannot perform browser OAuth.
-2. **Persistent-TTY environment required** (tmux/screen). Dead in one-shot CI
-   sandboxes → use `bridge` there.
-3. **Permission pre-trust** — the relay skill trips tool-permission prompts; the
-   session needs a trusted-workspace allowed-tools config once.
-4. **`/loop` consumes interactive turns while idle** — tune the interval or
-   start/stop the loop around active quests.
-5. **One session serializes Claude roles** — usually fine (a phase rarely has >1
-   Claude role; reviewer A=Claude, B=Codex). Run N sessions for parallel Claude
-   roles.
-6. **ToS posture is *defensible, not blessed*.** It stays on the interactive side
-   of the line Anthropic drew (mode-based billing), but Anthropic has not
-   explicitly sanctioned "another agent drives my interactive session." This is a
-   side-step, offered behind an opt-in switch — not the default.
+1. **One-time human setup** per machine: `claude login`, plus one interactive
+   acceptance of `bypassPermissions`/`auto` before background sessions may use it.
+2. **Worktree auto-isolation for write roles.** Background sessions move into
+   `.claude/worktrees/<id>/` before editing, and `claude rm` can delete that worktree
+   (with uncommitted changes). Read-only Claude roles (planner, plan/code reviewers,
+   arbiter, review-arbiter) are unaffected. A Claude **builder/fixer** would need
+   `worktree.bgIsolation: "none"` or path reconciliation — but quest's builder/fixer
+   default to Codex, so this rarely applies.
+3. **Research preview.** Agent view requires v2.1.139+ and "the interface and
+   keyboard shortcuts may change." Pin automation to `claude agents --json` and the
+   printed management commands, not the TUI.
+4. **Quota burns at interactive rates.** N parallel Claude roles ≈ N× subscription
+   quota. Fine for quest (1–2 Claude roles per phase).
+5. **`kind` values.** A running interactive session reports `kind: "interactive"`;
+   the doc lists `kind` in the JSON but does not enumerate the background value.
+   Treat `claude agents --json` `status` as authoritative for state.
+
+## ToS posture
+
+Stronger than the original tmux idea: this uses an **officially documented,
+subscription-billed** feature for its intended purpose ("dispatch tasks you don't
+watch every step, from your shell"). The only stretch is that *Codex* plays the
+supervisor role the docs frame as a human; billing is explicitly subscription, so
+the cost goal is met on sanctioned surfaces. Offered behind an opt-in switch; the
+default remains `bridge`.
 
 ## Why pursue it
 
-For a Pro/Max user, it keeps Codex-led Claude roles on the subscription pool
-(no API spend) after June 15, reuses quest's existing file-handoff contract almost
-untouched, and is self-bootstrapping once login is done. The default stays on the
-safe, sanctioned `bridge`; this is the cheap, intent-aligned alternative for users
-who want it and can host a live session.
+For a Pro/Max user it keeps Codex-led Claude roles on the subscription pool (no API
+spend) after June 15, reuses quest's existing file-handoff contract untouched, is
+self-bootstrapping once login is done, and rides official CLI surfaces
+(`claude --bg`, `claude agents --json`, `claude logs`, the per-user supervisor)
+instead of a bespoke harness.
+
+## Resolved / no longer open
+
+- **stream-json over interactive?** No — `--input-format`/`--output-format
+  stream-json` are `--print`-only (confirmed in `claude --help`). Background agents
+  make this moot.
 
 ## Open questions
 
-- Does interactive `claude` accept `--input-format stream-json` on stdin (and still
-  bill as interactive)? If so, a structured stdin/stdout channel could replace the
-  inbox+`send-keys` mechanics entirely — worth a short spike before building tmux.
-- Liveness/health: how should preflight detect a *wedged* (vs. merely idle) relay
-  session, and recover (restart vs. fall back to `bridge`)?
+- Liveness/health: how should preflight detect a *wedged* (vs. merely working)
+  background session, and recover (`claude respawn` vs. fall back to `bridge`)?
+- Confirm the exact `kind` string for background sessions for a tighter
+  `agents --json` filter.

--- a/ideas/2026-05-31-codex-driven-interactive-claude-relay.md
+++ b/ideas/2026-05-31-codex-driven-interactive-claude-relay.md
@@ -1,0 +1,137 @@
+# Codex-Driven Interactive Claude Relay
+
+Date: 2026-05-31
+Status: `proposed`
+Related: `claude-cli-login-context.md`, `codex_calls_claude.sh`,
+`2026-05-26-native-runtime-dispatch.md`, `2026-04-13-codex-companion-runtime.md`,
+`scripts/quest_claude_bridge.py`, `scripts/quest_claude_runner.py`,
+`scripts/quest_preflight.sh`
+
+## Problem
+
+Effective **June 15, 2026**, Anthropic moves `claude -p` (non-interactive /
+headless) and the Agent SDK off the subscription usage pool and onto a separate
+monthly **Agent SDK credit** metered at full API rates (Pro $20 / Max5x $100 /
+Max20x $200, no rollover, then spills to API rates). **Interactive Claude Code in
+the terminal stays on the normal subscription pool, unaffected.**
+
+Quest's Codex-led Claude roles run through `scripts/quest_claude_bridge.py`, which
+shells out to `claude --print` (`quest_claude_bridge.py:132`). After June 15 that
+path is API-priced. We want Codex-orchestrated quests to keep using Claude roles
+**on the subscription pool**, without API cost, while honoring the *intent* of the
+change (Claude as an interactive, human-supervisable runtime).
+
+Source: Anthropic Help Center, "Use the Claude Agent SDK with your Claude plan"
+(support.claude.com/en/articles/15036540...); The New Stack, "Anthropic splits
+billing again" (2026). Retrieved 2026-05-31.
+
+## Key insight
+
+The billing boundary is the **entry mode** (`-p`/SDK vs. interactive session),
+**not** whether a human typed. So a `claude` process started *without* `-p` is an
+interactive session billed to the subscription pool — regardless of who launched
+it or whether anyone is watching. Quest's cross-model contract is already
+file-based (every role writes an artifact + `handoff.json`; the orchestrator polls
+files in `quest_claude_runner.py`), so we never need the interactive session's
+stdout — only a way to (a) hand it a prompt and (b) detect when the files appear.
+
+## Approach: an interactive relay behind a hard switch
+
+Add a hard transport switch (config value consumed by the runner/preflight, **not**
+a prose rule in `workflow.md`), in `.ai/allowlist.json` and copied into
+`.quest/<id>/orchestration.json` at startup:
+
+```jsonc
+"claude_role_transport": "bridge"             // default: existing claude --print path
+// or
+"claude_role_transport": "interactive-relay"  // this proposal: subscription-pool path
+```
+
+`bridge` is the honest, headless, API-metered default (works in CI / locked
+sandboxes). `interactive-relay` is the opt-in subscription-pool path for
+Codex-led quests that want cheap Claude roles and run where a persistent TTY is
+available.
+
+### Mechanism (self-bootstrapping)
+
+Auth persists on disk after a one-time `claude login` / `claude setup-token`, so a
+fresh `claude` process is already authenticated — **Codex can open and own the
+session itself**; no human is required at launch. (Per
+`claude-cli-login-context.md`: auth is a property of the *execution context* — the
+session must run under the same HOME/user that completed login, and
+`claude auth status` must report `loggedIn: true` in that context.)
+
+```
+# one-time, ever, per machine (human, browser OAuth — the only step Codex cannot do):
+claude login            # creds persisted to ~/.claude
+
+# preflight for an interactive-relay quest (Codex, via its exec tool):
+tmux has-session -t quest-claude 2>/dev/null \
+  || { tmux new-session -d -s quest-claude 'claude'; \
+       tmux send-keys -t quest-claude '/loop 20s /quest-claude-relay' Enter; }
+
+# per Claude role (Codex orchestrator):
+1. write request → .quest/<id>/inbox/<role>.req.json   (prompt + prepared artifact paths)
+2. (optional) tmux send-keys -t quest-claude '' Enter   (wake the loop immediately)
+3. poll .quest/<id>/phase_xx/handoff_<role>.json        (the EXISTING contract)
+```
+
+- The session runs in **interactive mode** (no `-p`) → subscription pool.
+- The `/loop` skill (already in this repo) re-invokes a new **`/quest-claude-relay`**
+  skill on a timer; that skill drains the inbox: read oldest request, run the role
+  against the named files, write the artifact + `handoff.json`, delete the request.
+  So Codex never scripts keystrokes into the TUI — the large/multiline prompt
+  travels by file; `send-keys` is only an optional latency nudge.
+- Result detection reuses `quest_claude_runner.py` file polling verbatim.
+
+### Preflight + fallback (keeps the switch honest)
+
+`scripts/quest_preflight.sh` for `interactive-relay`:
+1. Detect persisted Claude auth (`claude auth status` → `loggedIn: true`) in the
+   execution context; if missing, instruct the user to run `claude login` once.
+2. Ensure the relay session is live (`tmux has-session`); bootstrap it if not.
+3. If neither auth nor a TTY/tmux environment is available, **fall back to
+   `bridge`** and record the downgrade — never silently block.
+
+## Reused vs. net-new
+
+- **Reused:** `/loop` skill; `quest_claude_runner.py` handoff polling;
+  `prepare_artifact_files` / `expected_artifacts_for_role`; preflight's
+  cache/availability pattern.
+- **Net-new:** the `/quest-claude-relay` inbox-drain skill; the
+  `claude_role_transport` key + dispatch branch; the preflight liveness/auth probe
+  and `tmux` bootstrap; a trusted-workspace `settings.json` allowed-tools list for
+  the session (interactive equivalent of the bridge's `bypassPermissions`).
+
+## Constraints (do not paper over)
+
+1. **One-time human login** per machine; Codex cannot perform browser OAuth.
+2. **Persistent-TTY environment required** (tmux/screen). Dead in one-shot CI
+   sandboxes → use `bridge` there.
+3. **Permission pre-trust** — the relay skill trips tool-permission prompts; the
+   session needs a trusted-workspace allowed-tools config once.
+4. **`/loop` consumes interactive turns while idle** — tune the interval or
+   start/stop the loop around active quests.
+5. **One session serializes Claude roles** — usually fine (a phase rarely has >1
+   Claude role; reviewer A=Claude, B=Codex). Run N sessions for parallel Claude
+   roles.
+6. **ToS posture is *defensible, not blessed*.** It stays on the interactive side
+   of the line Anthropic drew (mode-based billing), but Anthropic has not
+   explicitly sanctioned "another agent drives my interactive session." This is a
+   side-step, offered behind an opt-in switch — not the default.
+
+## Why pursue it
+
+For a Pro/Max user, it keeps Codex-led Claude roles on the subscription pool
+(no API spend) after June 15, reuses quest's existing file-handoff contract almost
+untouched, and is self-bootstrapping once login is done. The default stays on the
+safe, sanctioned `bridge`; this is the cheap, intent-aligned alternative for users
+who want it and can host a live session.
+
+## Open questions
+
+- Does interactive `claude` accept `--input-format stream-json` on stdin (and still
+  bill as interactive)? If so, a structured stdin/stdout channel could replace the
+  inbox+`send-keys` mechanics entirely — worth a short spike before building tmux.
+- Liveness/health: how should preflight detect a *wedged* (vs. merely idle) relay
+  session, and recover (restart vs. fall back to `bridge`)?

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -66,6 +66,7 @@ Current roadmap:
 | `claude-bridge-timeout-diagnosis-2026-03-23.md` | reference | Incident record showing sandbox-local Claude bridge probes can fail even when host execution is healthy. |
 | `claude-cli-login-context.md` | reference | Operational note: external `claude` CLI login must be validated in the same execution context; an open app session is not enough. |
 | `codex_calls_claude.sh` | reference | Older experimental bash bridge prototype retained as a reference alongside the supported Python bridge. |
+| `2026-05-31-codex-driven-interactive-claude-relay.md` | proposed | Hard-switch transport that runs Codex-led Claude roles through a self-bootstrapping interactive `claude` session (subscription pool) instead of `claude --print` (API-metered after June 15, 2026). |
 
 ### Execution Discipline and Observability
 | File | Status | Purpose |

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -66,7 +66,7 @@ Current roadmap:
 | `claude-bridge-timeout-diagnosis-2026-03-23.md` | reference | Incident record showing sandbox-local Claude bridge probes can fail even when host execution is healthy. |
 | `claude-cli-login-context.md` | reference | Operational note: external `claude` CLI login must be validated in the same execution context; an open app session is not enough. |
 | `codex_calls_claude.sh` | reference | Older experimental bash bridge prototype retained as a reference alongside the supported Python bridge. |
-| `2026-05-31-codex-driven-interactive-claude-relay.md` | proposed | Hard-switch transport that runs Codex-led Claude roles through a self-bootstrapping interactive `claude` session (subscription pool) instead of `claude --print` (API-metered after June 15, 2026). |
+| `2026-05-31-codex-driven-interactive-claude-relay.md` | proposed | Hard-switch transport that runs Codex-led Claude roles through official background agents (`claude --bg` / `claude agents --json` / per-user supervisor, subscription pool) instead of `claude --print` (API-metered after June 15, 2026). |
 
 ### Execution Discipline and Observability
 | File | Status | Purpose |


### PR DESCRIPTION
Capture a hard-switch transport (claude_role_transport) that runs Codex-led Claude roles through a self-bootstrapping interactive `claude` session on the subscription pool, instead of `claude --print` which becomes API-metered after the June 15, 2026 billing split. Notes the mechanism (tmux + file inbox + /loop relay skill), reuse of the existing handoff polling, preflight liveness/auth probe with bridge fallback, and the honest constraints and ToS posture. Index updated.

Quest/Co-Authored by

in collaboration with Kjell <kjell@onfleet.com>