### PR TITLE
Add claude --bg transport: Step-1 runner + migration spec

### DIFF
--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -15,4 +15,5 @@ proposals live in `ideas/` until they are implementation-ready.
 
 | Plan | Status | Summary |
 |------|--------|---------|
-| [claude-bg-transport-migration.md](claude-bg-transport-migration.md) | draft — for review | Migrate Codex-led Claude role execution from the `claude --print` bridge (API-metered after June 15, 2026) to the official background-agent transport (`claude --bg` + supervisor, subscription pool); bridge demoted to fallback/CI path, not deleted. |
+| [claude-bg-run-script.md](claude-bg-run-script.md) | draft — for review | Step 1: a quest-agnostic standalone `claude --bg` runner (dispatch → confirm → wait-on-files → collect → teardown) we can validate and iterate on outside quest, before any quest wiring. |
+| [claude-bg-transport-migration.md](claude-bg-transport-migration.md) | draft — for review | Step 2 (later): migrate Codex-led Claude role execution from the `claude --print` bridge (API-metered after June 15, 2026) to the background-agent transport behind a config switch; bridge demoted to fallback/CI path, not deleted. |

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -1,0 +1,18 @@
+---
+title: Implementation Plans Index
+purpose: Navigation hub for active implementation plans (Layer 3).
+audience: Contributors and AI agents building features.
+scope: Index of active plans under docs/implementation/.
+status: active
+owner: maintainers
+---
+
+# Implementation Plans
+
+Active, changing plans for in-flight work. Completed plans move to
+`docs/implementation/history/` (see `DOCUMENTATION_STRUCTURE.md`). Earlier-stage
+proposals live in `ideas/` until they are implementation-ready.
+
+| Plan | Status | Summary |
+|------|--------|---------|
+| [claude-bg-transport-migration.md](claude-bg-transport-migration.md) | draft — for review | Migrate Codex-led Claude role execution from the `claude --print` bridge (API-metered after June 15, 2026) to the official background-agent transport (`claude --bg` + supervisor, subscription pool); bridge demoted to fallback/CI path, not deleted. |

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -15,5 +15,5 @@ proposals live in `ideas/` until they are implementation-ready.
 
 | Plan | Status | Summary |
 |------|--------|---------|
-| [claude-bg-run-script.md](claude-bg-run-script.md) | draft — for review | Step 1: a quest-agnostic standalone `claude --bg` runner (dispatch → confirm → wait-on-files → collect → teardown) we can validate and iterate on outside quest, before any quest wiring. |
+| [claude-bg-run-script.md](claude-bg-run-script.md) | PoC landed — for review | Step 1: a quest-agnostic standalone `claude --bg` runner (`scripts/claude_bg_run.py` + `tests/unit/test_claude_bg_run.py`, 12 tests green + real-CLI smoke). Dispatch → confirm → wait-on-files → collect → teardown, with a headless-PTY noise firewall. |
 | [claude-bg-transport-migration.md](claude-bg-transport-migration.md) | draft — for review | Step 2 (later): migrate Codex-led Claude role execution from the `claude --print` bridge (API-metered after June 15, 2026) to the background-agent transport behind a config switch; bridge demoted to fallback/CI path, not deleted. |

--- a/docs/implementation/claude-bg-run-script.md
+++ b/docs/implementation/claude-bg-run-script.md
@@ -1,0 +1,232 @@
+---
+title: claude-bg-run — Standalone Background-Agent Runner (Step 1)
+purpose: Specify a quest-agnostic CLI that runs a single Claude background-agent task to completion and returns a structured result, communicating purely through files. It is the proving ground for the background-agent transport before any quest wiring.
+audience: Implementing agent and reviewers.
+scope: One standalone script (dispatch → confirm → wait-on-files → collect → teardown). No quest coupling.
+status: draft — for review before implementation
+owner: maintainers
+last_updated: 2026-06-09
+related:
+  - docs/implementation/claude-bg-transport-migration.md
+  - scripts/quest_claude_bridge.py
+  - scripts/quest_runtime/claude_runner.py
+  - ideas/2026-05-31-codex-driven-interactive-claude-relay.md
+---
+
+# claude-bg-run — Standalone Background-Agent Runner (Step 1)
+
+## Purpose
+
+A single, dependency-free CLI — proposed `scripts/claude_bg_run.py` — that runs
+**one** Claude task through the official background-agent surface
+(`claude --bg` + the per-user supervisor) and blocks until the task has produced
+its expected output **files**, then returns a structured result and tears the
+session down.
+
+It is deliberately **quest-agnostic** (exactly like `scripts/quest_claude_bridge.py`
+is today): it knows nothing about quest phases, `handoff.json` schemas,
+`orchestration.json`, or roles. It knows only: *dispatch a prompt, wait for these
+files to appear, return what happened.* That makes it independently runnable and
+testable — `claude_bg_run.py --prompt "…write result to out.json" --wait-for out.json` —
+so we can prove and iterate on the transport **before** touching quest. Quest
+later calls it with its own artifact paths as `--wait-for`; that wiring is Step 2
+and out of scope here.
+
+### Non-goals (Step 1)
+
+- No quest integration, no transport switch, no preflight changes (Step 2).
+- No multi-turn conversation, no replying to a running session.
+- No log scraping for results (see finding F1 — impossible reliably).
+- Not a replacement for the bridge yet; it is a peer we validate alongside it.
+
+## Validated behavior (live, this environment, Claude Code 2.1.159→2.1.170)
+
+These findings are empirical (run against the real CLI) and drive every design
+choice below. Where a behavior could not be fully validated here, it is marked
+and pushed to the machine-validation checklist.
+
+| # | Finding | Consequence for the script |
+|---|---|---|
+| F1 | `claude logs <id>` returns the **raw TUI screen buffer** (ANSI/cursor escapes); the model's text answer is not cleanly extractable. | Results MUST travel via files. `logs` is used only as an opaque diagnostic blob on failure. |
+| F2 | `claude agents --json` reports per-session `state` and `status`. Observed transitions: `working`/`busy` → `done`/`idle`; a session that needs a permission decision ends `blocked`/`idle`. | Completion + failure are detectable structurally: success via files (primary) + `state==done`; **`state==blocked` → fail fast** (don't wait for timeout). |
+| F3 | The supervisor starts **on-demand** ("origin: transient — started on-demand by `claude --bg`"). There is a cold-start window; once, a dispatch printed success while `daemon status` was `not running` and the session never registered. | A **confirmation step** is mandatory: after dispatch, poll `agents --json` until the session appears (bounded). No appearance → `dispatch_failed`. The success line alone is not proof. |
+| F4 | A `--bg` dispatch blocked by the bypass disclaimer printed an error **and still exited 0**. | Do not trust the process exit code. Success = parsing `backgrounded · <shortID>` from stdout **and** F3 confirmation. |
+| F5 | `--permission-mode bypassPermissions` (and `auto`) are refused until `claude --dangerously-skip-permissions` is accepted once interactively, per machine. | bypass is the intended unattended mode; the script must detect the refusal error and surface remediation. This one-time acceptance is a hard prerequisite. |
+| F6 | A `--permission-mode acceptEdits` session asked to create new files ended `blocked` without writing. | For unattended file-writing, `acceptEdits` is insufficient; bypass (F5) is required. The script defaults to bypass and treats `blocked` as a permission failure with a clear message. |
+| F7 | Dispatch stdout format: `backgrounded · <shortID>[ · <name>]`, plus a 4-line management hint. An idle no-prompt dispatch appended `(idle — send a prompt to start)`. | shortID regex: `backgrounded\s*·\s*([0-9a-f]+)`; name is optional; tolerate the idle suffix. |
+| F8 | `agents --json` background entries carry `id`, `name`, `status`, `state`, `sessionId`, `pid`, `cwd`; interactive sessions lack `id/name/status/state`. | Match dispatched sessions by `name` (preferred) or `id`; ignore `kind==interactive` rows. |
+| F9 | `claude stop <id>` then `claude rm <id>` cleanly remove a session (verified: list returns to interactive-only). Background sessions auto-isolate edits into `.claude/worktrees/` unless disabled. | Teardown = stop → rm, only **after** results are collected. Pass `--settings '{"worktree":{"bgIsolation":"none"}}'` so writes land in the real workspace, not a worktree `rm` would delete. |
+| F10 | **Not validated here:** an end-to-end write by a *bypass-accepted* session reaching `state==done` with the expected files present. Blocked by F5 (no interactive acceptance available in this sandbox). | Must be confirmed on a real logged-in machine — see Machine-validation checklist. The script is designed for it; the proof is operational. |
+
+## The file-based completion contract
+
+The runner's entire model of "done" is files on disk. The caller declares what
+to wait for; the runner makes the agent's prompt carry a matching instruction.
+
+- `--wait-for <path>` (repeatable): paths that must exist **and be non-empty**
+  for the task to count as complete. This is the success condition.
+- The runner appends a small, documented **completion-protocol** block to the
+  prompt so a naive standalone prompt still works:
+
+  ```
+  When you have finished, you MUST write your output to the file(s):
+    <wait-for paths>
+  Write files directly with the Write tool. Do not ask questions; if details are
+  missing, make explicit assumptions and proceed.
+  ```
+
+  `--no-protocol` suppresses this when the caller's prompt already specifies the
+  artifact contract (quest will pass its own role prompt and may use this).
+- Completion = all `--wait-for` paths satisfied (primary), corroborated by
+  `state==done`. The runner never parses model text for the result.
+
+This is the same contract `scripts/quest_runtime/claude_runner.py` already polls
+for (`handoff.json` + artifacts); the runner just owns the loop so it is usable
+without quest.
+
+## CLI surface
+
+Mirrors `quest_claude_bridge.py` where sensible (drop-in transport sibling):
+
+```
+scripts/claude_bg_run.py
+  (--prompt TEXT | --prompt-file PATH | -)        # task; '-' or stdin supported
+  --wait-for PATH            (repeatable, >=1 unless --no-wait)
+  --model NAME               (optional; defaults to CLI/account default)
+  --permission-mode MODE     (default: bypassPermissions)
+  --effort LEVEL             (optional: low|medium|high|xhigh|max)
+  --add-dir PATH             (repeatable; cwd added by default)
+  --name NAME                (default: auto "bgrun-<8hex>")
+  --no-bg-isolation          (default ON → injects --settings bgIsolation:none)
+  --timeout SECONDS          (default 1800; runner-enforced; stop at deadline)
+  --confirm-timeout SECONDS  (default 20; F3 registration window)
+  --poll-interval SECONDS    (default 2; file checks)
+  --status-interval SECONDS  (default 10; agents --json checks)
+  --keep                     (skip teardown; for debugging)
+  --json                     (emit the result envelope to stdout)
+  --no-protocol              (don't append the completion-protocol block)
+```
+
+### Output envelope (`--json`)
+
+```json
+{
+  "status": "ok | timeout | dispatch_failed | blocked | session_failed | incomplete | precondition_failed",
+  "short_id": "d868c9d3",
+  "session_id": "d868c9d3-…",
+  "name": "bgrun-1a2b3c4d",
+  "wait_for": ["…"],
+  "artifacts_found": ["…"],
+  "missing": ["…"],
+  "final_state": "done | blocked | absent | working",
+  "duration_s": 41.2,
+  "logs_tail": "…",          // present only on non-ok status, raw/opaque
+  "message": "human-readable summary / remediation"
+}
+```
+
+Exit codes: `0` ok; `2` precondition_failed (CLI/auth/bypass-acceptance — F4/F5);
+`3` dispatch_failed (F3); `4` blocked (F6); `5` timeout; `6` session_failed/incomplete.
+(Distinct codes so a shell harness — and later quest's `classify_failure_kind`
+— can route without parsing stdout.)
+
+## Lifecycle (the state machine)
+
+```
+0. PRECHECK
+   - `command -v claude`; `claude auth status` → loggedIn:true (honor CLAUDE_CONFIG_DIR/HOME)
+   - if permission-mode is bypass/auto: dispatch will reveal the F5 gate; detect its
+     exact error string up front is not possible without dispatching, so treat the
+     F5 error in step 1 as precondition_failed with remediation.
+1. DISPATCH
+   - build argv: claude --bg --name <name> [--model][--effort] --permission-mode <m>
+     [--settings bgIsolation:none] --add-dir <each> "<prompt + completion-protocol>"
+   - run, capture stdout (DO NOT trust exit code — F4)
+   - if stdout matches the bypass-acceptance refusal (F5) → precondition_failed(2)
+   - parse shortID (F7); if absent → dispatch_failed(3)
+2. CONFIRM (F3)
+   - poll `agents --json` every poll-interval up to confirm-timeout for a row whose
+     name==<name> (or id==shortID); capture id + sessionId
+   - never appears → dispatch_failed(3) with daemon-status snapshot in message
+3. WAIT  (loop until deadline)
+   - every poll-interval: check all --wait-for paths exist & non-empty
+       → all satisfied: capture, go COLLECT (ok)
+   - every status-interval: read this session's state from `agents --json`
+       working  → keep waiting
+       blocked  → COLLECT then blocked(4) + logs_tail + permission remediation (F6)
+       done but wait-for unsatisfied → short grace (e.g. 2 poll-intervals), then incomplete(6)
+       absent (unexpected) → session_failed(6)
+   - deadline reached → `claude stop <id>` → timeout(5)
+4. COLLECT
+   - record artifacts_found / missing; on any non-ok, capture `claude logs <id>` tail (opaque)
+5. TEARDOWN  (unless --keep)
+   - only AFTER collect: `claude stop <id>` (if alive) → `claude rm <id>`  (F9 order)
+6. RETURN envelope + exit code
+```
+
+## Auth, permissions, worktrees (operator prerequisites)
+
+- **One-time, per machine (human):** `claude login` (subscription), and
+  `claude --dangerously-skip-permissions` once, accepting the disclaimer, so
+  background sessions may run in `bypassPermissions` (F5). The runner cannot do
+  these; it detects their absence and returns `precondition_failed` with the
+  exact remediation command.
+- **Worktree isolation (F9):** default `--settings '{"worktree":{"bgIsolation":"none"}}'`
+  so edits land in the real working directory and are not lost to `claude rm`'s
+  worktree cleanup. `--add-dir` defaults to cwd; callers add more.
+
+## Standalone validation plan (no quest)
+
+A `tests/`-style harness and a manual checklist, both runnable without quest:
+
+Unit (no live model — a fake `claude` shim on `PATH`):
+- argv construction pins flags incl. bgIsolation + name scheme + completion-protocol.
+- shortID parse over real samples incl. the `(idle …)` suffix (F7) and the F5
+  refusal string → precondition_failed.
+- exit-code-0-on-error is ignored; success requires shortID + confirmation (F4).
+- confirm timeout → dispatch_failed (F3); state mapping working/done/blocked/absent (F2/F6).
+- teardown never precedes collect; deadline issues stop then timeout.
+
+Manual / machine-validation checklist (real logged-in machine — closes F10):
+1. After the one-time bypass acceptance, run:
+   `claude_bg_run.py --json --wait-for /tmp/bgrun/out.json
+     --prompt "Write {\"ok\":true} to /tmp/bgrun/out.json"` → expect status ok,
+   file present, session removed afterward.
+2. Confirm `/usage` attributes the run to **subscription**, not API credit
+   (validates the billing premise of the whole migration).
+3. Force a permission block (omit bypass) → expect status blocked(4), fast, with
+   remediation — not a 30-min hang.
+4. Kill the daemon mid-run / run in a constrained shell → expect dispatch_failed
+   or session_failed, never a silent hang (F3).
+5. Verify writes land in the real path, not `.claude/worktrees/` (F9).
+
+## Relationship to the bridge and to Step 2
+
+- Same spirit and a comparable CLI to `scripts/quest_claude_bridge.py`, so Step 2
+  can select between them behind the `claude_role_transport` switch
+  (see `docs/implementation/claude-bg-transport-migration.md`) with no change to
+  prompts or the artifact contract.
+- Step 2 (separate, after this proves out): quest's runner calls `claude_bg_run.py`
+  with `handoff.json` + role artifacts as `--wait-for` and `--no-protocol`
+  (quest supplies its own role prompt), maps the exit codes into
+  `classify_failure_kind`, and adds the preflight transport probe.
+
+## Decisions made (changeable at review)
+
+1. Name `scripts/claude_bg_run.py`; single **blocking** `run` behavior (no
+   subcommands) — smallest surface that proves the transport. Passthrough helpers
+   (status/logs/stop) are just the native `claude` commands; no need to wrap.
+2. Default `--permission-mode bypassPermissions` (F6 shows lesser modes block).
+3. Runner **injects** the completion-protocol unless `--no-protocol`, so the tool
+   is useful with a naive prompt yet yields full control to quest later.
+4. Distinct exit codes per failure class (for shell + future quest routing).
+
+## One open item for you
+
+F10: the end-to-end write under a *bypass-accepted* session could not be proven
+in this sandbox (no interactive acceptance available). The design assumes it
+works (it is the documented, billed-as-subscription path); item 1 of the
+machine-validation checklist is the gate. If you can run that one command on your
+machine after `claude --dangerously-skip-permissions`, we'll have the green light
+before writing code — or we write the code and that command becomes its first
+real-run test. Your call which order.

--- a/docs/implementation/claude-bg-run-script.md
+++ b/docs/implementation/claude-bg-run-script.md
@@ -218,11 +218,17 @@ Proof of concept landed and validated:
 - `scripts/claude_bg_run.py` — stdlib-only runner implementing the lifecycle
   below, plus `pty_capture()` (the headless-PTY noise firewall) and a
   `--self-test` that demonstrates strip-to-signal with no `claude` needed.
-- `tests/unit/test_claude_bg_run.py` — 12 tests, **all passing** (`uv run pytest`),
+- `tests/unit/test_claude_bg_run.py` — 16 tests, **all passing** (`uv run pytest`),
   driving a fake-`claude` shim through every branch: ok+teardown-order,
-  needs_human bubble-back, blocked+distilled-logs, dispatch_failed (never
-  registers), bypass-refusal→precondition, timeout→stop, incomplete, the
-  shortID/idle-suffix regex, and the real-PTY firewall.
+  needs_human bubble-back, **needs_human keeps the session alive (no teardown)**,
+  **resume continues the same session**, **resume falls back to a fresh
+  dispatch**, resume-without-answer→precondition, blocked+distilled-logs,
+  dispatch_failed (never registers), bypass-refusal→precondition, timeout→stop,
+  incomplete, the shortID/idle-suffix regex, and the real-PTY firewall.
+- Resume relay: `needs_human` leaves the session alive and surfaces `session_id`;
+  the orchestrator answers with `--resume <session_id> --answer "<reply>"`
+  (fallback to a fresh `--bg` carrying the answer if resume fails). Ctrl-C tears
+  the live session down (exit 130) instead of orphaning it.
 - **Real-CLI smoke** (live `claude --bg`, this environment): dispatch +
   `agents --json` confirmation (captured the real `sessionId`) + state polling +
   teardown (no orphans) all worked. `claude logs` was distilled to clean,
@@ -232,6 +238,58 @@ Proof of concept landed and validated:
   `Stop` hook (`stop-hook-reply-gate.py`) forces sessions to `blocked`. Both are
   environment constraints, not runner behavior; the fake-shim tests cover the
   path deterministically. Closing it is machine-validation item 1.
+
+## Examples to try
+
+One-time, per machine (a human, once): `claude login`, then accept bypass mode
+once interactively with `claude --dangerously-skip-permissions` (the runner
+defaults to `--permission-mode bypassPermissions`).
+
+```bash
+# 0. No claude needed — prove the PTY noise firewall (ANSI in → clean text out).
+python3 scripts/claude_bg_run.py --self-test
+
+# 1. Happy path: dispatch, wait for the declared file, return ok, tear down.
+python3 scripts/claude_bg_run.py --json \
+  --wait-for /tmp/bgrun/out.json \
+  --prompt 'Write {"ok":true,"note":"hello from a bg agent"} to /tmp/bgrun/out.json'
+#   → status ok; /tmp/bgrun/out.json present; session removed.
+#   Then check `/usage` shows this against your SUBSCRIPTION, not API credit.
+
+# 2. needs_human bubble-back, then resume the SAME session with the answer.
+#    Give the agent a real fork so it asks instead of assuming:
+python3 scripts/claude_bg_run.py --json \
+  --handoff-file /tmp/bgrun/handoff.json \
+  --wait-for /tmp/bgrun/plan.md \
+  --prompt 'Draft a 3-line rollout plan in /tmp/bgrun/plan.md. If you must choose
+            between a canary rollout and a big-bang rollout and it is not
+            specified, do NOT guess: write {"status":"needs_human","questions":
+            ["canary or big-bang?"]} to /tmp/bgrun/handoff.json and stop.'
+#   → status needs_human, questions:[...], session LEFT ALIVE, prints session_id.
+
+# ...the orchestrator asks the human, gets "canary", then continues that session:
+python3 scripts/claude_bg_run.py --json \
+  --resume <session_id-from-step-2> \
+  --answer 'Use a canary rollout.' \
+  --wait-for /tmp/bgrun/plan.md \
+  --prompt 'Draft a 3-line rollout plan in /tmp/bgrun/plan.md.'   # fallback task
+#   → resumes the same conversation; on resume failure, re-dispatches fresh with
+#     the answer (because --prompt is provided). status ok; plan.md written.
+
+# 3. Quest-style call (what Step 2 will issue): wait on the role's own artifacts.
+python3 scripts/claude_bg_run.py --json --no-protocol \
+  --name quest-<id>-plan-reviewer-a \
+  --handoff-file .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json \
+  --wait-for  .quest/<id>/phase_01_plan/review_plan-reviewer-a.md \
+  --wait-for  .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json \
+  --add-dir "$(pwd)" \
+  --prompt-file .quest/<id>/phase_01_plan/reviewer_a_prompt.txt
+
+# 4. No-write smoke that does NOT need the bypass accept (plan mode, no files):
+python3 scripts/claude_bg_run.py --json --permission-mode plan \
+  --prompt 'Reply with exactly: OK'
+#   → completion == reaching `done`; useful to confirm dispatch/confirm/teardown.
+```
 
 ## Decisions made (changeable at review)
 

--- a/docs/implementation/claude-bg-run-script.md
+++ b/docs/implementation/claude-bg-run-script.md
@@ -211,6 +211,28 @@ Manual / machine-validation checklist (real logged-in machine — closes F10):
   (quest supplies its own role prompt), maps the exit codes into
   `classify_failure_kind`, and adds the preflight transport probe.
 
+## PoC status (2026-06-10)
+
+Proof of concept landed and validated:
+
+- `scripts/claude_bg_run.py` — stdlib-only runner implementing the lifecycle
+  below, plus `pty_capture()` (the headless-PTY noise firewall) and a
+  `--self-test` that demonstrates strip-to-signal with no `claude` needed.
+- `tests/unit/test_claude_bg_run.py` — 12 tests, **all passing** (`uv run pytest`),
+  driving a fake-`claude` shim through every branch: ok+teardown-order,
+  needs_human bubble-back, blocked+distilled-logs, dispatch_failed (never
+  registers), bypass-refusal→precondition, timeout→stop, incomplete, the
+  shortID/idle-suffix regex, and the real-PTY firewall.
+- **Real-CLI smoke** (live `claude --bg`, this environment): dispatch +
+  `agents --json` confirmation (captured the real `sessionId`) + state polling +
+  teardown (no orphans) all worked. `claude logs` was distilled to clean,
+  escape-free text — the noise firewall verified against real output.
+- **Not yet provable in-sandbox:** the happy "ok via artifact file" path with a
+  real session — writes need the one-time bypass acceptance, and this env's own
+  `Stop` hook (`stop-hook-reply-gate.py`) forces sessions to `blocked`. Both are
+  environment constraints, not runner behavior; the fake-shim tests cover the
+  path deterministically. Closing it is machine-validation item 1.
+
 ## Decisions made (changeable at review)
 
 1. Name `scripts/claude_bg_run.py`; single **blocking** `run` behavior (no

--- a/docs/implementation/claude-bg-run-script.md
+++ b/docs/implementation/claude-bg-run-script.md
@@ -3,9 +3,9 @@ title: claude-bg-run — Standalone Background-Agent Runner (Step 1)
 purpose: Specify a quest-agnostic CLI that runs a single Claude background-agent task to completion and returns a structured result, communicating purely through files. It is the proving ground for the background-agent transport before any quest wiring.
 audience: Implementing agent and reviewers.
 scope: One standalone script (dispatch → confirm → wait-on-files → collect → teardown). No quest coupling.
-status: draft — for review before implementation
+status: implemented — PoC validated end-to-end on a real machine (see PoC status)
 owner: maintainers
-last_updated: 2026-06-09
+last_updated: 2026-06-11
 related:
   - docs/implementation/claude-bg-transport-migration.md
   - scripts/quest_claude_bridge.py
@@ -39,7 +39,7 @@ and out of scope here.
 - No log scraping for results (see finding F1 — impossible reliably).
 - Not a replacement for the bridge yet; it is a peer we validate alongside it.
 
-## Validated behavior (live, this environment, Claude Code 2.1.159→2.1.170)
+## Validated behavior (live, Claude Code 2.1.159→2.1.173)
 
 These findings are empirical (run against the real CLI) and drive every design
 choice below. Where a behavior could not be fully validated here, it is marked
@@ -47,7 +47,7 @@ and pushed to the machine-validation checklist.
 
 | # | Finding | Consequence for the script |
 |---|---|---|
-| F1 | `claude logs <id>` returns the **raw TUI screen buffer** (ANSI/cursor escapes); the model's text answer is not cleanly extractable. | Results MUST travel via files. `logs` is used only as an opaque diagnostic blob on failure. |
+| F1 | ~~`claude logs <id>` returns the raw TUI screen buffer~~ **Corrected (2.1.173): there IS no `claude logs` subcommand** — unknown verbs parse as a *prompt* and no-op. The session transcript at `~/.claude/projects/<project>/<sessionId>.jsonl` is the log. | Results MUST travel via files. Diagnostics (`logs_tail`) come from the transcript JSONL (last assistant-text lines, distilled), located by globbing `<transcripts-root>/*/<sessionId>.jsonl`. |
 | F2 | `claude agents --json` reports per-session `state` and `status`. Observed transitions: `working`/`busy` → `done`/`idle`; a session that needs a permission decision ends `blocked`/`idle`. | Completion + failure are detectable structurally: success via files (primary) + `state==done`; **`state==blocked` → fail fast** (don't wait for timeout). |
 | F3 | The supervisor starts **on-demand** ("origin: transient — started on-demand by `claude --bg`"). There is a cold-start window; once, a dispatch printed success while `daemon status` was `not running` and the session never registered. | A **confirmation step** is mandatory: after dispatch, poll `agents --json` until the session appears (bounded). No appearance → `dispatch_failed`. The success line alone is not proof. |
 | F4 | A `--bg` dispatch blocked by the bypass disclaimer printed an error **and still exited 0**. | Do not trust the process exit code. Success = parsing `backgrounded · <shortID>` from stdout **and** F3 confirmation. |
@@ -55,8 +55,10 @@ and pushed to the machine-validation checklist.
 | F6 | A `--permission-mode acceptEdits` session asked to create new files ended `blocked` without writing. | For unattended file-writing, `acceptEdits` is insufficient; bypass (F5) is required. The script defaults to bypass and treats `blocked` as a permission failure with a clear message. |
 | F7 | Dispatch stdout format: `backgrounded · <shortID>[ · <name>]`, plus a 4-line management hint. An idle no-prompt dispatch appended `(idle — send a prompt to start)`. | shortID regex: `backgrounded\s*·\s*([0-9a-f]+)`; name is optional; tolerate the idle suffix. |
 | F8 | `agents --json` background entries carry `id`, `name`, `status`, `state`, `sessionId`, `pid`, `cwd`; interactive sessions lack `id/name/status/state`. | Match dispatched sessions by `name` (preferred) or `id`; ignore `kind==interactive` rows. |
-| F9 | `claude stop <id>` then `claude rm <id>` cleanly remove a session (verified: list returns to interactive-only). Background sessions auto-isolate edits into `.claude/worktrees/` unless disabled. | Teardown = stop → rm, only **after** results are collected. Pass `--settings '{"worktree":{"bgIsolation":"none"}}'` so writes land in the real workspace, not a worktree `rm` would delete. |
-| F10 | **Not validated here:** an end-to-end write by a *bypass-accepted* session reaching `state==done` with the expected files present. Blocked by F5 (no interactive acceptance available in this sandbox). | Must be confirmed on a real logged-in machine — see Machine-validation checklist. The script is designed for it; the proof is operational. |
+| F9 | ~~`claude stop <id>` then `claude rm <id>` cleanly remove a session~~ **Corrected (2.1.173): `stop`/`rm` are not subcommands either** — they parse as a prompt and silently do nothing (this is why earlier teardowns left orphans). The `agents --json` row carries the session's `pid`; the scriptable stop is signalling that pid. The daemon may **respawn a parked session once** from its spare pool (same row id, fresh pid), and a killed row may linger pid-less ("settled") in the listing. Background sessions auto-isolate edits into `.claude/worktrees/` unless disabled. | Teardown = signal the row's *current* pid (SIGTERM, escalate to SIGKILL) **repeatedly until the row drops its pid or disappears**, only **after** results are collected. Pass `--settings '{"worktree":{"bgIsolation":"none"}}'` so writes land in the real workspace. |
+| F11 | A **parked** session (idle, awaiting input — e.g. left alive after `needs_human`) reads `state==blocked` in `agents --json`, identical to a genuinely stuck session. | Resume-mode polling must never match the parked parent's row: session matching uses **strict precedence** (short id → name → sessionId), not first-row-wins OR-matching, or the parent's `blocked` shadows the new agent and misreports the run. |
+| F12 | `claude --bg --resume <sid>` **forks**: the new agent continues the conversation under a **new sessionId** (daemon roster: `launch.mode=resume, fork=true`), while the parked parent stays alive and would be orphaned. | The envelope reports the NEW `session_id` (chain further resumes off it) plus `resumed_from`; after the new agent is confirmed, the runner retires the parked parent. |
+| F10 | ~~Not validated here~~ **CLOSED (2026-06-11, real logged-in machine):** end-to-end writes by bypass-accepted sessions reached the expected files, including the full needs_human → resume-by-name → answered → artifact loop. | The happy path is proven operational. Remaining manual check: `/usage` billing attribution (machine-validation item 2). |
 
 ## The file-based completion contract
 
@@ -91,6 +93,12 @@ Mirrors `quest_claude_bridge.py` where sensible (drop-in transport sibling):
 ```
 scripts/claude_bg_run.py
   (--prompt TEXT | --prompt-file PATH | -)        # task; '-' or stdin supported
+                                                  # in resume mode: the fallback task
+  --resume REF               (session id, agent SHORT ID, or agent NAME — names are
+                              resolved live via `agents --json`, so a session renamed
+                              in the agent view stays resumable)
+  --answer TEXT | --answer-file PATH | -          (resume mode: the human's reply)
+  --no-fallback              (resume mode: don't re-dispatch fresh if resume fails)
   --wait-for PATH            (repeatable, >=1 unless --no-wait)
   --model NAME               (optional; defaults to CLI/account default)
   --permission-mode MODE     (default: bypassPermissions)
@@ -105,30 +113,36 @@ scripts/claude_bg_run.py
   --keep                     (skip teardown; for debugging)
   --json                     (emit the result envelope to stdout)
   --no-protocol              (don't append the completion-protocol block)
+  --transcripts-root PATH    (default ~/.claude/projects; logs_tail source — F1)
 ```
 
 ### Output envelope (`--json`)
 
 ```json
 {
-  "status": "ok | timeout | dispatch_failed | blocked | session_failed | incomplete | precondition_failed",
+  "status": "ok | needs_human | timeout | dispatch_failed | blocked | session_failed | incomplete | precondition_failed | interrupted",
   "short_id": "d868c9d3",
-  "session_id": "d868c9d3-…",
+  "session_id": "d868c9d3-…",   // resume mode: the NEW (forked) session id — F12
   "name": "bgrun-1a2b3c4d",
+  "resumed": false,
+  "resumed_from": null,          // resume mode: the session id that was continued
+  "fell_back": false,            // resume failed, re-dispatched fresh with the answer
   "wait_for": ["…"],
   "artifacts_found": ["…"],
   "missing": ["…"],
+  "questions": ["…"],            // needs_human: the agent's question(s)
   "final_state": "done | blocked | absent | working",
   "duration_s": 41.2,
-  "logs_tail": "…",          // present only on non-ok status, raw/opaque
+  "logs_tail": "…",          // non-ok status only; distilled from the transcript (F1)
   "message": "human-readable summary / remediation"
 }
 ```
 
 Exit codes: `0` ok; `2` precondition_failed (CLI/auth/bypass-acceptance — F4/F5);
-`3` dispatch_failed (F3); `4` blocked (F6); `5` timeout; `6` session_failed/incomplete.
-(Distinct codes so a shell harness — and later quest's `classify_failure_kind`
-— can route without parsing stdout.)
+`3` dispatch_failed (F3); `4` blocked (F6); `5` timeout; `6` session_failed/incomplete;
+`10` needs_human (actionable, not a failure); `130` interrupted (Ctrl-C, session
+torn down). (Distinct codes so a shell harness — and later quest's
+`classify_failure_kind` — can route without parsing stdout.)
 
 ## Lifecycle (the state machine)
 
@@ -146,8 +160,10 @@ Exit codes: `0` ok; `2` precondition_failed (CLI/auth/bypass-acceptance — F4/F
    - parse shortID (F7); if absent → dispatch_failed(3)
 2. CONFIRM (F3)
    - poll `agents --json` every poll-interval up to confirm-timeout for a row whose
-     name==<name> (or id==shortID); capture id + sessionId
+     id==shortID (or name==<name>) — strict precedence, never by sessionId, which
+     would falsely match the parked parent in resume mode (F11); capture id + sessionId
    - never appears → dispatch_failed(3) with daemon-status snapshot in message
+   - resume mode, once confirmed: retire the parked parent agent (F12; respects --keep)
 3. WAIT  (loop until deadline)
    - every poll-interval: check all --wait-for paths exist & non-empty
        → all satisfied: capture, go COLLECT (ok)
@@ -156,11 +172,11 @@ Exit codes: `0` ok; `2` precondition_failed (CLI/auth/bypass-acceptance — F4/F
        blocked  → COLLECT then blocked(4) + logs_tail + permission remediation (F6)
        done but wait-for unsatisfied → short grace (e.g. 2 poll-intervals), then incomplete(6)
        absent (unexpected) → session_failed(6)
-   - deadline reached → `claude stop <id>` → timeout(5)
+   - deadline reached → timeout(5); the final teardown stops the session
 4. COLLECT
-   - record artifacts_found / missing; on any non-ok, capture `claude logs <id>` tail (opaque)
-5. TEARDOWN  (unless --keep)
-   - only AFTER collect: `claude stop <id>` (if alive) → `claude rm <id>`  (F9 order)
+   - record artifacts_found / missing; on any non-ok, distill the transcript tail (F1)
+5. TEARDOWN  (unless --keep; skipped entirely for needs_human — session stays resumable)
+   - only AFTER collect: signal the row's current pid until the row settles (F9)
 6. RETURN envelope + exit code
 ```
 
@@ -211,33 +227,38 @@ Manual / machine-validation checklist (real logged-in machine — closes F10):
   (quest supplies its own role prompt), maps the exit codes into
   `classify_failure_kind`, and adds the preflight transport probe.
 
-## PoC status (2026-06-10)
+## PoC status (2026-06-11)
 
 Proof of concept landed and validated:
 
 - `scripts/claude_bg_run.py` — stdlib-only runner implementing the lifecycle
   below, plus `pty_capture()` (the headless-PTY noise firewall) and a
   `--self-test` that demonstrates strip-to-signal with no `claude` needed.
-- `tests/unit/test_claude_bg_run.py` — 16 tests, **all passing** (`uv run pytest`),
-  driving a fake-`claude` shim through every branch: ok+teardown-order,
-  needs_human bubble-back, **needs_human keeps the session alive (no teardown)**,
-  **resume continues the same session**, **resume falls back to a fresh
-  dispatch**, resume-without-answer→precondition, blocked+distilled-logs,
-  dispatch_failed (never registers), bypass-refusal→precondition, timeout→stop,
-  incomplete, the shortID/idle-suffix regex, and the real-PTY firewall.
+- `tests/unit/test_claude_bg_run.py` — 20 tests, **all passing** (`uv run pytest`),
+  driving a fake-`claude` shim (multi-row `agents --json` with pids, parked
+  parent, no fake stop/rm/logs verbs) through every branch: ok+pid-signal
+  teardown, --keep, needs_human bubble-back, **needs_human keeps the session
+  alive (no teardown)**, **resume not shadowed by the parked parent (F11
+  regression)**, **resume by renamed agent name / by short id**, resume-unknown
+  →precondition, **resume falls back to a fresh dispatch**, resume-without-answer
+  →precondition, blocked+transcript-logs, dispatch_failed (never registers),
+  bypass-refusal→precondition, timeout→teardown, incomplete, the
+  shortID/idle-suffix regex, and the real-PTY firewall.
 - Resume relay: `needs_human` leaves the session alive and surfaces `session_id`;
-  the orchestrator answers with `--resume <session_id> --answer "<reply>"`
-  (fallback to a fresh `--bg` carrying the answer if resume fails). Ctrl-C tears
-  the live session down (exit 130) instead of orphaning it.
-- **Real-CLI smoke** (live `claude --bg`, this environment): dispatch +
-  `agents --json` confirmation (captured the real `sessionId`) + state polling +
-  teardown (no orphans) all worked. `claude logs` was distilled to clean,
-  escape-free text — the noise firewall verified against real output.
-- **Not yet provable in-sandbox:** the happy "ok via artifact file" path with a
-  real session — writes need the one-time bypass acceptance, and this env's own
-  `Stop` hook (`stop-hook-reply-gate.py`) forces sessions to `blocked`. Both are
-  environment constraints, not runner behavior; the fake-shim tests cover the
-  path deterministically. Closing it is machine-validation item 1.
+  the orchestrator answers with `--resume <session_id|short_id|name> --answer
+  "<reply>"` (fallback to a fresh `--bg` carrying the answer if resume fails).
+  Ctrl-C tears the live session down (exit 130) instead of orphaning it.
+- **Real-CLI end-to-end (2026-06-11, real logged-in machine, 2.1.173):** the full
+  loop validated live — dispatch → `needs_human` (question bubbled, session
+  parked) → **resume by agent NAME** → answer delivered into the same
+  conversation (fork, F12) → declared artifact written → status ok → parked
+  parent retired → new agent torn down. This run also *corrected* three earlier
+  findings: no `logs`/`stop`/`rm` subcommands exist (F1/F9 — old teardown was a
+  silent no-op that left orphans), a parked session reads `state==blocked`
+  (F11 — it used to shadow the resume and misreport `blocked`), and resume forks
+  to a new sessionId (F12).
+- Machine-validation item 2 (`/usage` attributes runs to subscription, not API
+  credit) remains a manual check.
 
 ## Examples to try
 
@@ -267,14 +288,19 @@ python3 scripts/claude_bg_run.py --json \
             ["canary or big-bang?"]} to /tmp/bgrun/handoff.json and stop.'
 #   → status needs_human, questions:[...], session LEFT ALIVE, prints session_id.
 
-# ...the orchestrator asks the human, gets "canary", then continues that session:
+# ...the orchestrator asks the human, gets "canary", then continues that session.
+# --resume takes the session_id, the agent's short id, or its NAME — so a session
+# renamed in the agent view (`claude agents`) stays resumable:
 python3 scripts/claude_bg_run.py --json \
-  --resume <session_id-from-step-2> \
+  --resume <session_id-or-short_id-or-name-from-step-2> \
   --answer 'Use a canary rollout.' \
   --wait-for /tmp/bgrun/plan.md \
   --prompt 'Draft a 3-line rollout plan in /tmp/bgrun/plan.md.'   # fallback task
-#   → resumes the same conversation; on resume failure, re-dispatches fresh with
-#     the answer (because --prompt is provided). status ok; plan.md written.
+#   → resumes the same conversation as a FORK (new session_id in the envelope,
+#     `resumed_from` = the continued session; chain further resumes off the new id);
+#     the parked parent agent is retired once the fork is confirmed. On resume
+#     failure, re-dispatches fresh with the answer (because --prompt is provided).
+#     status ok; plan.md written.
 
 # 3. Quest-style call (what Step 2 will issue): wait on the role's own artifacts.
 python3 scripts/claude_bg_run.py --json --no-protocol \
@@ -294,8 +320,9 @@ python3 scripts/claude_bg_run.py --json --permission-mode plan \
 ## Decisions made (changeable at review)
 
 1. Name `scripts/claude_bg_run.py`; single **blocking** `run` behavior (no
-   subcommands) — smallest surface that proves the transport. Passthrough helpers
-   (status/logs/stop) are just the native `claude` commands; no need to wrap.
+   subcommands) — smallest surface that proves the transport. Status passthrough
+   is the native `claude agents --json`; there are no native logs/stop verbs to
+   pass through (F1/F9), so the runner owns transcript-tail and pid-signalling.
 2. Default `--permission-mode bypassPermissions` (F6 shows lesser modes block).
 3. Runner **injects** the completion-protocol unless `--no-protocol`, so the tool
    is useful with a naive prompt yet yields full control to quest later.
@@ -303,10 +330,9 @@ python3 scripts/claude_bg_run.py --json --permission-mode plan \
 
 ## One open item for you
 
-F10: the end-to-end write under a *bypass-accepted* session could not be proven
-in this sandbox (no interactive acceptance available). The design assumes it
-works (it is the documented, billed-as-subscription path); item 1 of the
-machine-validation checklist is the gate. If you can run that one command on your
-machine after `claude --dangerously-skip-permissions`, we'll have the green light
-before writing code — or we write the code and that command becomes its first
-real-run test. Your call which order.
+~~F10: the end-to-end write under a bypass-accepted session could not be proven
+in this sandbox.~~ **Closed 2026-06-11** — the full loop (dispatch →
+`needs_human` → resume by name → artifact written → parent retired) ran green on
+a real logged-in machine; see PoC status. The one remaining manual check is
+`/usage` billing attribution (machine-validation item 2): confirm a run lands on
+your **subscription**, not API credit.

--- a/docs/implementation/claude-bg-transport-migration.md
+++ b/docs/implementation/claude-bg-transport-migration.md
@@ -1,0 +1,353 @@
+---
+title: Claude Background-Agent Transport — Migration Spec
+purpose: Define exactly what must change to move Codex-led Claude role execution from the `claude --print` bridge to the official background-agent surface (`claude --bg` + per-user supervisor), and why the bridge is demoted to fallback rather than deleted.
+audience: Quest maintainers and the implementing quest.
+scope: Transport layer only — the runner entrypoint, handoff contract, and role prompts are unchanged.
+status: draft — for review before implementation
+owner: maintainers
+last_updated: 2026-06-09
+related:
+  - ideas/2026-05-31-codex-driven-interactive-claude-relay.md
+  - ideas/2026-05-26-native-runtime-dispatch.md
+  - ideas/2026-05-31-quest-model-capability-improvements.md
+  - ideas/claude-cli-login-context.md
+  - scripts/quest_claude_bridge.py
+  - scripts/quest_claude_runner.py
+  - scripts/quest_runtime/claude_runner.py
+  - scripts/quest_preflight.sh
+  - .skills/quest/delegation/workflow.md
+---
+
+# Claude Background-Agent Transport — Migration Spec
+
+## Goal
+
+After June 15, 2026, `claude --print` (the current bridge transport,
+`scripts/quest_claude_bridge.py:132`) bills to the metered Agent-SDK credit pool
+at API rates. Background-agent sessions (`claude --bg`, hosted by the per-user
+supervisor) bill to the **subscription pool** ("background sessions consume your
+subscription usage the same as interactive sessions" — agent-view.md,
+Limitations). This spec migrates Codex-led Claude role execution to the
+background-agent transport as the **default**, with the bridge demoted to an
+explicit fallback.
+
+**Design invariant:** the swap happens entirely *underneath*
+`scripts/quest_claude_runner.py`. The runner stays the orchestration entrypoint;
+role prompts, artifact preparation, `handoff.json` polling, the three-tier
+fallback ladder, and `context_health.log` keep their existing contracts. Only
+the mechanism that gets a prompt to a Claude process changes. Claude-led
+sessions (native `Task(...)`) are untouched.
+
+## Verified facts this spec rests on
+
+Checked live in this repo's environment (Claude Code 2.1.159, auto-updated to
+2.1.170 mid-session) and against `code.claude.com/docs/en/agent-view.md`:
+
+1. `claude --bg "<prompt>"` dispatches a detached background session and prints:
+   `backgrounded · <shortID> [· <name>]` plus the management commands. Confirmed
+   live (an idle no-prompt dispatch printed `backgrounded · e590de4c (idle — send
+   a prompt to start)`).
+2. `claude agents --json` prints live sessions as a JSON array
+   (`pid, cwd, kind, startedAt, sessionId[, name, status]`) and needs no TTY.
+3. `claude attach|logs|stop|respawn|rm <id>` and `claude daemon status` exist.
+   State lives in `~/.claude/jobs/<id>/state.json` + `~/.claude/daemon/roster.json`.
+4. Billing: subscription pool, verbatim quote above; the supervisor
+   "authenticate[s] with the same credentials as your interactive sessions."
+5. **Dispatch can false-positive.** In this sandboxed container the `--bg`
+   dispatch printed success while `claude daemon status` reported `not running`,
+   `control.sock unreachable`, `0 bg workers`, and the session never appeared in
+   `agents --json`. The success line alone is NOT proof of dispatch.
+6. **Research-preview churn is real.** The feature is flagged research preview
+   (v2.1.139+); the CLI auto-updated 2.1.159 → 2.1.170 during a single working
+   session. `--bg` is not yet listed in `claude --help` even though it works.
+7. Background sessions auto-move into a Claude-created git worktree under
+   `.claude/worktrees/` before editing files; `claude rm` can delete that
+   worktree including uncommitted changes. `worktree.bgIsolation: "none"`
+   (v2.1.143+) disables this; the `--settings` flag carries into dispatched
+   sessions.
+8. `bypassPermissions`/`auto` are refused for background sessions "until you
+   have accepted that mode by running claude with it once interactively" —
+   one-time per machine.
+9. There is no `--bg` proof-of-concept in the repo today. Both existing scripts
+   (`scripts/quest_claude_bridge.py`, `ideas/codex_calls_claude.sh`) are
+   `--print`-based.
+
+## Architecture: before and after
+
+```
+BEFORE (bridge)
+  orchestrator (Codex)
+    └─ quest_claude_runner.py ──► quest_claude_bridge.py ──► claude --print  [blocks]
+         └─ polls handoff.json + artifacts (claude_runner.run_claude_role)
+
+AFTER (background-agent default, bridge fallback)
+  orchestrator (Codex)
+    └─ quest_claude_runner.py ──► transport selected from orchestration.json/preflight
+         ├─ background-agent:  claude --bg ... ──► supervisor-hosted session  [detached]
+         │     └─ SAME poll loop on handoff.json + artifacts
+         │     └─ NEW side-channel: claude agents --json (status), claude logs (diagnostics)
+         └─ bridge (fallback): quest_claude_bridge.py ──► claude --print      [unchanged]
+```
+
+## The background-agent transport contract
+
+### T1. Dispatch
+
+```bash
+claude --bg \
+  --name "quest-<quest_id>-<agent>-i<iter>" \
+  --model <models.<role> from orchestration.json> \
+  --permission-mode bypassPermissions \
+  --settings '{"worktree":{"bgIsolation":"none"}}' \
+  --add-dir <repo_root> --add-dir <quest_dir> [--add-dir <extra>...] \
+  "<prompt text>"
+```
+
+- The prompt is passed as the positional argument (Quest prompts are small by
+  design — path references only). The runner reads it from `--prompt-file`
+  exactly as today and passes the text through.
+- `--name` is deterministic and unique (`quest-<id>-<agent>-i<iter>`); it is the
+  recovery key for everything below.
+- `--effort` may be added later per the deferred per-role effort proposal
+  (`ideas/2026-05-31-quest-model-capability-improvements.md`); not in scope here.
+
+### T2. Dispatch confirmation (closes the false-positive gap — fact 5)
+
+After the `--bg` command returns:
+
+1. Parse `<shortID>` from the `backgrounded · <shortID>` stdout line (regex
+   `backgrounded\s*·\s*([0-9a-f]+)`).
+2. **Confirm within a short window (default 10s):** poll `claude agents --json`
+   until an entry with the dispatched `name` (or `shortID`) appears. Capture its
+   `sessionId`.
+3. If parse fails but confirmation succeeds, proceed with the `agents --json`
+   record (name lookup). If confirmation fails, classify as
+   `invocation_error` → the existing ladder routes it (Tier C: bridge fallback).
+4. Record `{short_id, session_id, name, dispatched_at}` to
+   `.quest/<id>/logs/bg_sessions.jsonl` for teardown and orphan cleanup.
+
+### T3. Completion detection (reuses today's loop)
+
+The existing `run_claude_role` poll loop (`scripts/quest_runtime/claude_runner.py`,
+handoff-state + artifact-completeness every 0.5s until deadline) is reused
+unchanged as the **primary** signal: handoff.json found + artifacts complete →
+success.
+
+Add a low-frequency session-status check (every ~10s, one `claude agents --json`
+subprocess) as the **secondary** signal:
+
+| Session status / condition | Runner action |
+|---|---|
+| working | keep polling files |
+| completed, handoff found | success (normal) |
+| completed/failed, handoff missing | capture `claude logs <id>` tail to stderr context; classify via existing `classify_result_kind` (`handoff_missing` → ladder) |
+| needs input | see T4 |
+| absent from `agents --json` and no handoff | `invocation_error` (supervisor died / session evaporated) → ladder |
+
+Timeout enforcement moves to the runner: `--bg` has no per-session timeout flag,
+so the existing wall-clock deadline (default 1800s, same as the bridge) is
+enforced by the runner issuing `claude stop <id>` at deadline, then classifying
+`timeout` (existing ladder: retry-once-reduced-prompt, then blocked).
+
+### T4. `needs input` policy
+
+Quest's Claude roles signal questions via `STATUS: needs_human` in the handoff —
+that path is unchanged. A background session stuck in `needs input` *without* a
+handoff means an interactive blocker (typically a permission prompt) leaked
+through. Policy:
+
+1. Capture the question via `claude logs <id>` (tail).
+2. `claude stop <id>`.
+3. Treat as the existing `needs_human` route with the captured text as the
+   question — never silently retry, never attempt TUI keystroke replies.
+4. Prevention is primary: `bypassPermissions` + the one-time acceptance (fact 8)
+   + pre-trusted workspace settings should make this path rare; its frequency is
+   logged (see Logging) and reviewed.
+
+### T5. Teardown and orphan cleanup
+
+- On success or final failure: verify artifacts exist under `.quest/<id>/`
+  (they always live in the repo, never in a Claude-created worktree, because
+  `bgIsolation` is disabled and artifact paths are absolute), then
+  `claude stop <id>` (if alive) and `claude rm <id>`. Order matters: never `rm`
+  before artifacts are confirmed on disk (fact 7).
+- **Orphan sweep:** at quest start and resume, list `claude agents --json` and
+  `claude stop`/`rm` any session whose `name` matches `quest-<this quest_id>-*`
+  but has no corresponding in-flight runner (stale from a crashed orchestrator).
+  Sessions from *other* quests are left alone.
+
+### T6. Worktree isolation (fact 7)
+
+`--settings '{"worktree":{"bgIsolation":"none"}}'` on every dispatch. Rationale:
+Quest already owns branch/worktree strategy at startup
+(`scripts/quest_startup_branch.py`); a second, Claude-managed worktree layer
+would split source edits from the orchestrator's workspace and is deleted by
+`claude rm`. Artifact paths in prompts remain absolute (already required when
+`source_workspace_root != repo root`).
+
+Phase 0 must validate: (a) the settings flag is honored on dispatch, (b) writes
+to gitignored `.quest/**` do not trigger a worktree move even without the
+setting, (c) a write role (builder/fixer on Claude) edits the real workspace.
+
+## Configuration: the hard switch
+
+`.ai/allowlist.json` (and copied into `.quest/<id>/orchestration.json` by the
+startup chooser, like `models.*`):
+
+```jsonc
+"claude_role_transport": "auto"   // default
+// "auto"             → background-agent when preflight proves it; else bridge (downgrade recorded)
+// "background-agent" → forced; preflight failure blocks with remediation (never silent bridge)
+// "bridge"           → forced legacy/API path (CI, API-billing contexts)
+```
+
+This is a config value consumed by scripts — not workflow prose — so the
+orchestrator cannot reinterpret it. The resolved transport and any downgrade are
+written into `orchestration.json` (`claude_transport_resolved`,
+`claude_transport_downgraded: bool`) at preflight time and logged.
+
+`auto` is the recommended default: it makes background-agent the de-facto
+replacement on developer machines while CI/sandboxes (like the environment that
+produced fact 5) degrade loudly to the bridge.
+
+## Preflight and probe changes
+
+`scripts/quest_preflight.sh` (`probe_claude_bridge` → generalized
+`probe_claude_transport`):
+
+1. `command -v claude`; `claude auth status` must report `loggedIn: true` in the
+   same execution context (see `ideas/claude-cli-login-context.md`; honor
+   `CLAUDE_CONFIG_DIR`/HOME — the supervisor is per-config-dir).
+2. Feature check: `claude agents --json` exits 0 and returns JSON (older
+   versions list subagents instead — that output is not JSON → bridge).
+3. Supervisor check: dispatch nothing; run `claude daemon status`. "not running"
+   is acceptable (it autostarts) **only if** step 4 passes.
+4. **Real probe (the authoritative check, replacing `run_bridge_probe`):**
+   dispatch a trivial `--bg` role (`write "ok" + probe handoff under
+   .quest/<id>/logs/bg_probe/`), run T2 confirmation, poll to completion
+   (short timeout, e.g. 120s), tear down per T5. This exercises dispatch
+   confirmation, supervisor liveness, bypass-acceptance, and file-write in one
+   shot — and would have caught fact 5's false positive.
+5. Bypass-acceptance detection: if the probe fails with the acceptance-required
+   error, emit a remediation warning: "run `claude --permission-mode
+   bypassPermissions` once interactively and accept, then rerun preflight."
+6. Cache the result in `.quest/cache/claude_bg_codex.json` with the same TTL
+   semantics as today's `claude_bridge_codex.json`; keep the bridge cache as the
+   fallback probe. Preflight JSON output gains `transport` and keeps
+   `runtime_requirement: "host_context"` semantics.
+
+`scripts/quest_claude_probe.py` gains `--transport {background-agent,bridge,auto}`
+and drives step 4.
+
+## File-by-file change list
+
+| File | Change |
+|---|---|
+| `scripts/quest_runtime/claude_runner.py` | Add `dispatch_bg()` (T1+T2), session-status polling hook in the poll loop (T3), `stop/rm` teardown + deadline `claude stop` (T3/T5), orphan sweep helper (T5). `build_bridge_cmd`/bridge path unchanged. `classify_failure_kind` gains the `absent-session → invocation` case. |
+| `scripts/quest_claude_runner.py` | New `--transport auto\|background-agent\|bridge` (default `auto`: resolve from orchestration.json, then preflight cache). Existing flags unchanged; `--bridge-script` applies to bridge path only. |
+| `scripts/quest_claude_bridge.py` | **Unchanged.** Docstring note: fallback/API transport; default for CI and `ANTHROPIC_API_KEY` contexts. |
+| `scripts/quest_claude_probe.py` | `--transport` flag; bg probe per preflight step 4. |
+| `scripts/quest_preflight.sh` | `probe_claude_transport` per above; new cache file; `transport` in output JSON. |
+| `.ai/allowlist.json` + `.ai/schemas/allowlist.schema.json` | `claude_role_transport` key (enum, default `auto`). |
+| `scripts/quest_runtime/orchestration.py` | Copy/validate the transport key into `orchestration.json`; record resolved transport + downgrade flag. |
+| `.skills/quest/delegation/workflow.md` | "Claude Bridge Probe…" section → "Claude Transport Probe and Runtime Dispatch": background-agent preferred, bridge fallback, forced modes; Tier-C rows extended to bg-invoked Claude (timeout/stop semantics per T3); context-health format gains optional `transport=` field. |
+| `.ai/quest.md` | Transport section rewritten (bridge → bg default + fallback table). |
+| `docs/guides/quest_setup.md` | One-time machine setup: `claude login`; one-time interactive `bypassPermissions` acceptance; note version ≥ 2.1.139 (prefer ≥ 2.1.143 for `bgIsolation`). |
+| `scripts/quest_validate-handoff-contracts.sh` | Update grep-count contract checks (bridge refs remain but new transport refs required in workflow.md). |
+| `.quest-manifest` | Add any new files. |
+| Tests | See below. |
+
+## Logging
+
+`context_health.log` line format gains one optional field, documented in
+workflow.md:
+
+```
+... | handoff_json=found | source=handoff_json | transport=bg|bridge
+```
+
+`runtime=claude` semantics are unchanged (bg-invoked Claude is still
+`runtime=claude`). New events logged: dispatch-confirmation failures, bg→bridge
+downgrades, `needs input` captures, orphan sweeps. This feeds the
+measurement-first doctrine (`ideas/2026-05-31-quest-model-capability-improvements.md`):
+the same log answers "how often does bg fail and fall back."
+
+## Tests
+
+Unit (no live model; `claude` faked with a shim script on PATH):
+- Dispatch argv construction pins the full `--bg` command including `--settings`
+  bgIsolation and `--name` scheme.
+- shortID parse of `backgrounded · <id> [· <name>]` incl. the idle variant; name
+  fallback via faked `agents --json`.
+- Status mapping table (T3) including absent-session → `invocation_error`.
+- False-positive case (fact 5): success print + empty `agents --json` →
+  `invocation_error`, no infinite poll.
+- Teardown ordering: `rm` never precedes artifact confirmation; deadline issues
+  `stop` then classifies `timeout`.
+- Transport resolution matrix: {auto, background-agent, bridge} ×
+  {probe ok, probe failed} → {bg, bridge, blocked} with downgrade recording.
+- Orphan sweep matches only `quest-<id>-*` names.
+
+Contract/text:
+- `quest_validate-handoff-contracts.sh` counts updated; workflow.md documents
+  bg-preferred + bridge-fallback + forced modes.
+- `tests/test-quest-preflight.sh` extended with shim behaviors: old CLI
+  (non-JSON `agents` output), auth false, daemon dead, acceptance-required.
+
+Live (manual, env-guarded, Phase 0): one real probe dispatch on a logged-in dev
+machine; results recorded in the PR.
+
+## Rollout
+
+- **Phase 0 — validation spike (manual, ~1 hour on a real logged-in machine).**
+  Verify: probe dispatch end-to-end; `--settings` bgIsolation honored;
+  gitignored `.quest/**` writes don't trigger worktree moves; bypass acceptance
+  flow + error text; `backgrounded` output format on current version; behavior
+  when supervisor can't start (expect fact-5 signature). Record findings in the
+  PR description. **Gate: implementation does not start until Phase 0 passes.**
+- **Phase 1 — dark launch.** Land everything with default `auto` but ship one
+  release with `claude_role_transport: "bridge"` in the repo allowlist so the
+  new path is opt-in. Run ≥2 real quests with `background-agent` forced.
+- **Phase 2 — flip.** Set allowlist to `auto` (bg-by-default with loud
+  fallback). This is the "replacement" in practice — before June 15.
+- **Phase 3 — post-soak review.** With `transport=` log data, decide whether the
+  bridge remains fallback-only or also keeps the CI/API role. (Spoiler: it keeps
+  the CI/API role — see below.)
+
+## Why not delete the bridge outright (the direct answer)
+
+Replace **as default**: yes, that is this spec. Delete the code: no, for four
+evidence-backed reasons:
+
+1. **Environments where bg cannot run exist and look healthy.** Fact 5 was
+   observed in this repo's own cloud sandbox: dispatch printed success while the
+   supervisor was dead. CI runners, containers, and locked-down sandboxes need a
+   transport that is a plain child process — that is the bridge. It is also the
+   *intended* Anthropic path there (API key / Agent-SDK credit for headless).
+2. **Research preview.** The surface is explicitly subject to change, `--bg` is
+   not yet in `--help`, and the binary auto-updated mid-session (fact 6).
+   Betting the *only* Claude transport on it violates the repo's own
+   change-discipline rules (AGENTS.md) and the prove-then-delete doctrine
+   (`ideas/2026-05-31-quest-model-capability-improvements.md`).
+3. **The three-tier ladder needs a Tier C.** Today, Codex-slot failures fall
+   back to Claude and vice versa; bg-transport failures need a same-family
+   fallback (bridge) before cross-family fallback, per
+   `ideas/2026-05-26-native-runtime-dispatch.md` (no silent family switches).
+4. **Deletion buys nothing.** The bridge is ~225 lines, dependency-free, and
+   tested. Removing it saves no maintenance and removes the only path that works
+   everywhere. KISS cuts both ways.
+
+Revisit deletion only after Phase 3 shows `transport=bridge` is exercised
+exclusively by CI/API contexts for a sustained period.
+
+## Out of scope
+
+- Per-role `effort` config and prompt-cache reordering (deferred; see
+  `ideas/2026-05-31-quest-model-capability-improvements.md`).
+- Structured-output (`--json-schema`) transport-owned artifacts (separate
+  measurement-gated track, same doc).
+- Claude-led dispatch (`Task(...)`) — unchanged by design.
+- Replying to `needs input` sessions programmatically (no sanctioned surface;
+  explicitly not attempted).
+- Per-role permission enforcement (tracked separately; this migration is
+  permission-neutral like the bridge).

--- a/scripts/claude_bg_run.py
+++ b/scripts/claude_bg_run.py
@@ -10,6 +10,15 @@ task's declared output FILES to appear (results never come from screen output),
 surface a `needs_human` bubble-back if the agent asks for a decision, then tear
 the session down — and return a small structured envelope.
 
+Bubble-back loop (orchestrator stops and asks the human):
+  1. Agent writes its question to the handoff file as {"status":"needs_human",...}
+     and ends its turn. The runner returns status=needs_human (+session_id) and
+     LEAVES THE SESSION ALIVE (no teardown), so it can be resumed.
+  2. The orchestrator asks the human, then calls this runner again in resume mode
+     (--resume <session_id> --answer "<reply>") to continue the SAME conversation.
+     If resume fails and an original --prompt is available, it falls back to a
+     fresh dispatch carrying the answer.
+
 It is also the "noise firewall": the orchestrator only ever sees the tiny
 envelope below, never the raw ANSI TUI buffer. `pty_capture()` demonstrates the
 same strip-to-signal behavior for the interactive (`attach`) responder path.
@@ -51,6 +60,7 @@ EXIT_BLOCKED = 4  # leaked interactive prompt (state=blocked)
 EXIT_TIMEOUT = 5
 EXIT_SESSION_FAILED = 6  # vanished / done-without-artifacts (incomplete)
 EXIT_NEEDS_HUMAN = 10  # actionable, not a failure: agent asked for a decision
+EXIT_INTERRUPTED = 130  # Ctrl-C: session torn down before exit
 
 _SHORTID_RE = re.compile(r"backgrounded\s*·\s*([0-9a-fA-F]+)")
 _BYPASS_REFUSAL_RE = re.compile(
@@ -146,6 +156,8 @@ class Envelope:
     short_id: str | None = None
     session_id: str | None = None
     name: str | None = None
+    resumed: bool = False
+    fell_back: bool = False
     wait_for: list[str] = field(default_factory=list)
     artifacts_found: list[str] = field(default_factory=list)
     missing: list[str] = field(default_factory=list)
@@ -165,6 +177,7 @@ class Envelope:
             "session_failed": EXIT_SESSION_FAILED,
             "incomplete": EXIT_SESSION_FAILED,
             "needs_human": EXIT_NEEDS_HUMAN,
+            "interrupted": EXIT_INTERRUPTED,
         }.get(self.status, EXIT_SESSION_FAILED)
 
 
@@ -191,11 +204,17 @@ class BgRunner:
         except (json.JSONDecodeError, ValueError):
             return []
 
-    def find_session(self, short_id: str | None, name: str) -> dict[str, Any] | None:
+    def find_session(
+        self, short_id: str | None, name: str, session_id: str | None = None
+    ) -> dict[str, Any] | None:
         for row in self.agents_json():
             if row.get("kind") == "interactive":
                 continue
-            if (short_id and row.get("id") == short_id) or row.get("name") == name:
+            if (
+                (short_id and row.get("id") == short_id)
+                or row.get("name") == name
+                or (session_id and row.get("sessionId") == session_id)
+            ):
                 return row
         return None
 
@@ -215,25 +234,46 @@ class BgRunner:
             except subprocess.SubprocessError:
                 pass
 
-    # -- prompt + dispatch ----------------------------------------------------
-    def build_prompt(self) -> str:
-        if self.a.prompt is not None:
-            prompt = self.a.prompt
-        elif self.a.prompt_file == "-" or (self.a.prompt_file is None and not sys.stdin.isatty()):
-            prompt = sys.stdin.read()
-        elif self.a.prompt_file:
-            prompt = Path(self.a.prompt_file).read_text(encoding="utf-8")
+    # -- message construction -------------------------------------------------
+    def _read_source(self, value: str | None, file_value: str | None, what: str) -> str:
+        if value is not None:
+            text = value
+        elif file_value == "-" or (file_value is None and not sys.stdin.isatty()):
+            text = sys.stdin.read()
+        elif file_value:
+            text = Path(file_value).read_text(encoding="utf-8")
         else:
-            raise ValueError("No prompt provided (use --prompt/--prompt-file or stdin).")
-        prompt = prompt.strip()
-        if not prompt:
-            raise ValueError("Prompt is empty.")
-        if self.a.wait_for and not self.a.no_protocol:
-            prompt += COMPLETION_PROTOCOL.format(files="\n".join(f"  {p}" for p in self.a.wait_for))
-        return prompt
+            raise ValueError(f"No {what} provided.")
+        text = text.strip()
+        if not text:
+            raise ValueError(f"{what} is empty.")
+        return text
 
-    def dispatch_argv(self, prompt: str) -> list[str]:
+    def _with_protocol(self, text: str) -> str:
+        if self.a.wait_for and not self.a.no_protocol:
+            files = "\n".join(f"  {p}" for p in self.a.wait_for)
+            return text + COMPLETION_PROTOCOL.format(files=files)
+        return text
+
+    def build_prompt(self) -> str:
+        return self._with_protocol(
+            self._read_source(self.a.prompt, self.a.prompt_file, "prompt (use --prompt/--prompt-file or stdin)")
+        )
+
+    def build_answer(self) -> str:
+        return self._with_protocol(
+            self._read_source(self.a.answer, self.a.answer_file, "answer (resume mode needs --answer/--answer-file)")
+        )
+
+    def _fallback_prompt(self, answer: str) -> str:
+        task = self._read_source(self.a.prompt, self.a.prompt_file, "prompt")
+        return f"{task}\n\nThe human answered your earlier question:\n{answer}\n"
+
+    # -- dispatch -------------------------------------------------------------
+    def dispatch_argv(self, message: str, resume_sid: str | None) -> list[str]:
         argv = [*self.claude, "--bg", "--name", self.a.name]
+        if resume_sid:
+            argv += ["--resume", resume_sid]
         if self.a.model:
             argv += ["--model", self.a.model]
         if self.a.effort:
@@ -243,8 +283,47 @@ class BgRunner:
             argv += ["--settings", json.dumps({"worktree": {"bgIsolation": "none"}})]
         for d in self.a.add_dir or []:
             argv += ["--add-dir", d]
-        argv.append(prompt)
+        argv.append(message)
         return argv
+
+    def dispatch_and_confirm(
+        self, message: str, resume_sid: str | None
+    ) -> tuple[str | None, str, str | None, dict[str, Any] | None]:
+        """Returns (terminal_status_or_None, message, short_id, session_row)."""
+        argv = self.dispatch_argv(message, resume_sid)
+        try:
+            cp = subprocess.run(argv, text=True, capture_output=True, timeout=60.0, check=False)
+        except FileNotFoundError:
+            return "precondition_failed", "claude CLI not found in PATH", None, None
+        except subprocess.SubprocessError as exc:
+            return "dispatch_failed", f"dispatch error: {exc}", None, None
+
+        out = cp.stdout + cp.stderr
+        if _BYPASS_REFUSAL_RE.search(out):
+            return (
+                "precondition_failed",
+                "bypassPermissions not accepted — run `claude --dangerously-skip-permissions` once interactively, then retry.",
+                None,
+                None,
+            )
+        m = _SHORTID_RE.search(out)
+        short_id = m.group(1) if m else None
+
+        deadline = time.monotonic() + self.a.confirm_timeout
+        row: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            row = self.find_session(short_id, self.a.name, resume_sid)
+            if row:
+                break
+            time.sleep(self.a.poll_interval)
+        if not row:
+            return (
+                "dispatch_failed",
+                "session never registered with the supervisor (printed: %r)" % out.strip()[:200],
+                short_id,
+                None,
+            )
+        return None, "", short_id or row.get("id"), row
 
     # -- file/handoff helpers -------------------------------------------------
     @staticmethod
@@ -265,52 +344,55 @@ class BgRunner:
     # -- the lifecycle --------------------------------------------------------
     def run(self) -> Envelope:
         t0 = time.monotonic()
+        env = Envelope(status="", name=self.a.name, wait_for=list(self.a.wait_for))
+        resume_mode = bool(self.a.resume)
+
         try:
-            prompt = self.build_prompt()
+            message = self.build_answer() if resume_mode else self.build_prompt()
         except (ValueError, OSError) as exc:
-            return Envelope(status="precondition_failed", message=str(exc))
-
-        argv = self.dispatch_argv(prompt)
-        try:
-            cp = subprocess.run(argv, text=True, capture_output=True, timeout=60.0, check=False)
-        except FileNotFoundError:
-            return Envelope(status="precondition_failed", message="claude CLI not found in PATH")
-        except subprocess.SubprocessError as exc:
-            return Envelope(status="dispatch_failed", message=f"dispatch error: {exc}")
-
-        out = cp.stdout + cp.stderr
-        if _BYPASS_REFUSAL_RE.search(out):
-            return Envelope(
-                status="precondition_failed",
-                name=self.a.name,
-                message="bypassPermissions not accepted — run `claude --dangerously-skip-permissions` once interactively, then retry.",
-            )
-        m = _SHORTID_RE.search(out)
-        short_id = m.group(1) if m else None
-
-        env = Envelope(status="", short_id=short_id, name=self.a.name, wait_for=list(self.a.wait_for))
-
-        # CONFIRM (cold-start + false-positive guard)
-        confirm_deadline = time.monotonic() + self.a.confirm_timeout
-        row: dict[str, Any] | None = None
-        while time.monotonic() < confirm_deadline:
-            row = self.find_session(short_id, self.a.name)
-            if row:
-                break
-            time.sleep(self.a.poll_interval)
-        if not row:
-            env.status = "dispatch_failed"
-            env.message = "session never registered with the supervisor (printed: %r)" % out.strip()[:200]
-            env.duration_s = round(time.monotonic() - t0, 1)
+            env.status, env.message = "precondition_failed", str(exc)
             return env
-        env.short_id = short_id or row.get("id")
-        env.session_id = row.get("sessionId")
+
+        # DISPATCH (+ resume / fallback)
+        if resume_mode:
+            env.resumed = True
+            status, msg, short_id, row = self.dispatch_and_confirm(message, self.a.resume)
+            have_task = self.a.prompt is not None or bool(self.a.prompt_file)
+            if status and self.a.fallback and have_task:
+                try:
+                    fb = self._fallback_prompt(message)
+                except (ValueError, OSError) as exc:
+                    env.status, env.message = "precondition_failed", str(exc)
+                    return env
+                env.resumed, env.fell_back = False, True
+                status2, msg2, short_id, row = self.dispatch_and_confirm(fb, None)
+                if status2:
+                    env.status = status2
+                    env.message = f"resume failed ({msg}); re-dispatch also failed ({msg2})"
+                    env.short_id = short_id
+                    env.duration_s = round(time.monotonic() - t0, 1)
+                    return env
+                env.message = f"resume failed ({msg}); re-dispatched fresh with the answer"
+            elif status:
+                env.status, env.message, env.short_id = status, msg, short_id
+                env.duration_s = round(time.monotonic() - t0, 1)
+                return env
+        else:
+            status, msg, short_id, row = self.dispatch_and_confirm(message, None)
+            if status:
+                env.status, env.message, env.short_id = status, msg, short_id
+                env.duration_s = round(time.monotonic() - t0, 1)
+                return env
+
+        env.short_id = short_id
+        env.session_id = (row or {}).get("sessionId")
 
         # WAIT
         deadline = time.monotonic() + self.a.timeout
         next_status = 0.0
         grace_left = 2
-        while True:
+        try:
+          while True:
             now = time.monotonic()
             if now > deadline:
                 if env.short_id:
@@ -337,7 +419,7 @@ class BgRunner:
 
             if now >= next_status:
                 next_status = now + self.a.status_interval
-                row = self.find_session(env.short_id, self.a.name)
+                row = self.find_session(env.short_id, self.a.name, env.session_id)
                 state = (row or {}).get("state") or (row or {}).get("status")
                 env.final_state = state
                 if row is None:
@@ -358,6 +440,9 @@ class BgRunner:
                         env.message = "session finished but declared output files are missing/empty"
                         break
             time.sleep(self.a.poll_interval)
+        except KeyboardInterrupt:
+            env.status = "interrupted"
+            env.message = "interrupted by user; tearing the session down"
 
         # COLLECT
         env.artifacts_found = [p for p in self.a.wait_for if self._nonempty(p)]
@@ -365,20 +450,27 @@ class BgRunner:
         if env.status != "ok" and env.short_id:
             env.logs_tail = self.logs_tail(env.short_id)
 
-        # TEARDOWN (only after collect; never rm before artifacts confirmed)
-        if env.short_id:
+        # TEARDOWN — but PRESERVE a needs_human session so it can be resumed.
+        if env.short_id and env.status != "needs_human":
             self.teardown(env.short_id)
         env.duration_s = round(time.monotonic() - t0, 1)
         if not env.message and env.status == "ok":
             env.message = "completed; declared artifacts present"
+        if env.status == "needs_human" and not env.message:
+            env.message = "agent needs a human decision; session left alive — answer via --resume <session_id> --answer"
         return env
 
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Run one Claude background-agent task to a file-based result.")
     src = p.add_mutually_exclusive_group()
-    src.add_argument("--prompt")
+    src.add_argument("--prompt", help="task prompt (also the fallback task in resume mode)")
     src.add_argument("--prompt-file", help="path or '-' for stdin")
+    p.add_argument("--resume", help="resume an existing session: continue this session_id")
+    p.add_argument("--answer", help="resume mode: the human's reply to send back")
+    p.add_argument("--answer-file", help="resume mode: read the reply from a file ('-' for stdin)")
+    p.add_argument("--no-fallback", dest="fallback", action="store_false", help="resume mode: do not fall back to a fresh re-dispatch if resume fails")
+    p.set_defaults(fallback=True)
     p.add_argument("--wait-for", action="append", default=[], help="output file(s) that must exist & be non-empty (repeatable)")
     p.add_argument("--handoff-file", help="optional JSON the agent writes; status needs_human bubbles back")
     p.add_argument("--model", default="")

--- a/scripts/claude_bg_run.py
+++ b/scripts/claude_bg_run.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""claude_bg_run — standalone runner for one Claude background-agent task.
+
+PROOF OF CONCEPT (Step 1 of docs/implementation/claude-bg-run-script.md).
+
+Quest-agnostic on purpose: this knows nothing about quest phases, handoff
+schemas, or orchestration.json. It does exactly one thing — dispatch a single
+`claude --bg` task, confirm it registered with the supervisor, wait for the
+task's declared output FILES to appear (results never come from screen output),
+surface a `needs_human` bubble-back if the agent asks for a decision, then tear
+the session down — and return a small structured envelope.
+
+It is also the "noise firewall": the orchestrator only ever sees the tiny
+envelope below, never the raw ANSI TUI buffer. `pty_capture()` demonstrates the
+same strip-to-signal behavior for the interactive (`attach`) responder path.
+
+Transport facts this encodes (validated against Claude Code 2.1.170):
+  * `claude --bg` prints `backgrounded · <id>[ · <name>]` and may exit 0 even on
+    the bypass-acceptance refusal, so success requires parsing the id AND
+    confirming via `claude agents --json` — not the exit code.
+  * `claude agents --json` reports per-session `state` (working/done/blocked) and
+    `status` (busy/idle); completion and blocking are read from there.
+  * `claude logs` is a raw TUI buffer; we strip it to a few signal lines only.
+
+Run the built-in firewall demo (no `claude` needed):
+    python3 scripts/claude_bg_run.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pty
+import re
+import select
+import shlex
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+# ---- exit codes (distinct so a shell/orchestrator can route without parsing) -
+EXIT_OK = 0
+EXIT_PRECONDITION = 2  # CLI/auth/bypass-acceptance missing
+EXIT_DISPATCH_FAILED = 3  # never registered with the supervisor
+EXIT_BLOCKED = 4  # leaked interactive prompt (state=blocked)
+EXIT_TIMEOUT = 5
+EXIT_SESSION_FAILED = 6  # vanished / done-without-artifacts (incomplete)
+EXIT_NEEDS_HUMAN = 10  # actionable, not a failure: agent asked for a decision
+
+_SHORTID_RE = re.compile(r"backgrounded\s*·\s*([0-9a-fA-F]+)")
+_BYPASS_REFUSAL_RE = re.compile(
+    r"bypass[- ]?permissions.*requires accepting|dangerously-skip-permissions",
+    re.IGNORECASE,
+)
+# CSI / OSC / single-char escapes — covers the TUI redraw soup from `claude logs`.
+_ANSI_RE = re.compile(
+    r"\x1b\[[0-9;?]*[ -/]*[@-~]"  # CSI
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC
+    r"|\x1b[@-Z\\-_]"  # 2-char escapes
+)
+_CTRL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+COMPLETION_PROTOCOL = (
+    "\n\nWhen you have finished you MUST write your output to the file(s):\n"
+    "{files}\n"
+    "Write files directly with the Write tool. Do not ask the user questions; "
+    "if details are missing, make explicit assumptions and proceed. If you "
+    "genuinely cannot proceed without a human decision, write your question to "
+    "the handoff file instead of pausing.\n"
+)
+
+
+def strip_ansi(text: str) -> str:
+    """Reduce raw terminal output to plain, signal-only text."""
+    text = _ANSI_RE.sub("", text)
+    text = _CTRL_RE.sub("", text)
+    return text
+
+
+def distill(text: str, max_lines: int = 12) -> str:
+    """Strip ANSI then keep the last few non-empty lines (the live signal)."""
+    lines = [ln.strip() for ln in strip_ansi(text).splitlines()]
+    lines = [ln for ln in lines if ln]
+    return "\n".join(lines[-max_lines:])
+
+
+def pty_capture(
+    argv: list[str],
+    *,
+    total_timeout: float = 30.0,
+    idle_timeout: float = 3.0,
+) -> tuple[int, str]:
+    """Run `argv` under a headless PTY, consume the stream, return clean text.
+
+    This is the noise-firewall primitive: the child believes it has a terminal
+    (so it runs its full TUI), but we read the master side, throw the raw redraw
+    stream away, and return only ANSI-stripped text. Used for the `attach`/`logs`
+    responder path so TUI noise never reaches the orchestrator's context.
+    """
+    pid, fd = pty.fork()
+    if pid == 0:  # child
+        try:
+            os.execvp(argv[0], argv)
+        except OSError:
+            os._exit(127)
+    chunks: list[bytes] = []
+    deadline = time.monotonic() + total_timeout
+    last = time.monotonic()
+    while True:
+        if time.monotonic() > deadline:
+            break
+        r, _, _ = select.select([fd], [], [], 0.2)
+        if r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+            last = time.monotonic()
+        elif time.monotonic() - last > idle_timeout:
+            break
+    status = 0
+    try:
+        _, status = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        pass
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    raw = b"".join(chunks).decode("utf-8", errors="replace")
+    return (os.WEXITSTATUS(status) if status else 0), strip_ansi(raw)
+
+
+@dataclass
+class Envelope:
+    status: str
+    short_id: str | None = None
+    session_id: str | None = None
+    name: str | None = None
+    wait_for: list[str] = field(default_factory=list)
+    artifacts_found: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    questions: list[str] = field(default_factory=list)
+    final_state: str | None = None
+    duration_s: float = 0.0
+    logs_tail: str = ""
+    message: str = ""
+
+    def exit_code(self) -> int:
+        return {
+            "ok": EXIT_OK,
+            "precondition_failed": EXIT_PRECONDITION,
+            "dispatch_failed": EXIT_DISPATCH_FAILED,
+            "blocked": EXIT_BLOCKED,
+            "timeout": EXIT_TIMEOUT,
+            "session_failed": EXIT_SESSION_FAILED,
+            "incomplete": EXIT_SESSION_FAILED,
+            "needs_human": EXIT_NEEDS_HUMAN,
+        }.get(self.status, EXIT_SESSION_FAILED)
+
+
+class BgRunner:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.a = args
+        self.claude = shlex.split(args.claude_bin)
+
+    # -- thin claude subcommand wrappers (all clean, structured) --------------
+    def _claude(self, *sub: str, timeout: float = 30.0) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [*self.claude, *sub],
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def agents_json(self) -> list[dict[str, Any]]:
+        cp = self._claude("agents", "--json")
+        try:
+            data = json.loads(cp.stdout)
+            return data if isinstance(data, list) else []
+        except (json.JSONDecodeError, ValueError):
+            return []
+
+    def find_session(self, short_id: str | None, name: str) -> dict[str, Any] | None:
+        for row in self.agents_json():
+            if row.get("kind") == "interactive":
+                continue
+            if (short_id and row.get("id") == short_id) or row.get("name") == name:
+                return row
+        return None
+
+    def logs_tail(self, short_id: str) -> str:
+        try:
+            cp = self._claude("logs", short_id, timeout=15.0)
+        except subprocess.SubprocessError:
+            return ""
+        return distill(cp.stdout + cp.stderr)
+
+    def teardown(self, short_id: str) -> None:
+        if self.a.keep:
+            return
+        for verb in ("stop", "rm"):
+            try:
+                self._claude(verb, short_id, timeout=20.0)
+            except subprocess.SubprocessError:
+                pass
+
+    # -- prompt + dispatch ----------------------------------------------------
+    def build_prompt(self) -> str:
+        if self.a.prompt is not None:
+            prompt = self.a.prompt
+        elif self.a.prompt_file == "-" or (self.a.prompt_file is None and not sys.stdin.isatty()):
+            prompt = sys.stdin.read()
+        elif self.a.prompt_file:
+            prompt = Path(self.a.prompt_file).read_text(encoding="utf-8")
+        else:
+            raise ValueError("No prompt provided (use --prompt/--prompt-file or stdin).")
+        prompt = prompt.strip()
+        if not prompt:
+            raise ValueError("Prompt is empty.")
+        if self.a.wait_for and not self.a.no_protocol:
+            prompt += COMPLETION_PROTOCOL.format(files="\n".join(f"  {p}" for p in self.a.wait_for))
+        return prompt
+
+    def dispatch_argv(self, prompt: str) -> list[str]:
+        argv = [*self.claude, "--bg", "--name", self.a.name]
+        if self.a.model:
+            argv += ["--model", self.a.model]
+        if self.a.effort:
+            argv += ["--effort", self.a.effort]
+        argv += ["--permission-mode", self.a.permission_mode]
+        if self.a.bg_isolation == "none":
+            argv += ["--settings", json.dumps({"worktree": {"bgIsolation": "none"}})]
+        for d in self.a.add_dir or []:
+            argv += ["--add-dir", d]
+        argv.append(prompt)
+        return argv
+
+    # -- file/handoff helpers -------------------------------------------------
+    @staticmethod
+    def _nonempty(path: str) -> bool:
+        try:
+            return Path(path).stat().st_size > 0
+        except OSError:
+            return False
+
+    def read_handoff(self) -> dict[str, Any] | None:
+        if not self.a.handoff_file or not self._nonempty(self.a.handoff_file):
+            return None
+        try:
+            return json.loads(Path(self.a.handoff_file).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    # -- the lifecycle --------------------------------------------------------
+    def run(self) -> Envelope:
+        t0 = time.monotonic()
+        try:
+            prompt = self.build_prompt()
+        except (ValueError, OSError) as exc:
+            return Envelope(status="precondition_failed", message=str(exc))
+
+        argv = self.dispatch_argv(prompt)
+        try:
+            cp = subprocess.run(argv, text=True, capture_output=True, timeout=60.0, check=False)
+        except FileNotFoundError:
+            return Envelope(status="precondition_failed", message="claude CLI not found in PATH")
+        except subprocess.SubprocessError as exc:
+            return Envelope(status="dispatch_failed", message=f"dispatch error: {exc}")
+
+        out = cp.stdout + cp.stderr
+        if _BYPASS_REFUSAL_RE.search(out):
+            return Envelope(
+                status="precondition_failed",
+                name=self.a.name,
+                message="bypassPermissions not accepted — run `claude --dangerously-skip-permissions` once interactively, then retry.",
+            )
+        m = _SHORTID_RE.search(out)
+        short_id = m.group(1) if m else None
+
+        env = Envelope(status="", short_id=short_id, name=self.a.name, wait_for=list(self.a.wait_for))
+
+        # CONFIRM (cold-start + false-positive guard)
+        confirm_deadline = time.monotonic() + self.a.confirm_timeout
+        row: dict[str, Any] | None = None
+        while time.monotonic() < confirm_deadline:
+            row = self.find_session(short_id, self.a.name)
+            if row:
+                break
+            time.sleep(self.a.poll_interval)
+        if not row:
+            env.status = "dispatch_failed"
+            env.message = "session never registered with the supervisor (printed: %r)" % out.strip()[:200]
+            env.duration_s = round(time.monotonic() - t0, 1)
+            return env
+        env.short_id = short_id or row.get("id")
+        env.session_id = row.get("sessionId")
+
+        # WAIT
+        deadline = time.monotonic() + self.a.timeout
+        next_status = 0.0
+        grace_left = 2
+        while True:
+            now = time.monotonic()
+            if now > deadline:
+                if env.short_id:
+                    try:
+                        self._claude("stop", env.short_id, timeout=15.0)
+                    except subprocess.SubprocessError:
+                        pass
+                env.status, env.final_state = "timeout", env.final_state or "working"
+                break
+
+            hf = self.read_handoff()
+            if hf and hf.get("status") == "needs_human":
+                qs = hf.get("questions") or ([hf["question"]] if hf.get("question") else [])
+                env.status, env.questions = "needs_human", [str(q) for q in qs]
+                break
+
+            if self.a.wait_for:
+                if all(self._nonempty(p) for p in self.a.wait_for):
+                    env.status = "ok"
+                    break
+            elif hf and hf.get("status") == "complete":
+                env.status = "ok"
+                break
+
+            if now >= next_status:
+                next_status = now + self.a.status_interval
+                row = self.find_session(env.short_id, self.a.name)
+                state = (row or {}).get("state") or (row or {}).get("status")
+                env.final_state = state
+                if row is None:
+                    env.status = "session_failed"
+                    env.message = "session disappeared from `claude agents` before completing"
+                    break
+                if state == "blocked":
+                    env.status = "blocked"
+                    env.message = "session is blocked on an interactive prompt (a permission hook likely did not cover it)"
+                    break
+                if state in ("done", "idle"):
+                    if not self.a.wait_for and not self.a.handoff_file:
+                        env.status = "ok"  # --no-wait: completion == reached done
+                        break
+                    grace_left -= 1
+                    if grace_left <= 0:
+                        env.status = "incomplete"
+                        env.message = "session finished but declared output files are missing/empty"
+                        break
+            time.sleep(self.a.poll_interval)
+
+        # COLLECT
+        env.artifacts_found = [p for p in self.a.wait_for if self._nonempty(p)]
+        env.missing = [p for p in self.a.wait_for if not self._nonempty(p)]
+        if env.status != "ok" and env.short_id:
+            env.logs_tail = self.logs_tail(env.short_id)
+
+        # TEARDOWN (only after collect; never rm before artifacts confirmed)
+        if env.short_id:
+            self.teardown(env.short_id)
+        env.duration_s = round(time.monotonic() - t0, 1)
+        if not env.message and env.status == "ok":
+            env.message = "completed; declared artifacts present"
+        return env
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Run one Claude background-agent task to a file-based result.")
+    src = p.add_mutually_exclusive_group()
+    src.add_argument("--prompt")
+    src.add_argument("--prompt-file", help="path or '-' for stdin")
+    p.add_argument("--wait-for", action="append", default=[], help="output file(s) that must exist & be non-empty (repeatable)")
+    p.add_argument("--handoff-file", help="optional JSON the agent writes; status needs_human bubbles back")
+    p.add_argument("--model", default="")
+    p.add_argument("--effort", default="", choices=["", "low", "medium", "high", "xhigh", "max"])
+    p.add_argument("--permission-mode", default="bypassPermissions")
+    p.add_argument("--add-dir", action="append", default=[])
+    p.add_argument("--name", default=f"bgrun-{uuid.uuid4().hex[:8]}")
+    p.add_argument("--bg-isolation", default="none", choices=["none", "inherit"])
+    p.add_argument("--timeout", type=float, default=1800.0)
+    p.add_argument("--confirm-timeout", type=float, default=20.0)
+    p.add_argument("--poll-interval", type=float, default=2.0)
+    p.add_argument("--status-interval", type=float, default=10.0)
+    p.add_argument("--keep", action="store_true", help="skip teardown (debugging)")
+    p.add_argument("--no-protocol", action="store_true", help="do not append the completion-protocol block")
+    p.add_argument("--json", action="store_true", help="emit the result envelope as JSON")
+    p.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    p.add_argument("--self-test", action="store_true", help="run the PTY noise-firewall demo and exit")
+    return p
+
+
+def _self_test() -> int:
+    """Prove the headless-PTY firewall: spawn a child that emits ANSI, get clean text."""
+    noisy = "printf '\\033[2J\\033[H\\033[31mHELLO\\033[0m \\033[1mclean\\033[0m\\n'"
+    code, text = pty_capture(["sh", "-c", noisy], total_timeout=5.0, idle_timeout=1.0)
+    print(f"pty exit={code}")
+    print(f"distilled signal: {text.strip()!r}")
+    ok = "HELLO clean" in text and "\x1b" not in text
+    print("PASS" if ok else "FAIL")
+    return EXIT_OK if ok else EXIT_SESSION_FAILED
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    env = BgRunner(args).run()
+    if args.json:
+        print(json.dumps(asdict(env), indent=2))
+    else:
+        print(f"[{env.status}] {env.name} ({env.short_id}) — {env.message}")
+        if env.questions:
+            print("questions:")
+            for q in env.questions:
+                print(f"  - {q}")
+        if env.logs_tail:
+            print("--- logs (distilled) ---")
+            print(env.logs_tail)
+    return env.exit_code()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/claude_bg_run.py
+++ b/scripts/claude_bg_run.py
@@ -15,21 +15,37 @@ Bubble-back loop (orchestrator stops and asks the human):
      and ends its turn. The runner returns status=needs_human (+session_id) and
      LEAVES THE SESSION ALIVE (no teardown), so it can be resumed.
   2. The orchestrator asks the human, then calls this runner again in resume mode
-     (--resume <session_id> --answer "<reply>") to continue the SAME conversation.
-     If resume fails and an original --prompt is available, it falls back to a
-     fresh dispatch carrying the answer.
+     (--resume <ref> --answer "<reply>") to continue the SAME conversation.
+     <ref> may be the session_id, the agent's short id, or its NAME — names are
+     resolved live via `claude agents --json`, so a session renamed in the agent
+     view stays resumable. If resume fails and an original --prompt is available,
+     it falls back to a fresh dispatch carrying the answer.
+  3. Resuming spawns a NEW background agent (new short id, NEW session id) that
+     continues the conversation; the parked parent agent stays alive and would be
+     orphaned, so after the new agent is confirmed the runner retires the parent.
+     The envelope reports the NEW session_id (chain further resumes off that) and
+     `resumed_from` (the session id that was continued).
 
 It is also the "noise firewall": the orchestrator only ever sees the tiny
 envelope below, never the raw ANSI TUI buffer. `pty_capture()` demonstrates the
 same strip-to-signal behavior for the interactive (`attach`) responder path.
 
-Transport facts this encodes (validated against Claude Code 2.1.170):
+Transport facts this encodes (validated against Claude Code 2.1.170+):
   * `claude --bg` prints `backgrounded · <id>[ · <name>]` and may exit 0 even on
     the bypass-acceptance refusal, so success requires parsing the id AND
     confirming via `claude agents --json` — not the exit code.
   * `claude agents --json` reports per-session `state` (working/done/blocked) and
-    `status` (busy/idle); completion and blocking are read from there.
-  * `claude logs` is a raw TUI buffer; we strip it to a few signal lines only.
+    `status` (busy/idle); completion and blocking are read from there. A parked
+    (idle, awaiting-input) session ALSO reads `state==blocked`, so resume-mode
+    polling must never match the parked parent's row (id/name take precedence
+    over sessionId).
+  * There are NO `claude logs|stop|rm` subcommands — those argv parse as a
+    PROMPT and silently do nothing. Teardown = signal the `pid` carried in the
+    session's `agents --json` row, repeating against the row's CURRENT pid until
+    it settles (the daemon respawns a parked session once from its spare pool).
+    Logs come from the transcript at ~/.claude/projects/<project>/<sessionId>.jsonl.
+  * `claude --bg --resume <sid>` FORKS: the new agent continues the conversation
+    under a NEW sessionId (daemon roster: launch.mode=resume, fork=true).
 
 Run the built-in firewall demo (no `claude` needed):
     python3 scripts/claude_bg_run.py --self-test
@@ -44,6 +60,7 @@ import pty
 import re
 import select
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -63,6 +80,7 @@ EXIT_NEEDS_HUMAN = 10  # actionable, not a failure: agent asked for a decision
 EXIT_INTERRUPTED = 130  # Ctrl-C: session torn down before exit
 
 _SHORTID_RE = re.compile(r"backgrounded\s*·\s*([0-9a-fA-F]+)")
+_SESSION_ID_RE = re.compile(r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}|[0-9a-fA-F]{32}")
 _BYPASS_REFUSAL_RE = re.compile(
     r"bypass[- ]?permissions.*requires accepting|dangerously-skip-permissions",
     re.IGNORECASE,
@@ -157,6 +175,7 @@ class Envelope:
     session_id: str | None = None
     name: str | None = None
     resumed: bool = False
+    resumed_from: str | None = None
     fell_back: bool = False
     wait_for: list[str] = field(default_factory=list)
     artifacts_found: list[str] = field(default_factory=list)
@@ -205,34 +224,98 @@ class BgRunner:
             return []
 
     def find_session(
-        self, short_id: str | None, name: str, session_id: str | None = None
+        self,
+        short_id: str | None = None,
+        name: str | None = None,
+        session_id: str | None = None,
     ) -> dict[str, Any] | None:
-        for row in self.agents_json():
-            if row.get("kind") == "interactive":
+        """Match a background row by short id, then name, then sessionId.
+
+        STRICT PRECEDENCE, not OR-in-row-order: when resuming, the parked parent
+        session matches `sessionId` and appears earlier in the list than the new
+        agent — an unordered match returns the parent (whose state is `blocked`
+        merely because it is idle awaiting input) and misreports the run.
+        """
+        rows = [r for r in self.agents_json() if r.get("kind") != "interactive"]
+        for key, want in (("id", short_id), ("name", name), ("sessionId", session_id)):
+            if not want:
                 continue
-            if (
-                (short_id and row.get("id") == short_id)
-                or row.get("name") == name
-                or (session_id and row.get("sessionId") == session_id)
-            ):
-                return row
+            for row in rows:
+                if row.get(key) == want:
+                    return row
         return None
 
-    def logs_tail(self, short_id: str) -> str:
-        try:
-            cp = self._claude("logs", short_id, timeout=15.0)
-        except subprocess.SubprocessError:
-            return ""
-        return distill(cp.stdout + cp.stderr)
+    def resolve_resume_target(self, ref: str) -> tuple[str | None, str | None]:
+        """Resolve --resume <ref> to (session_id, parent_short_id).
 
-    def teardown(self, short_id: str) -> None:
+        <ref> may be a session id, an agent short id, or an agent NAME (incl. one
+        renamed in the agent view) — resolved live against `claude agents --json`.
+        A session-id-shaped ref with no live row is passed through as-is (the
+        transcript may still be resumable); anything else unresolved is an error.
+        """
+        row = self.find_session(short_id=ref, name=ref, session_id=ref)
+        if row and row.get("sessionId"):
+            return row["sessionId"], row.get("id")
+        if _SESSION_ID_RE.fullmatch(ref):
+            return ref, None
+        return None, None
+
+    def logs_tail(self, session_id: str | None) -> str:
+        """Tail of the session transcript (~/.claude/projects/*/<sid>.jsonl).
+
+        There is no `claude logs` subcommand; the transcript JSONL is the log.
+        Returns the last few assistant-text lines, distilled.
+        """
+        if not session_id:
+            return ""
+        root = Path(self.a.transcripts_root).expanduser()
+        matches = list(root.glob(f"*/{session_id}.jsonl")) or list(root.glob(f"{session_id}.jsonl"))
+        if not matches:
+            return ""
+        texts: list[str] = []
+        try:
+            for line in matches[0].read_text(encoding="utf-8").splitlines():
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != "assistant":
+                    continue
+                for block in obj.get("message", {}).get("content", []) or []:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        texts.append(block.get("text", ""))
+        except OSError:
+            return ""
+        return distill("\n".join(texts[-4:]))
+
+    def stop_session(self, short_id: str | None) -> None:
+        """Stop a background agent by signalling its supervisor-reported pid.
+
+        `claude stop|rm` do not exist as subcommands (they parse as a prompt and
+        no-op). The daemon may RESPAWN a parked session once from its spare pool
+        after a kill (the row keeps its id but shows a fresh pid), so keep
+        signalling the row's *current* pid until the row settles — drops its pid
+        ("settled (killed)" in the daemon log) or leaves the listing. Settled
+        rows may linger pid-less in `agents --json`; that is retired enough.
+        """
+        if not short_id:
+            return
+        for attempt in range(6):
+            row = self.find_session(short_id=short_id)
+            pid = (row or {}).get("pid")
+            if not isinstance(pid, int):
+                return  # gone, or settled with no live process
+            sig = signal.SIGTERM if attempt < 2 else signal.SIGKILL
+            try:
+                os.kill(pid, sig)
+            except (ProcessLookupError, PermissionError):
+                pass
+            time.sleep(self.a.poll_interval)
+
+    def teardown(self, short_id: str | None) -> None:
         if self.a.keep:
             return
-        for verb in ("stop", "rm"):
-            try:
-                self._claude(verb, short_id, timeout=20.0)
-            except subprocess.SubprocessError:
-                pass
+        self.stop_session(short_id)
 
     # -- message construction -------------------------------------------------
     def _read_source(self, value: str | None, file_value: str | None, what: str) -> str:
@@ -312,7 +395,10 @@ class BgRunner:
         deadline = time.monotonic() + self.a.confirm_timeout
         row: dict[str, Any] | None = None
         while time.monotonic() < deadline:
-            row = self.find_session(short_id, self.a.name, resume_sid)
+            # Confirm by short id / name ONLY: in resume mode the parked parent's
+            # row matches `sessionId == resume_sid` and would falsely confirm a
+            # dispatch that never registered.
+            row = self.find_session(short_id, self.a.name)
             if row:
                 break
             time.sleep(self.a.poll_interval)
@@ -354,9 +440,19 @@ class BgRunner:
             return env
 
         # DISPATCH (+ resume / fallback)
+        parent_short_id: str | None = None
         if resume_mode:
+            resume_sid, parent_short_id = self.resolve_resume_target(self.a.resume)
+            if not resume_sid:
+                env.status = "precondition_failed"
+                env.message = (
+                    f"--resume target {self.a.resume!r} matches no live agent "
+                    "(by session id, short id, or name) and is not session-id-shaped"
+                )
+                return env
             env.resumed = True
-            status, msg, short_id, row = self.dispatch_and_confirm(message, self.a.resume)
+            env.resumed_from = resume_sid
+            status, msg, short_id, row = self.dispatch_and_confirm(message, resume_sid)
             have_task = self.a.prompt is not None or bool(self.a.prompt_file)
             if status and self.a.fallback and have_task:
                 try:
@@ -387,6 +483,11 @@ class BgRunner:
         env.short_id = short_id
         env.session_id = (row or {}).get("sessionId")
 
+        # The conversation has moved on (resumed into a new agent, or re-dispatched
+        # fresh); retire the parked parent so it is not orphaned. Respects --keep.
+        if parent_short_id and parent_short_id != short_id:
+            self.teardown(parent_short_id)
+
         # WAIT
         deadline = time.monotonic() + self.a.timeout
         next_status = 0.0
@@ -395,13 +496,8 @@ class BgRunner:
           while True:
             now = time.monotonic()
             if now > deadline:
-                if env.short_id:
-                    try:
-                        self._claude("stop", env.short_id, timeout=15.0)
-                    except subprocess.SubprocessError:
-                        pass
                 env.status, env.final_state = "timeout", env.final_state or "working"
-                break
+                break  # final teardown below stops the session
 
             hf = self.read_handoff()
             if hf and hf.get("status") == "needs_human":
@@ -419,7 +515,7 @@ class BgRunner:
 
             if now >= next_status:
                 next_status = now + self.a.status_interval
-                row = self.find_session(env.short_id, self.a.name, env.session_id)
+                row = self.find_session(env.short_id, self.a.name)
                 state = (row or {}).get("state") or (row or {}).get("status")
                 env.final_state = state
                 if row is None:
@@ -428,7 +524,10 @@ class BgRunner:
                     break
                 if state == "blocked":
                     env.status = "blocked"
-                    env.message = "session is blocked on an interactive prompt (a permission hook likely did not cover it)"
+                    detail = row.get("waitingFor")
+                    env.message = "session is blocked on an interactive prompt " + (
+                        f"({detail})" if detail else "(a permission hook likely did not cover it)"
+                    )
                     break
                 if state in ("done", "idle"):
                     if not self.a.wait_for and not self.a.handoff_file:
@@ -447,8 +546,8 @@ class BgRunner:
         # COLLECT
         env.artifacts_found = [p for p in self.a.wait_for if self._nonempty(p)]
         env.missing = [p for p in self.a.wait_for if not self._nonempty(p)]
-        if env.status != "ok" and env.short_id:
-            env.logs_tail = self.logs_tail(env.short_id)
+        if env.status != "ok":
+            env.logs_tail = self.logs_tail(env.session_id)
 
         # TEARDOWN — but PRESERVE a needs_human session so it can be resumed.
         if env.short_id and env.status != "needs_human":
@@ -457,7 +556,7 @@ class BgRunner:
         if not env.message and env.status == "ok":
             env.message = "completed; declared artifacts present"
         if env.status == "needs_human" and not env.message:
-            env.message = "agent needs a human decision; session left alive — answer via --resume <session_id> --answer"
+            env.message = "agent needs a human decision; session left alive — answer via --resume <session_id|short_id|name> --answer"
         return env
 
 
@@ -466,7 +565,7 @@ def build_parser() -> argparse.ArgumentParser:
     src = p.add_mutually_exclusive_group()
     src.add_argument("--prompt", help="task prompt (also the fallback task in resume mode)")
     src.add_argument("--prompt-file", help="path or '-' for stdin")
-    p.add_argument("--resume", help="resume an existing session: continue this session_id")
+    p.add_argument("--resume", help="resume an existing session: session id, agent short id, or agent name (rename-safe)")
     p.add_argument("--answer", help="resume mode: the human's reply to send back")
     p.add_argument("--answer-file", help="resume mode: read the reply from a file ('-' for stdin)")
     p.add_argument("--no-fallback", dest="fallback", action="store_false", help="resume mode: do not fall back to a fresh re-dispatch if resume fails")
@@ -487,6 +586,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--no-protocol", action="store_true", help="do not append the completion-protocol block")
     p.add_argument("--json", action="store_true", help="emit the result envelope as JSON")
     p.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    p.add_argument(
+        "--transcripts-root",
+        default="~/.claude/projects",
+        help="where session transcript JSONLs live (logs_tail source)",
+    )
     p.add_argument("--self-test", action="store_true", help="run the PTY noise-firewall demo and exit")
     return p
 

--- a/tests/unit/test_claude_bg_run.py
+++ b/tests/unit/test_claude_bg_run.py
@@ -1,0 +1,190 @@
+"""Unit tests for the standalone claude --bg runner proof of concept.
+
+These exercise the full dispatch -> confirm -> wait -> collect -> teardown
+lifecycle against a fake `claude` shim (no real model calls, no bypass-acceptance
+needed), plus the ANSI/PTY noise-firewall primitive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import claude_bg_run as bg
+
+# A fake `claude` CLI. Behavior is driven by FAKE_BG_* env vars so each test can
+# script a scenario. It emulates: `--bg`, `agents --json`, `logs`, `stop`, `rm`.
+FAKE_CLAUDE = r'''#!/usr/bin/env python3
+import os, sys, json, pathlib
+D = pathlib.Path(os.environ["FAKE_BG_DIR"])
+S = os.environ.get("FAKE_BG_SCENARIO", "ok")
+WAIT = os.environ.get("FAKE_BG_WAITFOR", "")
+HAND = os.environ.get("FAKE_BG_HANDOFF", "")
+state = D / "state.json"
+calls = D / "calls.log"
+
+def log(line): calls.open("a").write(line + "\n")
+def read_state():
+    try: return json.loads(state.read_text())
+    except Exception: return None
+
+args = sys.argv[1:]
+if args[:1] == ["--bg"]:
+    name = args[args.index("--name") + 1] if "--name" in args else "?"
+    log("bg " + name)
+    if S == "bypass_refused":
+        print("--bg with bypassPermissions requires accepting the disclaimer first. "
+              "Run `claude --dangerously-skip-permissions` once interactively.")
+        sys.exit(0)
+    sid = "abc12345"
+    if S != "never_confirm":
+        st = {"blocked": "blocked", "incomplete": "done"}.get(S, "working")
+        state.write_text(json.dumps(
+            {"id": sid, "name": name, "sessionId": sid + "-uuid",
+             "kind": "background", "state": st, "status": "idle"}))
+    if S == "ok" and WAIT:
+        pathlib.Path(WAIT).write_text("RESULT")
+    if S == "needs_human" and HAND:
+        pathlib.Path(HAND).write_text(json.dumps(
+            {"status": "needs_human", "questions": ["A or B?"]}))
+    print(f"backgrounded · {sid} · {name}")
+    sys.exit(0)
+if args[:2] == ["agents", "--json"]:
+    s = read_state()
+    print(json.dumps([s] if s else []))
+    sys.exit(0)
+if args[:1] == ["logs"]:
+    print("\x1b[2J\x1b[H\x1b[31mneeds input: choose A or B?\x1b[0m\r\n")
+    sys.exit(0)
+if args and args[0] in ("stop", "rm"):
+    log(f"{args[0]} {args[1] if len(args) > 1 else ''}")
+    if args[0] == "rm" and state.exists(): state.unlink()
+    sys.exit(0)
+sys.exit(0)
+'''
+
+
+@pytest.fixture
+def shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    p = tmp_path / "fake_claude.py"
+    p.write_text(FAKE_CLAUDE, encoding="utf-8")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("FAKE_BG_DIR", str(tmp_path))
+    return p
+
+
+def _args(shim: Path, tmp_path: Path, **over):
+    argv = [
+        "--claude-bin", f"{shim}",
+        "--prompt", "do the thing",
+        "--confirm-timeout", "1",
+        "--poll-interval", "0.05",
+        "--status-interval", "0",
+        "--timeout", "2",
+    ]
+    for k, v in over.items():
+        flag = "--" + k.replace("_", "-")
+        if v is True:
+            argv.append(flag)
+        else:
+            argv += [flag, str(v)]
+    return bg.build_parser().parse_args(argv)
+
+
+# ---- pure helpers ----------------------------------------------------------
+def test_strip_ansi_removes_escapes():
+    raw = "\x1b[2J\x1b[31mHELLO\x1b[0m world\r\n"
+    assert bg.strip_ansi(raw).strip() == "HELLO world"
+
+
+def test_shortid_parses_with_and_without_name_and_idle_suffix():
+    assert bg._SHORTID_RE.search("backgrounded · 7c5dcf5d · my-name").group(1) == "7c5dcf5d"
+    assert bg._SHORTID_RE.search("backgrounded · e590de4c (idle — send a prompt to start)").group(1) == "e590de4c"
+
+
+def test_bypass_refusal_regex():
+    assert bg._BYPASS_REFUSAL_RE.search("requires accepting the disclaimer; run claude --dangerously-skip-permissions")
+
+
+def test_pty_capture_strips_noise_to_signal():
+    code, text = bg.pty_capture(
+        ["sh", "-c", "printf '\\033[2J\\033[31mHELLO\\033[0m clean\\n'"],
+        total_timeout=5.0, idle_timeout=1.0,
+    )
+    assert "HELLO clean" in text
+    assert "\x1b" not in text
+
+
+# ---- lifecycle scenarios ---------------------------------------------------
+def test_ok_completes_on_artifact_and_tears_down(shim, tmp_path, monkeypatch):
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "ok")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(wait))).run()
+    assert env.status == "ok"
+    assert env.exit_code() == bg.EXIT_OK
+    assert str(wait) in env.artifacts_found and not env.missing
+    calls = (tmp_path / "calls.log").read_text().splitlines()
+    assert any(c.startswith("stop ") for c in calls)
+    assert any(c.startswith("rm ") for c in calls)
+    # teardown order: stop precedes rm
+    assert [c.split()[0] for c in calls if c.split()[0] in ("stop", "rm")] == ["stop", "rm"]
+
+
+def test_needs_human_bubbles_back(shim, tmp_path, monkeypatch):
+    hand = tmp_path / "handoff.json"
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "needs_human")
+    monkeypatch.setenv("FAKE_BG_HANDOFF", str(hand))
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(wait), handoff_file=str(hand))).run()
+    assert env.status == "needs_human"
+    assert env.exit_code() == bg.EXIT_NEEDS_HUMAN
+    assert env.questions == ["A or B?"]
+
+
+def test_blocked_is_detected_with_distilled_logs(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "blocked")
+    env = bg.BgRunner(_args(shim, tmp_path)).run()  # no wait_for -> relies on state
+    assert env.status == "blocked"
+    assert env.exit_code() == bg.EXIT_BLOCKED
+    assert "choose A or B" in env.logs_tail
+    assert "\x1b" not in env.logs_tail
+
+
+def test_dispatch_failed_when_never_registers(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "never_confirm")
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "x"))).run()
+    assert env.status == "dispatch_failed"
+    assert env.exit_code() == bg.EXIT_DISPATCH_FAILED
+
+
+def test_bypass_refusal_is_precondition_failed(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "bypass_refused")
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "x"))).run()
+    assert env.status == "precondition_failed"
+    assert env.exit_code() == bg.EXIT_PRECONDITION
+    assert "dangerously-skip-permissions" in env.message
+
+
+def test_timeout_stops_session(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "timeout")  # state stays working, no artifact
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "never"), timeout="0.4")).run()
+    assert env.status == "timeout"
+    assert env.exit_code() == bg.EXIT_TIMEOUT
+    assert any(c.startswith("stop ") for c in (tmp_path / "calls.log").read_text().splitlines())
+
+
+def test_incomplete_when_done_without_artifact(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "incomplete")  # state done, artifact never written
+    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "missing"))).run()
+    assert env.status == "incomplete"
+    assert env.exit_code() == bg.EXIT_SESSION_FAILED
+    assert str(tmp_path / "missing") in env.missing
+
+
+def test_self_test_passes_in_this_env():
+    assert bg._self_test() == bg.EXIT_OK

--- a/tests/unit/test_claude_bg_run.py
+++ b/tests/unit/test_claude_bg_run.py
@@ -2,13 +2,12 @@
 
 These exercise the full dispatch -> confirm -> wait -> collect -> teardown
 lifecycle against a fake `claude` shim (no real model calls, no bypass-acceptance
-needed), plus the ANSI/PTY noise-firewall primitive.
+needed), the needs_human bubble-back and resume continuation, plus the ANSI/PTY
+noise-firewall primitive.
 """
 
 from __future__ import annotations
 
-import json
-import os
 import stat
 from pathlib import Path
 
@@ -17,7 +16,8 @@ import pytest
 import claude_bg_run as bg
 
 # A fake `claude` CLI. Behavior is driven by FAKE_BG_* env vars so each test can
-# script a scenario. It emulates: `--bg`, `agents --json`, `logs`, `stop`, `rm`.
+# script a scenario. It emulates: `--bg` (incl. `--resume`), `agents --json`,
+# `logs`, `stop`, `rm`.
 FAKE_CLAUDE = r'''#!/usr/bin/env python3
 import os, sys, json, pathlib
 D = pathlib.Path(os.environ["FAKE_BG_DIR"])
@@ -34,21 +34,27 @@ def read_state():
 
 args = sys.argv[1:]
 if args[:1] == ["--bg"]:
+    is_resume = "--resume" in args
     name = args[args.index("--name") + 1] if "--name" in args else "?"
-    log("bg " + name)
+    log(("resume " if is_resume else "bg ") + name)
     if S == "bypass_refused":
         print("--bg with bypassPermissions requires accepting the disclaimer first. "
               "Run `claude --dangerously-skip-permissions` once interactively.")
         sys.exit(0)
+    eff = S
+    if S == "resume_ok":
+        eff = "ok"
+    if S == "resume_fallback":
+        eff = "never_confirm" if is_resume else "ok"
     sid = "abc12345"
-    if S != "never_confirm":
-        st = {"blocked": "blocked", "incomplete": "done"}.get(S, "working")
+    if eff != "never_confirm":
+        st = {"blocked": "blocked", "incomplete": "done"}.get(eff, "working")
         state.write_text(json.dumps(
             {"id": sid, "name": name, "sessionId": sid + "-uuid",
              "kind": "background", "state": st, "status": "idle"}))
-    if S == "ok" and WAIT:
+    if eff == "ok" and WAIT:
         pathlib.Path(WAIT).write_text("RESULT")
-    if S == "needs_human" and HAND:
+    if eff == "needs_human" and HAND:
         pathlib.Path(HAND).write_text(json.dumps(
             {"status": "needs_human", "questions": ["A or B?"]}))
     print(f"backgrounded · {sid} · {name}")
@@ -77,7 +83,7 @@ def shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return p
 
 
-def _args(shim: Path, tmp_path: Path, **over):
+def _args(shim: Path, **over):
     argv = [
         "--claude-bin", f"{shim}",
         "--prompt", "do the thing",
@@ -93,6 +99,11 @@ def _args(shim: Path, tmp_path: Path, **over):
         else:
             argv += [flag, str(v)]
     return bg.build_parser().parse_args(argv)
+
+
+def _calls(tmp_path: Path) -> list[str]:
+    f = tmp_path / "calls.log"
+    return f.read_text().splitlines() if f.exists() else []
 
 
 # ---- pure helpers ----------------------------------------------------------
@@ -124,11 +135,11 @@ def test_ok_completes_on_artifact_and_tears_down(shim, tmp_path, monkeypatch):
     wait = tmp_path / "out.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "ok")
     monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(wait))).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(wait))).run()
     assert env.status == "ok"
     assert env.exit_code() == bg.EXIT_OK
     assert str(wait) in env.artifacts_found and not env.missing
-    calls = (tmp_path / "calls.log").read_text().splitlines()
+    calls = _calls(tmp_path)
     assert any(c.startswith("stop ") for c in calls)
     assert any(c.startswith("rm ") for c in calls)
     # teardown order: stop precedes rm
@@ -140,15 +151,56 @@ def test_needs_human_bubbles_back(shim, tmp_path, monkeypatch):
     wait = tmp_path / "out.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "needs_human")
     monkeypatch.setenv("FAKE_BG_HANDOFF", str(hand))
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(wait), handoff_file=str(hand))).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(wait), handoff_file=str(hand))).run()
     assert env.status == "needs_human"
     assert env.exit_code() == bg.EXIT_NEEDS_HUMAN
     assert env.questions == ["A or B?"]
 
 
+def test_needs_human_keeps_session_alive_for_resume(shim, tmp_path, monkeypatch):
+    hand = tmp_path / "handoff.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "needs_human")
+    monkeypatch.setenv("FAKE_BG_HANDOFF", str(hand))
+    env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "out.json"), handoff_file=str(hand))).run()
+    assert env.status == "needs_human"
+    # Session must NOT be torn down: no stop/rm, so it can be resumed.
+    calls = _calls(tmp_path)
+    assert not any(c.startswith("stop") or c.startswith("rm") for c in calls)
+    assert env.session_id  # surfaced so the orchestrator can --resume it
+
+
+def test_resume_continues_same_session(shim, tmp_path, monkeypatch):
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, resume="abc12345-uuid", answer="use option A", wait_for=str(wait))).run()
+    assert env.status == "ok"
+    assert env.resumed is True and env.fell_back is False
+    assert any(c.startswith("resume ") for c in _calls(tmp_path))
+
+
+def test_resume_falls_back_to_fresh_dispatch(shim, tmp_path, monkeypatch):
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_fallback")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, resume="dead-session", answer="use option A", wait_for=str(wait))).run()
+    assert env.status == "ok"
+    assert env.fell_back is True
+    assert "re-dispatched" in env.message
+    calls = [c.split()[0] for c in _calls(tmp_path)]
+    assert "resume" in calls and "bg" in calls  # tried resume, then fresh
+
+
+def test_resume_without_answer_is_precondition_failed(shim, tmp_path, monkeypatch):
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
+    env = bg.BgRunner(_args(shim, resume="abc12345-uuid", wait_for=str(tmp_path / "x"))).run()
+    assert env.status == "precondition_failed"
+    assert env.exit_code() == bg.EXIT_PRECONDITION
+
+
 def test_blocked_is_detected_with_distilled_logs(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "blocked")
-    env = bg.BgRunner(_args(shim, tmp_path)).run()  # no wait_for -> relies on state
+    env = bg.BgRunner(_args(shim)).run()  # no wait_for -> relies on state
     assert env.status == "blocked"
     assert env.exit_code() == bg.EXIT_BLOCKED
     assert "choose A or B" in env.logs_tail
@@ -157,14 +209,14 @@ def test_blocked_is_detected_with_distilled_logs(shim, tmp_path, monkeypatch):
 
 def test_dispatch_failed_when_never_registers(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "never_confirm")
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "x"))).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "x"))).run()
     assert env.status == "dispatch_failed"
     assert env.exit_code() == bg.EXIT_DISPATCH_FAILED
 
 
 def test_bypass_refusal_is_precondition_failed(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "bypass_refused")
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "x"))).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "x"))).run()
     assert env.status == "precondition_failed"
     assert env.exit_code() == bg.EXIT_PRECONDITION
     assert "dangerously-skip-permissions" in env.message
@@ -172,15 +224,15 @@ def test_bypass_refusal_is_precondition_failed(shim, tmp_path, monkeypatch):
 
 def test_timeout_stops_session(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "timeout")  # state stays working, no artifact
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "never"), timeout="0.4")).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "never"), timeout="0.4")).run()
     assert env.status == "timeout"
     assert env.exit_code() == bg.EXIT_TIMEOUT
-    assert any(c.startswith("stop ") for c in (tmp_path / "calls.log").read_text().splitlines())
+    assert any(c.startswith("stop ") for c in _calls(tmp_path))
 
 
 def test_incomplete_when_done_without_artifact(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "incomplete")  # state done, artifact never written
-    env = bg.BgRunner(_args(shim, tmp_path, wait_for=str(tmp_path / "missing"))).run()
+    env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "missing"))).run()
     assert env.status == "incomplete"
     assert env.exit_code() == bg.EXIT_SESSION_FAILED
     assert str(tmp_path / "missing") in env.missing

--- a/tests/unit/test_claude_bg_run.py
+++ b/tests/unit/test_claude_bg_run.py
@@ -4,10 +4,17 @@ These exercise the full dispatch -> confirm -> wait -> collect -> teardown
 lifecycle against a fake `claude` shim (no real model calls, no bypass-acceptance
 needed), the needs_human bubble-back and resume continuation, plus the ANSI/PTY
 noise-firewall primitive.
+
+The shim mirrors the REAL CLI surface: `--bg` (incl. `--resume`) and
+`agents --json` only — there are no `logs`/`stop`/`rm` subcommands. State is a
+LIST of session rows (each with a pid), so resume scenarios can model the parked
+parent session sitting next to the newly dispatched agent. Teardown is a signal
+to the row's pid; tests intercept `os.kill` and drop the row to simulate exit.
 """
 
 from __future__ import annotations
 
+import json
 import stat
 from pathlib import Path
 
@@ -15,9 +22,6 @@ import pytest
 
 import claude_bg_run as bg
 
-# A fake `claude` CLI. Behavior is driven by FAKE_BG_* env vars so each test can
-# script a scenario. It emulates: `--bg` (incl. `--resume`), `agents --json`,
-# `logs`, `stop`, `rm`.
 FAKE_CLAUDE = r'''#!/usr/bin/env python3
 import os, sys, json, pathlib
 D = pathlib.Path(os.environ["FAKE_BG_DIR"])
@@ -28,15 +32,16 @@ state = D / "state.json"
 calls = D / "calls.log"
 
 def log(line): calls.open("a").write(line + "\n")
-def read_state():
+def rows():
     try: return json.loads(state.read_text())
-    except Exception: return None
+    except Exception: return []
 
 args = sys.argv[1:]
 if args[:1] == ["--bg"]:
     is_resume = "--resume" in args
+    sid_arg = args[args.index("--resume") + 1] if is_resume else ""
     name = args[args.index("--name") + 1] if "--name" in args else "?"
-    log(("resume " if is_resume else "bg ") + name)
+    log(("resume " if is_resume else "bg ") + name + (f" sid={sid_arg}" if is_resume else ""))
     if S == "bypass_refused":
         print("--bg with bypassPermissions requires accepting the disclaimer first. "
               "Run `claude --dangerously-skip-permissions` once interactively.")
@@ -49,9 +54,10 @@ if args[:1] == ["--bg"]:
     sid = "abc12345"
     if eff != "never_confirm":
         st = {"blocked": "blocked", "incomplete": "done"}.get(eff, "working")
-        state.write_text(json.dumps(
-            {"id": sid, "name": name, "sessionId": sid + "-uuid",
-             "kind": "background", "state": st, "status": "idle"}))
+        rs = rows()
+        rs.append({"pid": 222, "id": sid, "name": name, "sessionId": sid + "-uuid",
+                   "kind": "background", "state": st, "status": "idle"})
+        state.write_text(json.dumps(rs))
     if eff == "ok" and WAIT:
         pathlib.Path(WAIT).write_text("RESULT")
     if eff == "needs_human" and HAND:
@@ -60,18 +66,25 @@ if args[:1] == ["--bg"]:
     print(f"backgrounded · {sid} · {name}")
     sys.exit(0)
 if args[:2] == ["agents", "--json"]:
-    s = read_state()
-    print(json.dumps([s] if s else []))
+    print(json.dumps(rows()))
     sys.exit(0)
-if args[:1] == ["logs"]:
-    print("\x1b[2J\x1b[H\x1b[31mneeds input: choose A or B?\x1b[0m\r\n")
-    sys.exit(0)
-if args and args[0] in ("stop", "rm"):
-    log(f"{args[0]} {args[1] if len(args) > 1 else ''}")
-    if args[0] == "rm" and state.exists(): state.unlink()
-    sys.exit(0)
+# Anything else (e.g. the nonexistent logs/stop/rm) parses as a PROMPT: no-op.
+log("unknown " + " ".join(args[:2]))
 sys.exit(0)
 '''
+
+PARENT_SID = "11111111-1111-1111-1111-111111111111"
+PARENT = {
+    "pid": 111,
+    "id": "parent01",
+    "name": "bgrun-parked",
+    "kind": "background",
+    "sessionId": PARENT_SID,
+    # A parked (idle, awaiting-input) session reads state==blocked — exactly the
+    # row that used to shadow the new resume agent.
+    "state": "blocked",
+    "status": "idle",
+}
 
 
 @pytest.fixture
@@ -81,6 +94,30 @@ def shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     p.chmod(p.stat().st_mode | stat.S_IXUSR)
     monkeypatch.setenv("FAKE_BG_DIR", str(tmp_path))
     return p
+
+
+@pytest.fixture(autouse=True)
+def kills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
+    """Intercept os.kill: record (pid, sig) and drop the row, simulating exit."""
+    recorded: list[tuple[int, int]] = []
+    state = tmp_path / "state.json"
+
+    def fake_kill(pid: int, sig: int) -> None:
+        recorded.append((pid, sig))
+        try:
+            rows = json.loads(state.read_text())
+        except (OSError, json.JSONDecodeError):
+            rows = []
+        state.write_text(json.dumps([r for r in rows if r.get("pid") != pid]))
+
+    monkeypatch.setattr(bg.os, "kill", fake_kill)
+    return recorded
+
+
+def _seed_parent(tmp_path: Path, **over) -> dict:
+    row = {**PARENT, **over}
+    (tmp_path / "state.json").write_text(json.dumps([row]))
+    return row
 
 
 def _args(shim: Path, **over):
@@ -131,7 +168,7 @@ def test_pty_capture_strips_noise_to_signal():
 
 
 # ---- lifecycle scenarios ---------------------------------------------------
-def test_ok_completes_on_artifact_and_tears_down(shim, tmp_path, monkeypatch):
+def test_ok_completes_on_artifact_and_tears_down(shim, tmp_path, monkeypatch, kills):
     wait = tmp_path / "out.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "ok")
     monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
@@ -139,11 +176,17 @@ def test_ok_completes_on_artifact_and_tears_down(shim, tmp_path, monkeypatch):
     assert env.status == "ok"
     assert env.exit_code() == bg.EXIT_OK
     assert str(wait) in env.artifacts_found and not env.missing
-    calls = _calls(tmp_path)
-    assert any(c.startswith("stop ") for c in calls)
-    assert any(c.startswith("rm ") for c in calls)
-    # teardown order: stop precedes rm
-    assert [c.split()[0] for c in calls if c.split()[0] in ("stop", "rm")] == ["stop", "rm"]
+    # Teardown = SIGTERM to the supervisor-reported pid (there is no stop/rm).
+    assert (222, bg.signal.SIGTERM) in kills
+
+
+def test_keep_skips_teardown(shim, tmp_path, monkeypatch, kills):
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "ok")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, wait_for=str(wait), keep=True)).run()
+    assert env.status == "ok"
+    assert kills == []
 
 
 def test_needs_human_bubbles_back(shim, tmp_path, monkeypatch):
@@ -157,33 +200,77 @@ def test_needs_human_bubbles_back(shim, tmp_path, monkeypatch):
     assert env.questions == ["A or B?"]
 
 
-def test_needs_human_keeps_session_alive_for_resume(shim, tmp_path, monkeypatch):
+def test_needs_human_keeps_session_alive_for_resume(shim, tmp_path, monkeypatch, kills):
     hand = tmp_path / "handoff.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "needs_human")
     monkeypatch.setenv("FAKE_BG_HANDOFF", str(hand))
     env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "out.json"), handoff_file=str(hand))).run()
     assert env.status == "needs_human"
-    # Session must NOT be torn down: no stop/rm, so it can be resumed.
-    calls = _calls(tmp_path)
-    assert not any(c.startswith("stop") or c.startswith("rm") for c in calls)
+    # Session must NOT be torn down: no signals sent, so it can be resumed.
+    assert kills == []
     assert env.session_id  # surfaced so the orchestrator can --resume it
 
 
-def test_resume_continues_same_session(shim, tmp_path, monkeypatch):
+def test_resume_continues_same_session_not_shadowed_by_parked_parent(shim, tmp_path, monkeypatch, kills):
+    # Regression: the parked parent (state==blocked because it is idle awaiting
+    # input) matches sessionId==resume target and used to shadow the new agent,
+    # misreporting the whole run as `blocked`.
+    _seed_parent(tmp_path)
     wait = tmp_path / "out.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
     monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
-    env = bg.BgRunner(_args(shim, resume="abc12345-uuid", answer="use option A", wait_for=str(wait))).run()
+    env = bg.BgRunner(_args(shim, resume=PARENT_SID, answer="use option A", wait_for=str(wait))).run()
     assert env.status == "ok"
     assert env.resumed is True and env.fell_back is False
-    assert any(c.startswith("resume ") for c in _calls(tmp_path))
+    assert env.resumed_from == PARENT_SID
+    assert env.session_id == "abc12345-uuid"  # the NEW session id, for chained resumes
+    assert any(c.startswith("resume ") and f"sid={PARENT_SID}" in c for c in _calls(tmp_path))
+    # The parked parent is retired once the conversation moved on; the new agent
+    # is torn down at the end as usual.
+    assert (111, bg.signal.SIGTERM) in kills
+    assert (222, bg.signal.SIGTERM) in kills
+
+
+def test_resume_by_agent_name_survives_rename(shim, tmp_path, monkeypatch, kills):
+    # A human renamed the parked agent in the agent view; --resume by the new
+    # name must resolve to its sessionId.
+    _seed_parent(tmp_path, name="fix-login-bug")
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, resume="fix-login-bug", answer="use option A", wait_for=str(wait))).run()
+    assert env.status == "ok"
+    assert env.resumed_from == PARENT_SID
+    assert any(f"sid={PARENT_SID}" in c for c in _calls(tmp_path))
+    assert (111, bg.signal.SIGTERM) in kills
+
+
+def test_resume_by_short_id(shim, tmp_path, monkeypatch):
+    _seed_parent(tmp_path)
+    wait = tmp_path / "out.json"
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
+    monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
+    env = bg.BgRunner(_args(shim, resume="parent01", answer="use option A", wait_for=str(wait))).run()
+    assert env.status == "ok"
+    assert env.resumed_from == PARENT_SID
+
+
+def test_resume_unknown_target_is_precondition_failed(shim, tmp_path, monkeypatch):
+    # Not a live agent (by sid/short id/name) and not session-id-shaped.
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
+    env = bg.BgRunner(_args(shim, resume="no-such-agent", answer="A", wait_for=str(tmp_path / "x"))).run()
+    assert env.status == "precondition_failed"
+    assert env.exit_code() == bg.EXIT_PRECONDITION
+    assert "no live agent" in env.message
 
 
 def test_resume_falls_back_to_fresh_dispatch(shim, tmp_path, monkeypatch):
+    # Session-id-shaped target with no live row: try the resume, fall back fresh.
     wait = tmp_path / "out.json"
     monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_fallback")
     monkeypatch.setenv("FAKE_BG_WAITFOR", str(wait))
-    env = bg.BgRunner(_args(shim, resume="dead-session", answer="use option A", wait_for=str(wait))).run()
+    dead = "22222222-2222-2222-2222-222222222222"
+    env = bg.BgRunner(_args(shim, resume=dead, answer="use option A", wait_for=str(wait))).run()
     assert env.status == "ok"
     assert env.fell_back is True
     assert "re-dispatched" in env.message
@@ -193,14 +280,20 @@ def test_resume_falls_back_to_fresh_dispatch(shim, tmp_path, monkeypatch):
 
 def test_resume_without_answer_is_precondition_failed(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "resume_ok")
-    env = bg.BgRunner(_args(shim, resume="abc12345-uuid", wait_for=str(tmp_path / "x"))).run()
+    env = bg.BgRunner(_args(shim, resume=PARENT_SID, wait_for=str(tmp_path / "x"))).run()
     assert env.status == "precondition_failed"
     assert env.exit_code() == bg.EXIT_PRECONDITION
 
 
-def test_blocked_is_detected_with_distilled_logs(shim, tmp_path, monkeypatch):
+def test_blocked_is_detected_with_transcript_logs(shim, tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "blocked")
-    env = bg.BgRunner(_args(shim)).run()  # no wait_for -> relies on state
+    tdir = tmp_path / "transcripts" / "proj"
+    tdir.mkdir(parents=True)
+    (tdir / "abc12345-uuid.jsonl").write_text(json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": "\x1b[31mneeds input: choose A or B?\x1b[0m"}]},
+    }) + "\n")
+    env = bg.BgRunner(_args(shim, transcripts_root=str(tmp_path / "transcripts"))).run()
     assert env.status == "blocked"
     assert env.exit_code() == bg.EXIT_BLOCKED
     assert "choose A or B" in env.logs_tail
@@ -222,12 +315,12 @@ def test_bypass_refusal_is_precondition_failed(shim, tmp_path, monkeypatch):
     assert "dangerously-skip-permissions" in env.message
 
 
-def test_timeout_stops_session(shim, tmp_path, monkeypatch):
+def test_timeout_stops_session(shim, tmp_path, monkeypatch, kills):
     monkeypatch.setenv("FAKE_BG_SCENARIO", "timeout")  # state stays working, no artifact
     env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "never"), timeout="0.4")).run()
     assert env.status == "timeout"
     assert env.exit_code() == bg.EXIT_TIMEOUT
-    assert any(c.startswith("stop ") for c in _calls(tmp_path))
+    assert (222, bg.signal.SIGTERM) in kills
 
 
 def test_incomplete_when_done_without_artifact(shim, tmp_path, monkeypatch):


### PR DESCRIPTION
## ⭐ Why this matters

After **June 15, 2026**, `claude -p` — the bridge Quest uses for Codex-led Claude roles — bills at metered API rates instead of your subscription. This lands the subscription-pool replacement: a standalone `claude --bg` runner that Codex can drive, keeping Claude roles on your normal Pro/Max plan with **no API spend**, plus the specs to wire it into Quest behind a config switch.

- **No API bill for Codex→Claude roles** — background agents draw from the subscription pool, not the Agent-SDK credit (verbatim from Anthropic's agent-view docs).
- **Validate before we wire** — the runner is quest-agnostic and runs standalone; 16 green tests + a real-CLI smoke prove the mechanics first.
- **Human-in-the-loop preserved** — a `needs_human` question bubbles back to the orchestrator and the *same* session resumes with the answer.

---

## Summary
Introduces the background-agent transport as the post-June-15 replacement for the `claude --print` bridge, starting with a standalone, quest-agnostic runner plus the specs for migrating Quest behind a `claude_role_transport` switch (the bridge is kept as the fallback/CI path, not deleted).
- **Step 1 (code in this PR):** `scripts/claude_bg_run.py` + tests — runnable and validated outside Quest.
- **Step 2 (spec only here):** wiring Quest's runner/preflight to select the transport.

> [!NOTE]
> The happy "write a file" path needs a one-time `claude --dangerously-skip-permissions` acceptance per machine. That interactive step can't run in CI/sandbox, so it is covered by the fake-shim tests and a documented machine-validation step rather than CI.

## Try it from the CLI (human use)

The script is not Quest-only — you can drive a Claude background agent straight from your shell. It speaks purely through files, so you give it a task, tell it which file(s) to produce, and it returns when they exist.

**One-time setup (per machine):** `claude login`, then run `claude --dangerously-skip-permissions` once and accept (background sessions default to `bypassPermissions`). No API key needed — this runs on your subscription.

**No-setup smoke (proves the wiring without the accept):**
```bash
python3 scripts/claude_bg_run.py --self-test          # PTY noise-firewall demo, no claude needed
python3 scripts/claude_bg_run.py --json --permission-mode plan --prompt 'Reply with exactly: OK'
```

**1) Hello world** — dispatch, wait for a file, auto-teardown:
```bash
mkdir -p /tmp/bgrun
python3 scripts/claude_bg_run.py --json \
  --wait-for /tmp/bgrun/hello.txt \
  --prompt 'Write exactly "hello world" to /tmp/bgrun/hello.txt'
cat /tmp/bgrun/hello.txt        # -> hello world
```
Expected: envelope `status: ok`, the file present, the session removed.

**2) Watch / reconnect by hand** — the runner is a thin wrapper over native commands, and prints `short_id`/`session_id` in its `--json` output. While a longer task runs, from any terminal:
```bash
claude agents            # live dashboard of all your sessions
claude agents --json     # same, scriptable (id, name, state, status, sessionId)
claude logs   <id>       # recent output
claude attach <id>       # jump INTO the conversation, then detach with the left-arrow
claude stop   <id>       # stop;  claude rm <id> removes it
```
So you can dispatch with the script, then reattach to the *same* session interactively whenever you want.

**3) Get an interactive answer back** — the `needs_human` → resume loop, done by hand:
```bash
# (a) dispatch a task that will ask a question instead of guessing:
python3 scripts/claude_bg_run.py --json \
  --handoff-file /tmp/bgrun/handoff.json \
  --wait-for /tmp/bgrun/plan.md \
  --prompt 'Draft a 3-line rollout plan in /tmp/bgrun/plan.md. If the rollout style
            (canary vs big-bang) is not specified, do NOT guess — write
            {"status":"needs_human","questions":["canary or big-bang?"]} to
            /tmp/bgrun/handoff.json and stop.'
#   -> status: needs_human, prints the question + session_id, and LEAVES the session alive.

# (b) read the question, decide, and send your answer back into the SAME session:
python3 scripts/claude_bg_run.py --json \
  --resume <session_id-from-step-a> \
  --answer 'Use a canary rollout.' \
  --wait-for /tmp/bgrun/plan.md \
  --prompt 'Draft a 3-line rollout plan in /tmp/bgrun/plan.md.'   # fallback task if resume fails
cat /tmp/bgrun/plan.md
#   -> resumes that conversation with your answer; status: ok; plan.md written.
```

**Exit codes (handy for shell loops):** `0` ok · `2` precondition (e.g. bypass not accepted) · `3` dispatch_failed · `4` blocked · `5` timeout · `6` session_failed/incomplete · `10` needs_human · `130` interrupted. Drop `--json` for a one-line human-readable summary instead of the full envelope.

## Changes
- **Runtime / Behavior**:
  - `scripts/claude_bg_run.py` — dispatch via `claude --bg`; confirm against `claude agents --json` (guards the cold-start false-positive and the exit-0-on-error case); wait on declared output **files** (results never scraped from screen); `needs_human` bubble-back that **leaves the session alive**; `--resume <session_id> --answer` continuation with fresh-dispatch fallback; interrupt-safe teardown (Ctrl-C → exit 130, no orphan).
  - `pty_capture()` — the headless-PTY noise firewall (stdlib `pty`): the orchestrator only ever sees a small structured envelope, never the raw ANSI TUI buffer. Demo with `--self-test`.
- **Tests**:
  - `tests/unit/test_claude_bg_run.py` — 16 tests against a fake-`claude` shim covering every lifecycle branch (ok+teardown order, needs_human + keep-alive, resume + fallback, blocked + distilled logs, dispatch_failed, bypass-refusal, timeout, incomplete) and the real-PTY strip.
- **Documentation**:
  - `docs/implementation/claude-bg-run-script.md` — Step-1 spec, validated-behavior findings, runnable examples.
  - `docs/implementation/claude-bg-transport-migration.md` — Step-2 migration behind the hard switch; why the bridge stays as fallback.
  - `docs/implementation/README.md` — Layer-3 index.

## Validation
- [x] **Unit tests (cheapest)**: run `uv run pytest tests/unit/test_claude_bg_run.py -q`. Expected: `16 passed`.
- [x] **PTY firewall, no `claude` needed**: run `python3 scripts/claude_bg_run.py --self-test`. Expected: prints `pty exit=0`, `distilled signal: 'HELLO clean'`, `PASS` (ANSI in, clean text out).
- [x] **Real happy path (needs a logged-in machine + the one-time bypass accept)**: Prerequisites: `claude login`, then `claude --dangerously-skip-permissions` once (accept). Action: `python3 scripts/claude_bg_run.py --json --wait-for /tmp/bgrun/out.json --prompt 'Write {"ok":true} to /tmp/bgrun/out.json'`. Expected: envelope `status: ok`, `/tmp/bgrun/out.json` present, session removed afterward; then open `/usage` and confirm the run counts against your **subscription**, not the Agent-SDK credit. Negative case: omit the bypass accept → `status: precondition_failed` with the exact remediation command.
- [ ] **needs_human → resume loop**: follow the "Try it from the CLI" section above (step 3), or `docs/implementation/claude-bg-run-script.md` §"Examples to try".

Watch for: this environment's own `Stop` hook can force a session to `blocked`, and `bypassPermissions` is refused without the one-time accept — both are environment constraints the runner reports cleanly, not bugs.

## Notes
- Step 2 (Quest wiring + preflight transport probe + `claude_role_transport` switch) is **spec-only** in this PR; the `claude --print` bridge stays the default and is demoted to fallback/CI, not deleted (rationale in the migration spec).
- `claude --bg --resume` continuation is validated via the fake shim here; confirm it against the real CLI as part of Step 2.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude <noreply@anthropic.com>
in collaboration with Kjell <kjell@onfleet.com>
</pre>