### PR TITLE
Make manifest validation safe for consumer repositories

### DIFF
--- a/.github/workflows/validate-quest-config.yml
+++ b/.github/workflows/validate-quest-config.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Validate manifest completeness
         run: |
           chmod +x scripts/quest_validate-manifest.sh
-          ./scripts/quest_validate-manifest.sh
+          ./scripts/quest_validate-manifest.sh --strict
 
       - name: Validate handoff contracts
         run: |

--- a/.skills/ci-code-reviewer/SKILL.md
+++ b/.skills/ci-code-reviewer/SKILL.md
@@ -9,8 +9,8 @@ Automated code review for CI pipelines. Designed to run inside GitHub Actions
 via `openai/codex-action`, producing a single structured PR comment.
 
 This skill extends `.skills/code-reviewer/SKILL.md` with CI-specific
-adaptations: no interactive prompts, PR description validation, manifest
-pre-checks, and concise output formatting for automated comments.
+adaptations: no interactive prompts, PR description validation, and concise
+output formatting for automated comments.
 
 At activation, announce the skill name and scope in one line. Example: `[ci-code-reviewer] reviewing PR #97`.
 
@@ -72,14 +72,6 @@ If neither condition is met:
 
 If description exists but is very thin (fewer than ~20 words, little context):
 - **Should fix**: "PR description is sparse. Add more context about purpose and approach."
-
-### Step 0.1: Manifest Validation (Mandatory)
-
-Run `bash scripts/quest_validate-manifest.sh`.
-
-- If it fails, flag **Must fix** with the failing file/path details.
-- If PR adds or renames files under Quest-managed paths, verify `.quest-manifest`
-  is updated in the diff.
 
 ### Step 0.5: Implementation Alignment
 
@@ -170,7 +162,6 @@ If acceptance criteria are available from Step 0.5:
 2. If missing, flag as **Must fix**.
 
 For workflow/config/skill-only changes, acceptable evidence can include:
-- `bash scripts/quest_validate-manifest.sh`
 - `./scripts/quest_validate-quest-config.sh`
 - Manual GitHub runtime verification steps when CI event behavior is required
 
@@ -195,7 +186,7 @@ Shell scripts:
 JSON/schema/config integrity:
 - Schema references and paths are valid
 - Config keys are spelled correctly and supported
-- New files are registered where required (`.quest-manifest`, skill index)
+- New skills are registered in the skill index where required
 
 Apply minimal diff principle: smallest correct change, no speculative refactors.
 

--- a/.skills/code-reviewer/SKILL.md
+++ b/.skills/code-reviewer/SKILL.md
@@ -72,10 +72,6 @@ If a code-specific issue is fixed before you comment, do **not** repost stale fe
 
 ## Review Process
 
-### Step 0: Manifest Validation
-
-Before reviewing code, run `scripts/quest_validate-manifest.sh` to check that all Quest files are listed in `.quest-manifest`. If validation fails, flag it as a **Must fix** — new or renamed files must be added to the manifest before merge.
-
 ### Step 1: Architecture Boundaries and Standards
 
 Enforce boundaries and conventions defined in:

--- a/.skills/git-commit-assistant/SKILL.md
+++ b/.skills/git-commit-assistant/SKILL.md
@@ -11,9 +11,8 @@ Generate a single commit message from the current staged diff. Output only the f
 
 ## Before Writing
 
-1. Run `scripts/quest_validate-manifest.sh` to check that all Quest files are listed in `.quest-manifest`. If validation fails, **stop and fix the manifest before proceeding**. Do not generate a commit message until validation passes.
-2. Run `git diff --cached` to see what actually changed.
-3. Run `git log --oneline` (or `git log --oneline -20`) to see existing commit style and conventions.
+1. Run `git diff --cached` to see what actually changed.
+2. Run `git log --oneline` (or `git log --oneline -20`) to see existing commit style and conventions.
 
 ---
 

--- a/docs/architecture/quest-install-posture.md
+++ b/docs/architecture/quest-install-posture.md
@@ -5,7 +5,7 @@ audience: Maintainers, contributors, and anyone setting up Quest in a project
 scope: Distribution and install topology only — not the runtime contract
 status: active
 owner: maintainers
-last_updated: 2026-05-26
+last_updated: 2026-07-11
 related:
   - docs/architecture/orchestration-runtime-v1.md
 ---
@@ -43,6 +43,11 @@ cd /path/to/your/repo
 It honours `.quest-manifest` categories (`copy-as-is`,
 `user-customized`, `merge-carefully`), self-updates, and can target a
 branch. Updating means re-running it.
+
+The manifest is an inventory of files managed by the Quest installer, not an
+allowlist for the project's tooling namespaces. Unlisted files under shared
+locations such as `.ai/`, `.skills/`, `.agents/`, and `.claude/` remain
+host-owned. Their location alone never transfers ownership to Quest.
 
 **Strengths**
 - Self-contained: works offline after install; CI can run Quest with no
@@ -88,6 +93,24 @@ up by host-specific means:
 - No one-command setup; the mechanism is host-specific.
 - Harder for offline/air-gapped projects and for forks that need
   customization the canonical install shouldn't carry.
+
+Outside-in operation does not make the target repository part of Quest's
+source distribution. Generic commit and review work runs against the target's
+own code and conventions; it does not apply canonical Quest source-completeness
+checks to target files.
+
+## Manifest validation by topology
+
+`scripts/quest_validate-manifest.sh` defaults to installed/consumer mode. It
+validates the inventory already declared in `.quest-manifest`, including stale
+or forbidden entries, while leaving unlisted host files alone. `--installed`
+selects the same behavior explicitly.
+
+`--strict` is for maintainers validating the canonical Quest source checkout
+and for Quest's own CI. It scans the source distribution patterns for omitted
+Quest-owned files. Do not run strict distribution validation as a generic
+commit or review gate in a vendored consumer repo or against an outside-in
+target, and do not add host-owned files to `.quest-manifest` to satisfy it.
 
 ---
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-07-11 | [host-safe-manifest-validation](host-safe-manifest-validation_2026-07-11.md) | Implement the Quest manifest-validation bugfix through the full Quest workflow. Quest is used in two supported topolo... |
 | 2026-07-04 | [bg-transport-hardening](bg-transport-hardening_2026-07-04.md) | implement ideas/2026-07-04-bg-transport-hardening-quest-brief.md The referenced brief (`ideas/2026-07-04-bg-transport... |
 | 2026-06-04 | [codex-subagent-dispatch-guardrails](codex-subagent-dispatch-guardrails_2026-06-04.md) | Fix Quest Codex-led role dispatch so Codex roles use local subagents, never Codex MCP. Context: In Codex-led Quest ru... |
 | 2026-05-31 | [pre-pr-sync](pre-pr-sync_2026-05-31.md) | implement using $quest ideas/2026-05-30-pre-pr-freshness-and-force-push-guard.md |

--- a/docs/quest-journal/celebrations/host-safe-manifest-validation_2026-07-11.md
+++ b/docs/quest-journal/celebrations/host-safe-manifest-validation_2026-07-11.md
@@ -1,0 +1,99 @@
+<!-- quest-id: host-safe-manifest-validation_2026-07-10__1602 -->
+<!-- style: celebration -->
+<!-- quality-tier: Gold -->
+<!-- date: 2026-07-11 -->
+<!-- journal: ../host-safe-manifest-validation_2026-07-11.md -->
+<!-- origin: step7-original -->
+
+# Quest Celebration: Host-safe manifest validation
+
+```text
+██╗  ██╗ ██████╗ ███████╗████████╗
+██║  ██║██╔═══██╗██╔════╝╚══██╔══╝
+███████║██║   ██║███████╗   ██║
+██╔══██║██║   ██║╚════██║   ██║
+██║  ██║╚██████╔╝███████║   ██║
+╚═╝  ╚═╝ ╚═════╝ ╚══════╝   ╚═╝
+
+███████╗ █████╗ ███████╗███████╗
+██╔════╝██╔══██╗██╔════╝██╔════╝
+███████╗███████║█████╗  █████╗
+╚════██║██╔══██║██╔══╝  ██╔══╝
+███████║██║  ██║██║     ███████╗
+╚══════╝╚═╝  ╚═╝╚═╝     ╚══════╝
+
+███╗   ███╗ █████╗ ███╗   ██╗██╗███████╗███████╗███████╗████████╗
+████╗ ████║██╔══██╗████╗  ██║██║██╔════╝██╔════╝██╔════╝╚══██╔══╝
+██╔████╔██║███████║██╔██╗ ██║██║█████╗  █████╗  ███████╗   ██║
+██║╚██╔╝██║██╔══██║██║╚██╗██║██║██╔══╝  ██╔══╝  ╚════██║   ██║
+██║ ╚═╝ ██║██║  ██║██║ ╚████║██║██║     ███████╗███████║   ██║
+╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═══╝╚═╝╚═╝     ╚══════╝╚══════╝   ╚═╝
+
+██╗   ██╗ █████╗ ██╗     ██╗██████╗
+██║   ██║██╔══██╗██║     ██║██╔══██╗
+██║   ██║███████║██║     ██║██║  ██║
+╚██╗ ██╔╝██╔══██║██║     ██║██║  ██║
+ ╚████╔╝ ██║  ██║███████╗██║██████╔╝
+  ╚═══╝  ╚═╝  ╚═╝╚══════╝╚═╝╚═════╝
+
+ █████╗ ████████╗██╗ ██████╗ ███╗   ██╗
+██╔══██╗╚══██╔══╝██║██╔═══██╗████╗  ██║
+███████║   ██║   ██║██║   ██║██╔██╗ ██║
+██╔══██║   ██║   ██║██║   ██║██║╚██╗██║
+██║  ██║   ██║   ██║╚██████╔╝██║ ╚████║
+╚═╝  ╚═╝   ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+```
+
+---
+
+## What Started This
+
+Implement the Quest manifest-validation bugfix through the full Quest workflow.
+
+## Starring Cast
+
+- **arbiter** ........ The Judge
+- **builder** ........ The Implementer
+
+## Achievements
+
+- [BUG] **Gremlin Slayer** — Tackled 5 review findings
+- [TEST] **Battle Tested** — Survived 4 reviews
+- [PLAN] **Plan Perfectionist** — Iterated plan 2 times
+- [WIN] **Quest Complete** — All phases finished successfully
+
+## Impact Metrics
+
+- Review findings addressed: **5**
+- Review rounds completed: **4**
+- Plan iterations: **2**
+- Fix iterations: **0**
+
+## Handoff & Reliability
+
+- Handoffs parsed: 2
+- Reviewer handoffs: 0
+- Fixer handoffs: 0
+- Review findings tracked: 5
+- Reliability signal: high
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## 🥇 Quality Tier: Gold
+
+QUALITY SCORE
+----------------------------------------
+  [██████████████████░░] 90% (Grade: A)
+
+
+## Quest Quote
+
+> "[1] Should fix - `plan.md:Step 1 and Acceptance criterion 7` - The acceptance criterion preserves both `QUEST_MANIFEST_STRICT=0|1`, but the explicit test instruction names only `=1`. Add a small `QUEST_MANIFEST_STRICT=0` assertion in the realistic fixture, ideally with an unmanifested source-pattern host file present, so the test proves the explicit consumer-safe override remains non-strict. This is bounded test detail; the intended behavior and precedence are already clear enough to build."
+>
+> — Review finding
+
+## Victory Narrative
+
+Implement the Quest manifest-validation bugfix through the full Quest workflow. The quest finished with 2 plan iteration(s), 0 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/host-safe-manifest-validation_2026-07-11.md
+++ b/docs/quest-journal/host-safe-manifest-validation_2026-07-11.md
@@ -1,0 +1,145 @@
+# Quest Journal: Host-safe manifest validation
+
+- Quest ID: `host-safe-manifest-validation_2026-07-10__1602`
+- Slug: host-safe-manifest-validation
+- Completed: 2026-07-11
+- Mode: workflow
+- Quality: Gold
+- Celebration: [`celebrations/host-safe-manifest-validation_2026-07-11.md`](celebrations/host-safe-manifest-validation_2026-07-11.md)
+- Outcome: Implement the Quest manifest-validation bugfix through the full Quest workflow. Quest is used in two supported topologies: 1. Installed into a consumer repository, where Quest runtime files coexist...
+
+## What Shipped
+
+**Problem:** The generic commit and review skills run Quest distribution validation against their current repository. The validator also infers strict Quest-source mode from `scripts/quest_installer.sh`, even though real consumer installs contain that script. Host-owned files in shared `.ai/`, `....
+
+## Files Changed
+
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_01_plan/plan.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_01_plan/review_findings.json.next`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_02_implementation/pr_description.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_03_review/review_code-reviewer-a.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_03_review/review_findings_code-reviewer-a.json`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_03_review/review_code-reviewer-b.md`
+- `.quest/host-safe-manifest-validation_2026-07-10__1602/phase_03_review/review_findings_code-reviewer-b.json`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 0
+
+## Agents
+
+- **The Judge** (arbiter):
+- **The Implementer** (builder):
+
+## Quest Brief
+
+Implement the Quest manifest-validation bugfix through the full Quest workflow.
+
+Quest is used in two supported topologies:
+
+1. Installed into a consumer repository, where Quest runtime files coexist with
+   host-owned `.ai/`, `.skills/`, `.agents/`, `.claude/`, documentation, and
+   other extensions.
+2. Outside-in, where a canonical Quest installation acts on another repository
+   and must not impose Quest-source packaging rules on that target.
+
+In both topologies, Quest must be helpful and respectful of repository content
+it does not own. A host file is not Quest-owned merely because it lives under a
+shared extension namespace.
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- Full celebration: [`celebrations/host-safe-manifest-validation_2026-07-11.md`](celebrations/host-safe-manifest-validation_2026-07-11.md)
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/host-safe-manifest-validation_2026-07-11.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "claude_transport_counts": {
+    "background-agent": 3
+  },
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 5 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 4 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review rounds: 4"
+    },
+    {
+      "icon": "🚌",
+      "label": "Claude transport: background-agent ×3"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 11
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/deterministic-json-orchestration-overrides.md
+++ b/ideas/deterministic-json-orchestration-overrides.md
@@ -1,0 +1,85 @@
+---
+title: Deterministic JSON orchestration overrides
+status: idea
+owner: maintainers
+origin: host-safe-manifest-validation Quest startup discussion
+---
+
+# Deterministic JSON orchestration overrides
+
+## Problem
+
+Quest's per-run orchestration chooser accepts comma-separated `role=model`
+pairs. The canonical Python helper already parses that format deterministically,
+but the chooser instructions do not require the orchestrator to call the helper.
+An orchestrator may therefore reproduce the prose contract itself, reject an
+otherwise natural JSON `models` block, or drift from the tested behavior.
+
+## Recommended direction
+
+Keep the conversational chooser in the Quest skill, but make input parsing and
+validation deterministic.
+
+1. Add a single parser such as `parse_override_input(text)` in
+   `scripts/quest_runtime/orchestration.py`.
+2. Preserve the current comma-separated format:
+
+   ```text
+   planner=gpt-5.6-sol, builder=gpt-5.6-terra
+   ```
+
+3. Also accept valid JSON in either of these forms:
+
+   ```json
+   {
+     "planner": "gpt-5.6-sol",
+     "builder": "gpt-5.6-terra"
+   }
+   ```
+
+   ```json
+   {
+     "models": {
+       "planner": "gpt-5.6-sol",
+       "builder": "gpt-5.6-terra"
+     }
+   }
+   ```
+
+4. Normalize both formats into the existing `Override` representation, then
+   reuse the canonical-role, solo-unused-role, model-availability, retry, and
+   orchestration-writing rules.
+5. Keep `parse_override_line()` as a compatibility wrapper if callers rely on
+   it.
+6. Provide a small stable CLI/entrypoint and require the Quest chooser to call
+   it, so parsing is actually code-driven rather than merely described in
+   Markdown.
+7. Update the chooser prompt to show both supported formats.
+
+## Validation and errors
+
+- Reject unknown roles, duplicate roles, non-string or empty model values,
+  malformed JSON, and unsupported top-level fields with specific messages.
+- Treat partial mappings as partial overrides over the existing defaults.
+- Ensure JSON and `role=model` inputs normalize to identical override lists and
+  produce identical `orchestration.json` output.
+- Preserve the existing three-attempt contract and availability checks.
+- If a user submits a fragment such as `"models": {...}` without outer braces,
+  return a clear instruction to wrap it in `{}` rather than adding a third
+  JSON-like grammar.
+
+## Scope boundary
+
+This should be implemented as a separate Quest. It changes orchestration input
+parsing, startup instructions, CLI behavior, and tests; it is intentionally not
+part of the host-safe manifest-validation fix.
+
+## Alternatives considered
+
+- **Instruction-only JSON detection:** smallest change, but not reliably
+  testable and repeats the drift that exposed this issue.
+- **Fully code-driven interactive chooser:** deterministic but unnecessarily
+  broad; it would need to own prompting, preflight state, retries, and artifact
+  writing.
+- **Deterministic parser with instructional UI:** preferred balance of KISS,
+  testability, compatibility, and maintainable ownership.

--- a/scripts/quest_validate-manifest.sh
+++ b/scripts/quest_validate-manifest.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 #
-# Validates that .quest-manifest includes all installer-managed Quest files
-# Fails if shipped Quest files are missing from the manifest
+# Validates Quest's declared installer inventory. Source-distribution
+# completeness is an explicit maintainer check, never inferred from repo files.
 #
 
 set -e
 
 MANIFEST=".quest-manifest"
 ERRORS=0
-STRICT_MODE="${QUEST_MANIFEST_STRICT:-auto}"
+STRICT_MODE="${QUEST_MANIFEST_STRICT:-0}"
 
 case "${1:-}" in
   "")
@@ -26,11 +26,12 @@ Usage: scripts/quest_validate-manifest.sh [--strict|--installed]
 Validates .quest-manifest.
 
 Modes:
-  --strict     Also scan Quest source paths for files missing from the manifest.
-  --installed  Validate only manifest entries; allow repo-local custom files.
+  --strict     Source-maintainer mode: scan canonical Quest source paths.
+  --installed  Consumer mode: validate declared inventory only.
 
-Default mode is auto: strict when scripts/quest_installer.sh exists, installed
-otherwise. Set QUEST_MANIFEST_STRICT=1 or 0 to override auto mode.
+Default mode is consumer-safe and equivalent to --installed. Shared namespaces
+may contain host-owned files that do not belong in .quest-manifest. Set
+QUEST_MANIFEST_STRICT=1 or 0 to explicitly select a mode without a flag.
 EOF
     exit 0
     ;;
@@ -40,14 +41,6 @@ EOF
     exit 2
     ;;
 esac
-
-if [ "$STRICT_MODE" = "auto" ]; then
-  if [ -f "scripts/quest_installer.sh" ]; then
-    STRICT_MODE=1
-  else
-    STRICT_MODE=0
-  fi
-fi
 
 # Colors
 RED=$'\033[0;31m'
@@ -123,25 +116,23 @@ EXPECTED_PATTERNS=(
   "scripts/quest_runtime/*.py"
 )
 
-# Find all files matching our patterns
-# Prune nested git worktrees so their files do not masquerade as repo content.
-FOUND_FILES=""
-for pattern in "${EXPECTED_PATTERNS[@]}"; do
-  # Use find with -path to handle glob patterns
-  matches=$(find . \
-    -type d \( -path './.claude/worktrees' -o -path './.worktrees' -o -path './.git' \) -prune -o \
-    -path "./$pattern" -type f -print 2>/dev/null | sed 's|^\./||' || true)
-  if [ -n "$matches" ]; then
-    FOUND_FILES="$FOUND_FILES"$'\n'"$matches"
-  fi
-done
-
-# Clean up and sort
-FOUND_FILES=$(echo "$FOUND_FILES" | grep -v '^$' | sort | uniq)
-
 if [ "$STRICT_MODE" = "1" ]; then
+  # Find canonical Quest source files only when a maintainer explicitly asks
+  # for distribution completeness. Prune nested git worktrees so their files
+  # do not masquerade as source-repository content.
+  FOUND_FILES=""
+  for pattern in "${EXPECTED_PATTERNS[@]}"; do
+    matches=$(find . \
+      -type d \( -path './.claude/worktrees' -o -path './.worktrees' -o -path './.git' \) -prune -o \
+      -path "./$pattern" -type f -print 2>/dev/null | sed 's|^\./||' || true)
+    if [ -n "$matches" ]; then
+      FOUND_FILES="$FOUND_FILES"$'\n'"$matches"
+    fi
+  done
+  FOUND_FILES=$(echo "$FOUND_FILES" | grep -v '^$' | sort | uniq)
+
   # Check each found file is in the manifest
-  echo "Checking Quest files are listed in $MANIFEST..."
+  echo "Quest source-maintainer mode: checking shipped files are listed in $MANIFEST..."
   echo ""
 
   MISSING_FILES=""
@@ -162,7 +153,8 @@ if [ "$STRICT_MODE" = "1" ]; then
       echo "  - $f"
     done
     echo ""
-    echo "Please add these files to the appropriate section in .quest-manifest"
+    echo "Quest maintainers should add only Quest-owned files intended for distribution."
+    echo "Consumers must not add host-owned files to .quest-manifest; use the default or --installed mode."
     echo ""
     echo "Sections:"
     echo "  [copy-as-is]       - Files replaced with upstream (most files)"
@@ -172,9 +164,9 @@ if [ "$STRICT_MODE" = "1" ]; then
     exit 1
   fi
 
-  log_ok "All Quest files are listed in .quest-manifest"
+  log_ok "All Quest-owned shipped files are listed in .quest-manifest"
 else
-  log_ok "Installed repo mode: allowing repo-local files outside .quest-manifest"
+  log_ok "Installed repo mode: validating declared inventory and allowing host-owned files outside .quest-manifest"
 fi
 
 # Also check for stale entries (files in manifest that don't exist)

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -1407,25 +1407,42 @@ test_manifest_excludes_repo_tests() {
   ! grep -q '^tests/' "$MANIFEST_FILE"
 }
 
-test_manifest_validator_allows_custom_skills_in_installed_mode() {
+test_manifest_validator_defaults_to_installed_inventory_with_host_extensions() {
   local tmpdir
   tmpdir=$(mktemp -d)
   (
     cd "$tmpdir" || exit 1
-    mkdir -p scripts .skills/prepare-mcp-quest
+    mkdir -p scripts .ai .skills/engineering-throughput-spreadsheet
     cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    cp "$REPO_ROOT/scripts/quest_installer.sh" scripts/quest_installer.sh
     cat > .quest-manifest <<'EOF'
 [copy-as-is]
+.quest-manifest
+.quest-checksums
+.quest-version
 scripts/quest_validate-manifest.sh
+scripts/quest_installer.sh
 
 [directories]
 .quest
 EOF
-    printf '# local custom skill\n' > .skills/prepare-mcp-quest/SKILL.md
+    printf '# representative installed checksums\n' > .quest-checksums
+    printf 'test-version\n' > .quest-version
+    printf '# host context digest\n' > .ai/context_digest.md
+    printf '# host spreadsheet skill\n' > .skills/engineering-throughput-spreadsheet/SKILL.md
 
-    bash scripts/quest_validate-manifest.sh > output.txt 2>&1 &&
-      grep -q 'Installed repo mode' output.txt &&
-      ! grep -q 'prepare-mcp-quest' output.txt
+    bash scripts/quest_validate-manifest.sh > default-output.txt 2>&1 &&
+      bash scripts/quest_validate-manifest.sh --installed > installed-output.txt 2>&1 &&
+      QUEST_MANIFEST_STRICT=0 bash scripts/quest_validate-manifest.sh > env-installed-output.txt 2>&1 &&
+      grep -q 'Installed repo mode' default-output.txt &&
+      grep -q 'Installed repo mode' installed-output.txt &&
+      grep -q 'Installed repo mode' env-installed-output.txt &&
+      ! grep -q 'context_digest.md' default-output.txt &&
+      ! grep -q 'engineering-throughput-spreadsheet' default-output.txt &&
+      ! grep -q 'context_digest.md' installed-output.txt &&
+      ! grep -q 'engineering-throughput-spreadsheet' installed-output.txt &&
+      ! grep -q 'context_digest.md' env-installed-output.txt &&
+      ! grep -q 'engineering-throughput-spreadsheet' env-installed-output.txt
   )
   local rc=$?
   rm -rf "$tmpdir"
@@ -1448,14 +1465,39 @@ scripts/quest_validate-manifest.sh
 EOF
     printf '# local custom skill\n' > .skills/prepare-mcp-quest/SKILL.md
 
-    if QUEST_MANIFEST_STRICT=1 bash scripts/quest_validate-manifest.sh > output.txt 2>&1; then
+    if bash scripts/quest_validate-manifest.sh --strict > output.txt 2>&1; then
       exit 1
     fi
-    grep -q '.skills/prepare-mcp-quest/SKILL.md' output.txt
+    grep -q '.skills/prepare-mcp-quest/SKILL.md' output.txt &&
+      grep -q 'Quest source-maintainer mode' output.txt &&
+      grep -q 'only Quest-owned files intended for distribution' output.txt &&
+      grep -q 'Consumers must not add host-owned files' output.txt &&
+      ! grep -q 'Please add these files' output.txt &&
+      if QUEST_MANIFEST_STRICT=1 bash scripts/quest_validate-manifest.sh > env-output.txt 2>&1; then
+        exit 1
+      fi &&
+      grep -q '.skills/prepare-mcp-quest/SKILL.md' env-output.txt
   )
   local rc=$?
   rm -rf "$tmpdir"
   return $rc
+}
+
+test_generic_commit_and_review_skills_do_not_gate_on_manifest_validation() {
+  local skill
+  for skill in \
+    "$REPO_ROOT/.skills/git-commit-assistant/SKILL.md" \
+    "$REPO_ROOT/.skills/code-reviewer/SKILL.md" \
+    "$REPO_ROOT/.skills/ci-code-reviewer/SKILL.md"; do
+    if grep -q 'quest_validate-manifest.sh' "$skill"; then
+      return 1
+    fi
+  done
+}
+
+test_quest_source_ci_requests_strict_manifest_validation() {
+  grep -Eq 'quest_validate-manifest\.sh[[:space:]]+--strict' \
+    "$REPO_ROOT/.github/workflows/validate-quest-config.yml"
 }
 
 test_manifest_validator_rejects_unknown_option() {
@@ -1500,6 +1542,27 @@ EOF
     fi
     grep -q "Repo tests do not belong in .quest-manifest or the Quest installer" output.txt &&
       grep -q "tests/integration/test-enforce-allowlist.sh" output.txt
+  )
+  local rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
+test_manifest_validator_reports_stale_declared_entries() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  (
+    cd "$tmpdir" || exit 1
+    mkdir -p scripts
+    cp "$REPO_ROOT/scripts/quest_validate-manifest.sh" scripts/quest_validate-manifest.sh
+    cat > .quest-manifest <<'EOF'
+[copy-as-is]
+scripts/quest_validate-manifest.sh
+scripts/missing-managed-file.py
+EOF
+
+    bash scripts/quest_validate-manifest.sh > output.txt 2>&1 &&
+      grep -q 'Stale entry (file not found): scripts/missing-managed-file.py' output.txt
   )
   local rc=$?
   rm -rf "$tmpdir"
@@ -2116,10 +2179,13 @@ run_test test_installer_preserves_modified_untracked_legacy_installed_test
 run_test test_installer_preserves_unowned_source_only_test_path
 run_test test_manifest_lists_prefixed_scripts
 run_test test_manifest_excludes_repo_tests
-run_test test_manifest_validator_allows_custom_skills_in_installed_mode
+run_test test_manifest_validator_defaults_to_installed_inventory_with_host_extensions
 run_test test_manifest_validator_strict_mode_catches_unmanifested_skills
 run_test test_manifest_validator_rejects_unknown_option
 run_test test_manifest_validator_rejects_test_paths
+run_test test_manifest_validator_reports_stale_declared_entries
+run_test test_generic_commit_and_review_skills_do_not_gate_on_manifest_validation
+run_test test_quest_source_ci_requests_strict_manifest_validation
 run_test test_validation_hook_script_accepts_legacy_symlink_target
 run_test test_quest_claude_runner_polls_handoff_and_logs_runtime
 run_test test_quest_claude_probe_requires_real_artifacts

--- a/tests/unit/test_quest_checks_cli.py
+++ b/tests/unit/test_quest_checks_cli.py
@@ -51,6 +51,15 @@ def test_cli_main_runs_all_installed_commands(monkeypatch: pytest.MonkeyPatch) -
     assert all(cwd == module.REPO_ROOT and check is False for _, cwd, check in calls)
 
 
+def test_cli_uses_consumer_safe_default_manifest_validation() -> None:
+    module = _load_cli_module()
+    manifest_commands = [
+        command for label, command in module.COMMANDS if label == "validate manifest"
+    ]
+
+    assert manifest_commands == [["bash", "scripts/quest_validate-manifest.sh"]]
+
+
 def test_cli_entrypoint_executes_main(monkeypatch: pytest.MonkeyPatch) -> None:
     script_path = _repo_root() / "scripts" / "quest_checks" / "cli.py"
     calls: list[tuple[list[str], Path, bool]] = []


### PR DESCRIPTION
## ⭐ Why this matters

Quest no longer treats host-owned files in shared tooling namespaces as part of its own distribution. Consumer repositories can extend `.ai/`, `.skills/`, `.agents/`, and `.claude/` freely, while Quest’s canonical source checkout remains protected by explicit strict validation in CI.

---

## Summary

Make manifest validation consumer-safe by default, reserve source completeness for explicit `--strict` calls, and remove distribution checks from generic commit and review workflows.

- Preserve declared-inventory checks for installed repositories.
- Document the same ownership boundary for vendored and outside-in operation.

## Changes

- **Manifest behavior**:
  - Default no-argument validation now behaves like `--installed` and never infers ownership from `scripts/quest_installer.sh` or directory location.
  - Source-pattern scanning runs only for `--strict` or `QUEST_MANIFEST_STRICT=1`.
  - Strict diagnostics identify source-maintainer mode and explicitly warn consumers not to add host-owned files to `.quest-manifest`.
- **Commit and review skills**:
  - Removed the universal manifest prerequisite from `git-commit-assistant`, `code-reviewer`, and `ci-code-reviewer`.
  - Kept their normal diff, architecture, correctness, security, and test-review responsibilities unchanged.
- **CI and documentation**:
  - Quest source CI now invokes `scripts/quest_validate-manifest.sh --strict`.
  - `quest-install-posture.md` defines manifest ownership for vendored and outside-in use.
  - Added the completed Quest journal and recorded deterministic JSON orchestration overrides as a separate follow-up.
- **Regression coverage**:
  - Added a realistic installed fixture containing the installer, inventory metadata, and the two reported host-owned extension files.
  - Added contracts for explicit strict failures, environment overrides, stale entries, generic skill behavior, source CI, and the installed checks CLI.

## Validation

- [x] Run `bash tests/test-quest-runtime.sh`; expect all 50 runtime and installer checks to pass.
- [x] Run `python3 -m pytest tests/unit/test_quest_manifest.py tests/unit/test_quest_checks_cli.py -q`; expect all 8 focused checks to pass.
- [x] Run `scripts/quest_validate-manifest.sh --strict && scripts/quest_validate-manifest.sh`; expect source completeness followed by consumer-safe inventory validation, both with no stale entries.
- [x] Run `./scripts/quest_validate-quest-config.sh && git diff --check`; expect configuration and whitespace validation to pass.

Watch for: consumer repositories should not add unrelated host files to `.quest-manifest`; canonical Quest source checks must continue to request `--strict` explicitly.

## Notes

- `.quest-checksums` is intentionally unchanged; it remains installer-managed local baseline data.
- JSON model-override implementation remains a separate follow-up; this PR records the design idea only.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: GPT-5.6 Sol &lt;noreply@openai.com&gt;
Co-Authored-By: GPT-5.6 Terra &lt;noreply@openai.com&gt;
Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

