### PR TITLE
Fix bg-run stale-name false confirm and PTY child leak

### DIFF
--- a/scripts/claude_bg_run.py
+++ b/scripts/claude_bg_run.py
@@ -139,33 +139,75 @@ def pty_capture(
     chunks: list[bytes] = []
     deadline = time.monotonic() + total_timeout
     last = time.monotonic()
+    exited = False  # EOF/EIO: the child ended its own stream
+    timed_out = False
     while True:
         if time.monotonic() > deadline:
+            timed_out = True
             break
         r, _, _ = select.select([fd], [], [], 0.2)
         if r:
             try:
                 data = os.read(fd, 65536)
             except OSError:
+                exited = True
                 break
             if not data:
+                exited = True
                 break
             chunks.append(data)
             last = time.monotonic()
         elif time.monotonic() - last > idle_timeout:
             break
-    status = 0
     try:
-        _, status = os.waitpid(pid, os.WNOHANG)
-    except ChildProcessError:
+        os.close(fd)
+    except OSError:
         pass
-    finally:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+    # Never leave the loop with a live child: a persistent TUI (the attach
+    # use-case) never exits on its own and would outlive the runner.
+    status = _reap_pty_child(pid, kill=not exited)
     raw = b"".join(chunks).decode("utf-8", errors="replace")
-    return (os.WEXITSTATUS(status) if status else 0), strip_ansi(raw)
+    if timed_out:
+        code = 124  # the stream never went quiet: surface as failure, not truncation
+    elif not exited:
+        code = 0  # idle-quiescence capture of a live TUI: success by design
+    elif os.WIFEXITED(status):
+        code = os.WEXITSTATUS(status)
+    elif os.WIFSIGNALED(status):
+        code = 128 + os.WTERMSIG(status)
+    else:
+        code = 0
+    return code, strip_ansi(raw)
+
+
+def _reap_pty_child(pid: int, *, kill: bool) -> int:
+    """Terminate (when asked) and reap the PTY child; return its wait status.
+
+    Reaping unconditionally — not WNOHANG-and-hope — also closes the race where
+    a child that had just exited read back as status 0.
+    """
+    if kill:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+    grace = time.monotonic() + 2.0
+    while time.monotonic() < grace:
+        try:
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return 0
+        if wpid == pid:
+            return status
+        time.sleep(0.05)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        return os.waitpid(pid, 0)[1]
+    except ChildProcessError:
+        return 0
 
 
 @dataclass
@@ -243,6 +285,30 @@ class BgRunner:
             for row in rows:
                 if row.get(key) == want:
                     return row
+        return None
+
+    def _confirm_row(
+        self, short_id: str | None, pre_existing: set[str]
+    ) -> dict[str, Any] | None:
+        """Find the row registered by THIS dispatch.
+
+        The printed short id is authoritative. The name fallback (short-id regex
+        missed, or the printed id never surfaced in the roster) only accepts a
+        row absent from the pre-dispatch snapshot — a stale same-name row must
+        not confirm a dispatch that never registered, poisoning session_id,
+        polling, and teardown with the wrong session.
+        """
+        rows = [r for r in self.agents_json() if r.get("kind") != "interactive"]
+        if short_id:
+            for row in rows:
+                if row.get("id") == short_id:
+                    return row
+        for row in rows:
+            if row.get("name") != self.a.name:
+                continue
+            if row.get("id") in pre_existing or row.get("sessionId") in pre_existing:
+                continue
+            return row
         return None
 
     def resolve_resume_target(self, ref: str) -> tuple[str | None, str | None]:
@@ -394,6 +460,16 @@ class BgRunner:
         self, message: str, resume_sid: str | None
     ) -> tuple[str | None, str, str | None, dict[str, Any] | None]:
         """Returns (terminal_status_or_None, message, short_id, session_row)."""
+        # Roster snapshot BEFORE dispatch: the confirm loop's name fallback may
+        # only accept a row that appeared after this dispatch. Callers can pass
+        # a stable --name (quest: quest-<id>-<role>-i<n>), so a stale row from a
+        # crashed prior run — or a settled pid-less remnant of a torn-down one —
+        # would otherwise confirm a dispatch that never registered.
+        pre_existing: set[str] = set()
+        for r in self.agents_json():
+            for key in ("id", "sessionId"):
+                if r.get(key):
+                    pre_existing.add(r[key])
         argv = self.dispatch_argv(resume_sid)
         try:
             cp = subprocess.run(
@@ -423,10 +499,11 @@ class BgRunner:
         deadline = time.monotonic() + self.a.confirm_timeout
         row: dict[str, Any] | None = None
         while time.monotonic() < deadline:
-            # Confirm by short id / name ONLY: in resume mode the parked parent's
-            # row matches `sessionId == resume_sid` and would falsely confirm a
-            # dispatch that never registered.
-            row = self.find_session(short_id, self.a.name)
+            # Confirm by short id, else by name restricted to NEW rows. Never by
+            # sessionId: in resume mode the parked parent's row matches
+            # `sessionId == resume_sid` and would falsely confirm a dispatch
+            # that never registered.
+            row = self._confirm_row(short_id, pre_existing)
             if row:
                 break
             time.sleep(self.a.poll_interval)

--- a/scripts/claude_bg_run.py
+++ b/scripts/claude_bg_run.py
@@ -465,11 +465,19 @@ class BgRunner:
         # a stable --name (quest: quest-<id>-<role>-i<n>), so a stale row from a
         # crashed prior run — or a settled pid-less remnant of a torn-down one —
         # would otherwise confirm a dispatch that never registered.
+        # A failed snapshot must return the structured envelope, not raise —
+        # and must not silently proceed with an empty snapshot, which would
+        # quietly reintroduce the stale-row false-confirm this guards against.
         pre_existing: set[str] = set()
-        for r in self.agents_json():
-            for key in ("id", "sessionId"):
-                if r.get(key):
-                    pre_existing.add(r[key])
+        try:
+            for r in self.agents_json():
+                for key in ("id", "sessionId"):
+                    if r.get(key):
+                        pre_existing.add(r[key])
+        except FileNotFoundError:
+            return "precondition_failed", "claude CLI not found in PATH", None, None
+        except (OSError, subprocess.SubprocessError) as exc:
+            return "dispatch_failed", f"roster snapshot before dispatch failed: {exc}", None, None
         argv = self.dispatch_argv(resume_sid)
         try:
             cp = subprocess.run(

--- a/tests/unit/test_claude_bg_run.py
+++ b/tests/unit/test_claude_bg_run.py
@@ -23,6 +23,11 @@ import pytest
 
 import claude_bg_run as bg
 
+# Captured at import, BEFORE the autouse `kills` fixture patches bg.os.kill:
+# `bg.os` and this module's `os` are the same module object, so by test time
+# `os.kill` already IS the fake — restoring from it would be a no-op.
+_REAL_OS_KILL = os.kill
+
 FAKE_CLAUDE = r'''#!/usr/bin/env python3
 import os, sys, json, pathlib
 D = pathlib.Path(os.environ["FAKE_BG_DIR"])
@@ -184,7 +189,7 @@ def test_pty_capture_strips_noise_to_signal():
 def test_pty_capture_total_timeout_kills_child_and_returns_failure(monkeypatch):
     # A child that streams forever: total_timeout must kill+reap it and surface
     # a non-zero exit instead of success-with-partial-text (and a leaked child).
-    monkeypatch.setattr(bg.os, "kill", os.kill)  # undo the autouse kill shim
+    monkeypatch.setattr(bg.os, "kill", _REAL_OS_KILL)  # undo the autouse kill shim
     code, text = bg.pty_capture(
         ["sh", "-c", "while :; do printf x; sleep 0.05; done"],
         total_timeout=0.5, idle_timeout=5.0,
@@ -198,7 +203,7 @@ def test_pty_capture_idle_quiescence_is_success_and_reaps_child(monkeypatch):
     # TUI screen (the attach responder use-case): exit 0, and the child is
     # terminated+reaped rather than left running past the runner's lifetime.
     # If reaping regressed, the blocking waitpid would hold this test ~30s.
-    monkeypatch.setattr(bg.os, "kill", os.kill)  # undo the autouse kill shim
+    monkeypatch.setattr(bg.os, "kill", _REAL_OS_KILL)  # undo the autouse kill shim
     code, text = bg.pty_capture(
         ["sh", "-c", "printf 'SCREEN'; sleep 30"],
         total_timeout=15.0, idle_timeout=0.4,
@@ -438,6 +443,18 @@ def test_dispatch_failed_when_never_registers(shim, tmp_path, monkeypatch):
     env = bg.BgRunner(_args(shim, wait_for=str(tmp_path / "x"))).run()
     assert env.status == "dispatch_failed"
     assert env.exit_code() == bg.EXIT_DISPATCH_FAILED
+
+
+def test_missing_claude_cli_is_precondition_failed(tmp_path):
+    # The pre-dispatch roster snapshot is the first `claude` invocation now; a
+    # missing CLI must still surface as the structured envelope, not a raised
+    # FileNotFoundError (cubic review on PR #141).
+    env = bg.BgRunner(
+        _args(Path("/nonexistent/claude-cli"), wait_for=str(tmp_path / "x"))
+    ).run()
+    assert env.status == "precondition_failed"
+    assert env.exit_code() == bg.EXIT_PRECONDITION
+    assert "not found" in env.message
 
 
 def test_bypass_refusal_is_precondition_failed(shim, tmp_path, monkeypatch):

--- a/tests/unit/test_claude_bg_run.py
+++ b/tests/unit/test_claude_bg_run.py
@@ -15,6 +15,7 @@ tests intercept `os.kill` and drop the row to simulate exit.
 from __future__ import annotations
 
 import json
+import os
 import stat
 from pathlib import Path
 
@@ -178,6 +179,42 @@ def test_pty_capture_strips_noise_to_signal():
     )
     assert "HELLO clean" in text
     assert "\x1b" not in text
+
+
+def test_pty_capture_total_timeout_kills_child_and_returns_failure(monkeypatch):
+    # A child that streams forever: total_timeout must kill+reap it and surface
+    # a non-zero exit instead of success-with-partial-text (and a leaked child).
+    monkeypatch.setattr(bg.os, "kill", os.kill)  # undo the autouse kill shim
+    code, text = bg.pty_capture(
+        ["sh", "-c", "while :; do printf x; sleep 0.05; done"],
+        total_timeout=0.5, idle_timeout=5.0,
+    )
+    assert code == 124
+    assert "x" in text  # partial capture still returned for diagnostics
+
+
+def test_pty_capture_idle_quiescence_is_success_and_reaps_child(monkeypatch):
+    # Idle-quiescence is the DESIGNED completion signal for capturing a live
+    # TUI screen (the attach responder use-case): exit 0, and the child is
+    # terminated+reaped rather than left running past the runner's lifetime.
+    # If reaping regressed, the blocking waitpid would hold this test ~30s.
+    monkeypatch.setattr(bg.os, "kill", os.kill)  # undo the autouse kill shim
+    code, text = bg.pty_capture(
+        ["sh", "-c", "printf 'SCREEN'; sleep 30"],
+        total_timeout=15.0, idle_timeout=0.4,
+    )
+    assert code == 0
+    assert "SCREEN" in text
+
+
+def test_pty_capture_reports_child_exit_code():
+    # A child that exits non-zero on its own must not read back as success
+    # (the old WNOHANG race could miss the just-exited status entirely).
+    code, _ = bg.pty_capture(
+        ["sh", "-c", "printf 'boom'; exit 3"],
+        total_timeout=5.0, idle_timeout=1.0,
+    )
+    assert code == 3
 
 
 # ---- lifecycle scenarios ---------------------------------------------------
@@ -527,3 +564,34 @@ def test_resume_clears_parked_handoff_but_keeps_wait_for(
     assert env.resumed is True
     assert env.questions == []  # stale questions did not replay
     assert wait.read_text(encoding="utf-8") == "PARKED-WORK"  # preserved
+
+
+# ---- confirm must not adopt a stale same-name row ---------------------------
+def test_stale_same_name_row_does_not_confirm_failed_dispatch(shim, tmp_path, monkeypatch):
+    """Quest passes deterministic names (quest-<id>-<role>-i<n>), so a settled
+    row left by a crashed prior run shares the new dispatch's name. A dispatch
+    that never registers must report dispatch_failed — not adopt the stale row
+    and misreport its state (here done → 'incomplete') for the wrong session."""
+    _seed_parent(tmp_path, name="quest-q7-planner-i1", state="done", status="idle")
+    monkeypatch.setenv("FAKE_BG_SCENARIO", "never_confirm")
+    env = bg.BgRunner(
+        _args(shim, name="quest-q7-planner-i1", wait_for=str(tmp_path / "x"))
+    ).run()
+    assert env.status == "dispatch_failed"
+    assert env.exit_code() == bg.EXIT_DISPATCH_FAILED
+    assert env.session_id != PARENT_SID  # never adopted the stale row
+
+
+def test_confirm_name_fallback_prefers_new_row_over_stale(shim, monkeypatch):
+    """With no parsed short id, the name fallback must skip rows that existed
+    before the dispatch and accept the newly registered one — even when the
+    stale row lists first."""
+    runner = bg.BgRunner(_args(shim, name="quest-q7-planner-i1"))
+    stale = {"id": "old00001", "sessionId": "old-sid", "name": "quest-q7-planner-i1", "kind": "background"}
+    fresh = {"id": "new00002", "sessionId": "new-sid", "name": "quest-q7-planner-i1", "kind": "background"}
+    monkeypatch.setattr(runner, "agents_json", lambda: [stale, fresh])
+    row = runner._confirm_row(None, {"old00001", "old-sid"})
+    assert row is not None and row["id"] == "new00002"
+    # And when only the stale row exists, nothing confirms.
+    monkeypatch.setattr(runner, "agents_json", lambda: [stale])
+    assert runner._confirm_row(None, {"old00001", "old-sid"}) is None


### PR DESCRIPTION
## ⭐ Why this matters

The background-agent transport is now the primary Claude transport for Codex-led quests, and it could silently run against the *wrong session*: a stale row from a crashed prior run with the same deterministic name could confirm a dispatch that never registered, so the runner would poll, log-tail, and tear down someone else's session while misreporting the failure. This PR closes that hole and stops the PTY capture primitive from leaking children and reporting hung reads as success.

- **Dispatch confirmation can no longer be satisfied by a leftover session** — a real dispatch failure now surfaces as `dispatch_failed` instead of a misleading `incomplete`/`blocked`.
- **`pty_capture` never leaves a live child behind** and a hung stream reads as failure (exit 124), not clean output.

---

## Summary
Fixes two robustness gaps in `scripts/claude_bg_run.py` on the background-agent transport path, surfaced by an automated Codex review of a downstream repo that vendors the quest bundle (checksum-tracked, so it needs the fix upstream).
- Finding 1 (high): stale same-name row false-confirms a dispatch. Verified real — and it fires even when the short-id regex *succeeds*, because the name fallback matches a stale row before the new row registers; settled pid-less rows also survive `--sweep`, so this wasn't limited to crash windows.
- Finding 2 (medium as reported, latent at source): `pty_capture` leaked its child and returned exit 0 on timeout. It has no production callers here today (only `--self-test`), but it is the documented attach/logs responder primitive, so vendored copies may call it.

## Changes
- **Dispatch confirmation** (`scripts/claude_bg_run.py`):
  - `dispatch_and_confirm()` snapshots all roster identities (ids + sessionIds) before spawning `claude --bg`.
  - New `_confirm_row()`: the printed short id stays authoritative; the name fallback only accepts rows absent from the pre-dispatch snapshot, and picks the fresh row even when a stale same-name row lists first.
- **PTY capture** (`scripts/claude_bg_run.py`):
  - `pty_capture()` distinguishes exited / idle-quiet / timed-out; total-timeout returns 124 with partial text, idle-quiescence stays exit 0 (the designed completion signal for snapshotting a live TUI).
  - New `_reap_pty_child()`: always terminates (SIGTERM → 2s grace → SIGKILL) and blocking-reaps a child that didn't exit on its own; also fixes the `WNOHANG` race that could lose a just-exited child's real non-zero status, and decodes signal deaths as 128+N.
- **Tests** (`tests/unit/test_claude_bg_run.py`):
  - 5 regression tests: stale-name no-confirm, new-row-over-stale selection, timeout → 124 + kill, idle-quiescence → 0 + reap, child exit-code propagation. All verified to fail against the unfixed script.

## Validation
- [ ] **Run the unit suite**: Action: `python3 -m pytest tests/unit/test_claude_bg_run.py tests/unit/test_quest_runtime.py -q`. Expected: 34 + 41 passed, no hangs (a reap regression would hold the idle-quiescence test ~30s).
- [ ] **Prove the tests bite**: Action: `git stash push scripts/claude_bg_run.py && python3 -m pytest tests/unit/test_claude_bg_run.py -q -k "stale_same_name or total_timeout or child_exit_code"; git stash pop`. Expected: 3 failed against the unfixed script, then restored.
- [ ] **PTY firewall demo**: Action: `python3 scripts/claude_bg_run.py --self-test`. Expected: `pty exit=0`, distilled signal `'HELLO clean'`, `PASS`.

Watch for: `pty_capture` exit-code semantics changed (timeout now 124, signal deaths 128+N) — no in-repo callers rely on the old behavior, but downstream vendored copies calling it directly should re-check assumptions on the next version bump.

## Notes
- Downstream (sketch2md) closes its Codex findings by pulling this via version bump + re-checksum; hand-patching the vendored copy would desync `.quest-checksums`.
- Idle-timeout truncation is intentionally still exit 0: it is how the attach responder snapshots a persistent TUI that never exits on its own. Only the child leak and the total-timeout-as-success were defects.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Fable 5 &lt;noreply@anthropic.com&gt;
Co-Authored-By: Codex &lt;noreply@openai.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

