### PR TITLE
Clarify Quest orchestration default choice

### DIFF
--- a/.quest-checksums
+++ b/.quest-checksums
@@ -51,7 +51,7 @@ d8aa0b101a64b82d0c440a35bb306c0b37258ed8e2744b1e7281070e513f408d  .skills/plan-m
 3fac0c21f5dfd84b5d84886302b389a7a048404b1bbd59b2224e971b4f8fb714  .skills/plan-reviewer/SKILL.md
 82b2fdc3ffc5053cd897276567a87ced79bc1902c713faaef449546364389b2d  .skills/pr-assistant/SKILL.md
 bbfea008c4cadcb650d72b2d981b7ef67305082cf94ae227a22ebeb03d9a8f2a  .skills/pr-shepherd/SKILL.md
-068822b36a32a2a945e646edc204920e82ad8374b8b63dcae63a19473852778a  .skills/quest/SKILL.md
+06cac077637aacb9dbb588393a81fc74e23b8605f3887eacef6fb8b263286238  .skills/quest/SKILL.md
 e1cef5bb261421226a8007f88aab5cac0295b16f4044735856305c155a952376  .skills/quest/agents/README.md
 69e5a590f02e66343efdfb2a8ba1090e32d3b5bbe56cf2151093b280138dc013  .skills/quest/agents/arbiter.md
 fa697c7d98bd24beab4629689e566982756e6455402360a2dc6e1dc7ec5e75b0  .skills/quest/agents/builder.md

--- a/.skills/quest/SKILL.md
+++ b/.skills/quest/SKILL.md
@@ -223,10 +223,10 @@ Before creating the quest folder, present the routing classification to the user
      review-arbiter    <model>  (unused in this mode)   [solo only]
      fixer             <model>
 
-   Customize for this quest only? [y/N]
+   Use these defaults? [Y/n]
    ```
 
-   **On N (default; single Enter):** before writing, validate every active-role model from the expanded default block against the Step 2b preflight result using the same availability rules as overrides below. If Step 2b was healthy, reject any unavailable active-role model as malformed config and stop before dispatch. If the user explicitly chose the single-model continuation after Step 2b failed, remap unavailable active-role models to this orchestrator's native runtime (`claude` for Claude-led sessions, `gpt-5.6-sol` for Codex-led sessions) before writing so `orchestration.json` only contains runnable active-role assignments. Then write `.quest/<id>/orchestration.json` with:
+   **On Y (default; single Enter):** before writing, validate every active-role model from the expanded default block against the Step 2b preflight result using the same availability rules as overrides below. If Step 2b was healthy, reject any unavailable active-role model as malformed config and stop before dispatch. If the user explicitly chose the single-model continuation after Step 2b failed, remap unavailable active-role models to this orchestrator's native runtime (`claude` for Claude-led sessions, `gpt-5.6-sol` for Codex-led sessions) before writing so `orchestration.json` only contains runnable active-role assignments. Then write `.quest/<id>/orchestration.json` with:
    - `version: 1`
    - `models`: `.ai/allowlist.json` `.models` expanded to all 9 canonical keys by `quest_runtime.orchestration.build_default_models`; omitted keys use the shipped `DEFAULT_MODELS` fallback from that module. The allowlist is the repo-configured startup default; do not restate the literal fallback matrix in this procedural skill.
    - `claude_role_transport`: the transport policy selected in Step 2b — `"bridge"` when the user explicitly chose the bridge option (including a per-run `QUEST_CLAUDE_ROLE_TRANSPORT=bridge` selection that was not written to `.ai/allowlist.json`), otherwise from `.ai/allowlist.json` (default `"auto"`). Persist the resolved opt-in so a bridge choice survives resume; never record `"auto"` alongside `claude_transport_resolved: "bridge"`.
@@ -236,7 +236,7 @@ Before creating the quest folder, present the routing classification to the user
    - `overridden_roles: []`
    - `preflight_validated_at: <ISO8601 now>`
 
-   **On Y:** present the shorthand override prompt:
+   **On N:** present the shorthand override prompt:
 
    ```
    Enter overrides as comma-separated role=model pairs or a JSON models object.
@@ -244,10 +244,12 @@ Before creating the quest folder, present the routing classification to the user
    Models: any model name your preflight reports as available (e.g., claude, gpt-5.6-sol, gpt-5.6-terra)
    Pair example: planner=gpt-5.6-sol, builder=claude-opus-4-8
    JSON example: {"models":{"planner":"gpt-5.6-sol","builder":"claude-opus-4-8"}}
-   (empty input = no overrides, equivalent to N)
+   (empty input = no overrides, equivalent to Y)
 
    Overrides:
    ```
+
+   If the override submission is empty after trimming, follow the **On Y** default writer above. Do not write `source: "overridden"`, do not add `overridden_roles`, and do not count the empty submission as a rejected attempt.
 
    **Parse contract (each full override submission is one attempt; cap re-prompts at 3, abort on the 4th rejection):** Run `python3 scripts/quest_parse_overrides.py`, send the complete submission unchanged on stdin, and consume its JSON envelope. Exit `0` returns `{"ok": true, "overrides": [...]}`; exit `2` returns `{"ok": false, "error": "..."}` on stderr and counts as one rejected attempt. Do not manually parse or rewrite JSON into pairs. `quest_runtime.orchestration.parse_override_input` is the canonical API; `parse_override_line` remains a compatibility wrapper.
 
@@ -262,7 +264,7 @@ Before creating the quest folder, present the routing classification to the user
    Once all overrides pass validation, build the merged `models` block (the expanded startup block returned by `build_default_models`, overlaid with the validated overrides — `overridden_roles` excludes ignored-because-unused entries) and write `.quest/<id>/orchestration.json` with:
    - `version: 1`
    - `models`: merged block (all 9 keys present; unused-in-mode roles still carry the default value)
-   - `claude_role_transport` / `claude_transport_resolved`: same sourcing as the N path above; `claude_transport_downgraded: false` for compatibility
+   - `claude_role_transport` / `claude_transport_resolved`: same sourcing as the Y path above; `claude_transport_downgraded: false` for compatibility
    - `source: "overridden"`
    - `overridden_roles`: list of role names that were actually overridden
    - `preflight_validated_at: <ISO8601 now>`

--- a/tests/test-quest-orchestration.sh
+++ b/tests/test-quest-orchestration.sh
@@ -1007,6 +1007,24 @@ test_orchestration_docs_do_not_duplicate_model_defaults() {
   return 0
 }
 
+test_chooser_default_prompt_is_affirmative() {
+  local skill_md="$REPO_ROOT/.skills/quest/SKILL.md"
+
+  grep -Fq 'Use these defaults? [Y/n]' "$skill_md" || return 1
+  grep -Fq '**On Y (default; single Enter):**' "$skill_md" || return 1
+  grep -Fq '**On N:** present the shorthand override prompt:' "$skill_md" || return 1
+  grep -Fq '(empty input = no overrides, equivalent to Y)' "$skill_md" || return 1
+  grep -Fq 'follow the **On Y** default writer above' "$skill_md" || return 1
+  grep -Fq 'same sourcing as the Y path above' "$skill_md" || return 1
+  if grep -Fq 'same sourcing as the N path above' "$skill_md"; then
+    return 1
+  fi
+  if grep -Fq 'Customize for this quest only? [y/N]' "$skill_md"; then
+    return 1
+  fi
+  return 0
+}
+
 test_opencode_dispatch_uses_orchestration_json() {
   if grep -n 'For these roles, use `codex_codex`' "$OPENCODE_QUEST_MD"; then
     return 1
@@ -1057,6 +1075,7 @@ run_test test_workflow_dispatch_reads_orchestration_json_not_allowlist
 run_test test_workflow_no_allowlist_models_string
 run_test test_workflow_defaults_are_not_dispatch_fallbacks
 run_test test_orchestration_docs_do_not_duplicate_model_defaults
+run_test test_chooser_default_prompt_is_affirmative
 run_test test_opencode_dispatch_uses_orchestration_json
 
 echo ""


### PR DESCRIPTION
## ⭐ Why this matters

Quest should not ask whether to use defaults and then tell users to answer “N.” This makes the chooser affirmative and unambiguous: Y or Enter accepts defaults; N opens customization.

---

## Summary

Align the orchestration chooser question with its Y/N behavior and pin that contract against future wording drift.

## Changes

- **Quest chooser**:
  - Replace “Customize for this quest only? [y/N]” with “Use these defaults? [Y/n].”
  - Make Y/Enter the default path and N the customization path.
  - Align empty override input with the affirmative default path.
- **Tests**:
  - Add a focused prose-contract test covering the question and all response mappings.
- **Distribution**:
  - Refresh the managed skill checksum.

## Validation

- [x] `bash tests/test-quest-orchestration.sh` — 34/34 passed.
- [x] `bash scripts/quest_validate-manifest.sh --strict` — completed successfully.
- [x] `pytest -q tests/unit/test_check_quest_checksum_drift.py tests/unit/test_canonical_role_lockstep.py` — 12/12 passed.
- [x] `git diff --check` — passed.

## Notes

- The already-running Workstream A quest used the previous wording; this change applies to future chooser prompts.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

