### PR TITLE
Harden Quest runtime trust and state transitions

### DIFF
--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -4,7 +4,7 @@ When starting, say: "Now I understand the Quest." Then proceed directly with the
 
 Follow these steps in order. After each step that modifies state, update `.quest/<id>/state.json`.
 
-**State update helper:** Use `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition <phase> ...` for state mutations instead of hand-editing `state.json`. The `--transition` flag validates the transition against `quest_validate-quest-state.sh` before writing — if validation fails, state.json is not modified. Use `--phase` only for non-transition updates (e.g., setting status without changing phase). Add `--expect-phase <current>` for optimistic locking — the transition is rejected immediately if the on-disk phase doesn't match the expected value, preventing TOCTOU race conditions when multiple agents update state concurrently. **Recommended for all Codex-orchestrated transitions.**
+**State update helper:** Use `python3 scripts/quest_state.py --quest-dir .quest/<id> --transition <phase> ...` for state mutations instead of hand-editing `state.json`. The `--transition` flag validates the transition against `quest_validate-quest-state.sh` before writing — if validation fails, state.json is not modified. Use `--phase` only for non-transition updates (e.g., setting status without changing phase). Add `--expect-phase <current>` for concurrent transitions: validation runs outside the lock, then the final read, expected-phase check, mutation, and atomic replacement happen under the persistent sibling `state.json.lock`. **Recommended for all Codex-orchestrated transitions.**
 
 ### Defaults (Opinionated)
 
@@ -56,8 +56,9 @@ If the preflight result was already cached by SKILL.md Step 2b, use the cached v
 1. Run `scripts/quest_preflight.sh --orchestrator claude` and parse the JSON output.
 2. Cache the `available` field as `codex_available` (boolean) for the rest of the session.
 3. If `codex_available` is false:
-   - Log: `"Codex MCP not available — using Claude runtime fallback for all roles."`
-   - **Global rule:** Every Claude-led + Codex-runtime entrypoint in this workflow (Reviewer B slots, Builder, Fixer — any role) is replaced with the equivalent Claude runtime fallback for that role. Use the same prompt (minus the non-interactive rule), the same output file paths, and the same handoff contract. Do not retry Codex. Do not treat this as an error.
+   - Pause startup and surface the preflight `warning` lines. Do not remap roles automatically.
+   - Ask the human to choose one route: fix the Codex setup and rerun preflight successfully, explicitly continue Claude-only for this Quest, or cancel.
+   - Only an explicit `continue Claude-only` choice may remap Codex-designated roles to Claude. A failed fix attempt returns to the same decision point.
 
 **Codex-led sessions:**
 1. `codex_available` is always true (Codex is the active runtime — no MCP needed).

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -55,10 +55,11 @@ If the preflight result was already cached by SKILL.md Step 2b, use the cached v
 **Claude-led sessions:**
 1. Run `scripts/quest_preflight.sh --orchestrator claude` and parse the JSON output.
 2. Cache the `available` field as `codex_available` (boolean) for the rest of the session.
-3. If `codex_available` is false:
+3. If `codex_available` is false and the per-Quest orchestration still assigns an active role to Codex:
    - Pause startup and surface the preflight `warning` lines. Do not remap roles automatically.
    - Ask the human to choose one route: fix the Codex setup and rerun preflight successfully, explicitly continue Claude-only for this Quest, or cancel.
    - Only an explicit `continue Claude-only` choice may remap Codex-designated roles to Claude. A failed fix attempt returns to the same decision point.
+   - If SKILL.md Step 2b already recorded that explicit single-model choice and remapped every active role to Claude before writing `orchestration.json`, reuse that decision and do not prompt again.
 
 **Codex-led sessions:**
 1. `codex_available` is always true (Codex is the active runtime — no MCP needed).

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-07-11 | [runtime-trust-state-boundaries](runtime-trust-state-boundaries_2026-07-11.md) | Implement Workstream A — Runtime trust and state boundaries from `ideas/2026-07-11-quest-hardening.md`. Scope is stri... |
 | 2026-07-11 | [host-safe-manifest-validation](host-safe-manifest-validation_2026-07-11.md) | Implement the Quest manifest-validation bugfix through the full Quest workflow. Quest is used in two supported topolo... |
 | 2026-07-04 | [bg-transport-hardening](bg-transport-hardening_2026-07-04.md) | implement ideas/2026-07-04-bg-transport-hardening-quest-brief.md The referenced brief (`ideas/2026-07-04-bg-transport... |
 | 2026-06-04 | [codex-subagent-dispatch-guardrails](codex-subagent-dispatch-guardrails_2026-06-04.md) | Fix Quest Codex-led role dispatch so Codex roles use local subagents, never Codex MCP. Context: In Codex-led Quest ru... |

--- a/docs/quest-journal/celebrations/runtime-trust-state-boundaries_2026-07-11.md
+++ b/docs/quest-journal/celebrations/runtime-trust-state-boundaries_2026-07-11.md
@@ -1,0 +1,120 @@
+<!-- quest-id: runtime-trust-state-boundaries_2026-07-11__1425 -->
+<!-- style: celebration -->
+<!-- quality-tier: Gold -->
+<!-- date: 2026-07-11 -->
+<!-- journal: ../runtime-trust-state-boundaries_2026-07-11.md -->
+<!-- origin: step7-original -->
+
+# Quest Celebration: Quest brief: Runtime trust and state boundaries
+
+```text
+ ██████╗ ██╗   ██╗███████╗███████╗████████╗
+██╔═══██╗██║   ██║██╔════╝██╔════╝╚══██╔══╝
+██║   ██║██║   ██║█████╗  ███████╗   ██║
+██║▄▄ ██║██║   ██║██╔══╝  ╚════██║   ██║
+╚██████╔╝╚██████╔╝███████╗███████║   ██║
+ ╚══▀▀═╝  ╚═════╝ ╚══════╝╚══════╝   ╚═╝
+
+██████╗ ██████╗ ██╗███████╗███████╗
+██╔══██╗██╔══██╗██║██╔════╝██╔════╝
+██████╔╝██████╔╝██║█████╗  █████╗
+██╔══██╗██╔══██╗██║██╔══╝  ██╔══╝
+██████╔╝██║  ██║██║███████╗██║
+╚═════╝ ╚═╝  ╚═╝╚═╝╚══════╝╚═╝
+
+██████╗ ██╗   ██╗███╗   ██╗████████╗██╗███╗   ███╗███████╗
+██╔══██╗██║   ██║████╗  ██║╚══██╔══╝██║████╗ ████║██╔════╝
+██████╔╝██║   ██║██╔██╗ ██║   ██║   ██║██╔████╔██║█████╗
+██╔══██╗██║   ██║██║╚██╗██║   ██║   ██║██║╚██╔╝██║██╔══╝
+██║  ██║╚██████╔╝██║ ╚████║   ██║   ██║██║ ╚═╝ ██║███████╗
+╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝   ╚═╝   ╚═╝╚═╝     ╚═╝╚══════╝
+
+████████╗██████╗ ██╗   ██╗███████╗████████╗
+╚══██╔══╝██╔══██╗██║   ██║██╔════╝╚══██╔══╝
+   ██║   ██████╔╝██║   ██║███████╗   ██║
+   ██║   ██╔══██╗██║   ██║╚════██║   ██║
+   ██║   ██║  ██║╚██████╔╝███████║   ██║
+   ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚══════╝   ╚═╝
+
+ █████╗ ███╗   ██╗██████╗
+██╔══██╗████╗  ██║██╔══██╗
+███████║██╔██╗ ██║██║  ██║
+██╔══██║██║╚██╗██║██║  ██║
+██║  ██║██║ ╚████║██████╔╝
+╚═╝  ╚═╝╚═╝  ╚═══╝╚═════╝
+
+███████╗████████╗ █████╗ ████████╗███████╗
+██╔════╝╚══██╔══╝██╔══██╗╚══██╔══╝██╔════╝
+███████╗   ██║   ███████║   ██║   █████╗
+╚════██║   ██║   ██╔══██║   ██║   ██╔══╝
+███████║   ██║   ██║  ██║   ██║   ███████╗
+╚══════╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝   ╚══════╝
+
+██████╗  ██████╗ ██╗   ██╗███╗   ██╗
+██╔══██╗██╔═══██╗██║   ██║████╗  ██║
+██████╔╝██║   ██║██║   ██║██╔██╗ ██║
+██╔══██╗██║   ██║██║   ██║██║╚██╗██║
+██████╔╝╚██████╔╝╚██████╔╝██║ ╚████║
+╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝
+
+██████╗  █████╗ ██████╗ ██╗███████╗███████╗
+██╔══██╗██╔══██╗██╔══██╗██║██╔════╝██╔════╝
+██║  ██║███████║██████╔╝██║█████╗  ███████╗
+██║  ██║██╔══██║██╔══██╗██║██╔══╝  ╚════██║
+██████╔╝██║  ██║██║  ██║██║███████╗███████║
+╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝
+```
+
+---
+
+## What Started This
+
+Implement Workstream A — Runtime trust and state boundaries from ideas/2026-07-11-quest-hardening.md`.
+
+## Starring Cast
+
+- **arbiter** ........ The Judge
+- **builder** ........ The Implementer
+
+## Achievements
+
+- [BUG] **Gremlin Slayer** — Tackled 27 review findings
+- [TEST] **Battle Tested** — Survived 6 reviews
+- [PLAN] **Plan Perfectionist** — Iterated plan 2 times
+- [WIN] **Quest Complete** — All phases finished successfully
+
+## Impact Metrics
+
+- Review findings addressed: **27**
+- Review rounds completed: **6**
+- Plan iterations: **2**
+- Fix iterations: **1**
+
+## Handoff & Reliability
+
+- Handoffs parsed: 2
+- Reviewer handoffs: 0
+- Fixer handoffs: 0
+- Review findings tracked: 27
+- Reliability signal: high
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## 🥇 Quality Tier: Gold
+
+QUALITY SCORE
+----------------------------------------
+  [██████████████████░░] 90% (Grade: A)
+
+
+## Quest Quote
+
+> "Every claim is grounded in the actual source. I independently confirmed the four defects exist exactly as described: the basename-identity bug (`quest_allowlist_matcher.py:73-75`), the unlocked/non-atomic `write_state` + the second unlocked parked-clear write (`quest_runtime/state.py:25-38`, `quest_state.py:216-218`), the missing shape validation and `.get`-on-non-object crash path (`quest_runtime/state.py:20-22`, `quest_complete.py:468-480`), and the CLI∧MCP-only availability with `codex auth` wording under `set -euo pipefail` (`quest_preflight.sh:13, 246-306`)."
+>
+> — Review finding
+
+## Victory Narrative
+
+Implement Workstream A — Runtime trust and state boundaries from ideas/2026-07-11-quest-hardening.md`. The quest finished with 2 plan iteration(s), 1 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/runtime-trust-state-boundaries_2026-07-11.md
+++ b/docs/quest-journal/runtime-trust-state-boundaries_2026-07-11.md
@@ -12,9 +12,27 @@
 
 **Problem:** Four trust-boundary defects can falsely authorize an executable, falsely advertise an unauthenticated Codex runtime, pass structurally invalid persisted state to callers, or lose an expected-phase race between validation and writing.
 
-**Impact:** Command authorization will bind absol...
+**Impact:** Command authorization now binds absolute invocations to the PATH-resolved executable identity, Claude-led preflight distinguishes authenticated from merely installed Codex, malformed state fails at the shared boundary with readable CLI errors, and state writers serialize final read/check/mutate/replace operations.
 
 ## Files Changed
+
+### Shipped files
+
+- `.skills/quest/delegation/workflow.md`
+- `ideas/2026-07-11-quest-hardening.md`
+- `scripts/quest_allowlist_matcher.py`
+- `scripts/quest_preflight.sh`
+- `scripts/quest_runtime/state.py`
+- `scripts/quest_state.py`
+- `scripts/quest_complete.py`
+- `tests/unit/test_allowlist_matcher.py`
+- `tests/test-quest-preflight.sh`
+- `tests/unit/test_quest_dispatch_guardrails.py`
+- `tests/unit/test_quest_state.py`
+- `tests/unit/test_quest_complete.py`
+- `tests/integration/test-enforce-allowlist.sh`
+
+### Quest artifacts
 
 - `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/plan.md`
 - `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/arbiter_verdict.md.next`

--- a/docs/quest-journal/runtime-trust-state-boundaries_2026-07-11.md
+++ b/docs/quest-journal/runtime-trust-state-boundaries_2026-07-11.md
@@ -1,0 +1,166 @@
+# Quest Journal: Quest brief: Runtime trust and state boundaries
+
+- Quest ID: `runtime-trust-state-boundaries_2026-07-11__1425`
+- Slug: runtime-trust-state-boundaries
+- Completed: 2026-07-11
+- Mode: workflow
+- Quality: Gold
+- Celebration: [`celebrations/runtime-trust-state-boundaries_2026-07-11.md`](celebrations/runtime-trust-state-boundaries_2026-07-11.md)
+- Outcome: Implement Workstream A — Runtime trust and state boundaries from `ideas/2026-07-11-quest-hardening.md`. Scope is strictly original findings #1, #4, #18, and #22: - #4 Allowlist executable identity:...
+
+## What Shipped
+
+**Problem:** Four trust-boundary defects can falsely authorize an executable, falsely advertise an unauthenticated Codex runtime, pass structurally invalid persisted state to callers, or lose an expected-phase race between validation and writing.
+
+**Impact:** Command authorization will bind absol...
+
+## Files Changed
+
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/plan.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/review_findings.json.next`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_02_implementation/pr_description.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_03_review/review_code-reviewer-a.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_03_review/review_findings_code-reviewer-a.json`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_03_review/review_code-reviewer-b.md`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_03_review/review_findings_code-reviewer-b.json`
+- `.quest/runtime-trust-state-boundaries_2026-07-11__1425/phase_03_review/review_fix_feedback_discussion.md`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 1
+
+## Agents
+
+- **The Judge** (arbiter):
+- **The Implementer** (builder):
+
+## Quest Brief
+
+Implement Workstream A — Runtime trust and state boundaries from
+`ideas/2026-07-11-quest-hardening.md`.
+
+Scope is strictly original findings #1, #4, #18, and #22:
+
+- #4 Allowlist executable identity: prevent a bare allowlist entry such as `rg`
+  or `find` from approving an arbitrary absolute binary with the same basename.
+  Preserve legitimate PATH-resolved executables and explicitly allowlisted
+  absolute paths. Keep existing metacharacter, find-action, and rg preprocessor
+  protections.
+- #22 Codex authentication preflight: Claude-led preflight must report Codex
+  available only when the CLI is installed, MCP is registered, and a bounded
+  `codex login status` succeeds. Authentication failure must be reported as
+  unauthenticated, not as a generic preflight crash. Update stale login
+  remediation wording.
+- #18 State boundary validation: shared state loading must reject JSON whose
+  top-level value is not an object. `quest_complete.py` and state-transition
+  callers must return deterministic, readable failures for invalid JSON,
+  arrays/scalars, decoding failures, and I/O failures.
+- #1 Atomic expected-phase transitions: enforce `--expect-phase` inside a
+  per-state locked read/check/write transaction, use atomic replacement, and
+  include parked-session clearing in the same mutation. Do not introduce state
+  versions, a database, or a broader state framework.
+
+Follow the full Quest workflow and approval gates. Use an isolated worktree. Do
+not modify Candid Talent Edge.
+
+Before implementation begins, change Workstream A in
+`ideas/2026-07-11-quest-hardening.md` from `[todo]` to `[ongoing]`. Do not change
+Workstreams B or C.
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- Full celebration: [`celebrations/runtime-trust-state-boundaries_2026-07-11.md`](celebrations/runtime-trust-state-boundaries_2026-07-11.md)
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/runtime-trust-state-boundaries_2026-07-11.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge",
+      "transport": "background-agent"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "claude_transport_counts": {
+    "background-agent": 9
+  },
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 27 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 6 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review rounds: 6"
+    },
+    {
+      "icon": "🚌",
+      "label": "Claude transport: background-agent ×9"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 12
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -41,11 +41,16 @@ Completing this plan will:
 - preserve caller prompt and answer content across both Claude transports;
 - prevent PR-summary upserts from targeting comments owned by another actor;
 - remove obsolete configuration guidance; and
-- keep installed Quest documentation from linking into unowned or stale host files.
+- keep installed Quest documentation from linking into unowned or stale host files;
+  and
+- enforce consistent Python formatting in the Quest source repository without
+  imposing that tooling on repositories where Quest is installed.
 
 ### Scope boundaries
 
 In scope: original findings **#1, #3, #4, #9, #16, #17, #18, #20, and #22**.
+Also in scope as a repository-maintenance follow-up: source-repo-only Python
+format enforcement that is not distributed by the Quest installer.
 
 Out of scope:
 
@@ -58,18 +63,19 @@ Out of scope:
 
 ## PR strategy
 
-Use three independent PRs. A single PR would mix security-sensitive command
+Use four independent PRs. A single PR would mix security-sensitive command
 matching, concurrency, git behavior, Claude transport fidelity, PR-comment
-ownership, and installed documentation across too many review surfaces. Nine
-separate PRs would add ceremony without improving isolation. These three
-vertical slices balance reviewability and delivery speed and may proceed in
-parallel.
+ownership, installed documentation, and repository tooling across too many
+review surfaces. Nine separate finding-level PRs would add ceremony without
+improving isolation. These four vertical slices balance reviewability and
+delivery speed and may proceed in parallel.
 
 | Status | PR workstream | Original findings | Branch suggestion | PR |
 |---|---|---|---|---|
 | [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [todo] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | — |
 | [todo] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
+| [todo] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
 
 ## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
 
@@ -382,9 +388,76 @@ of host documentation.
   remaining link resolves.
 - **Observability:** installed file list and rendered Markdown links.
 
+## Workstream D — Source-repository Python formatting [todo]
+
+### Goal
+
+Keep Python formatting deterministic in the Quest source repository without
+installing or enforcing Black in consumer repositories.
+
+### Acceptance criteria
+
+1. Quest source uses one pinned Black configuration and passes
+   `python3 -m black --check .` in CI.
+2. A versioned, source-repo-only pre-commit hook provides the same check and a
+   clear remediation command without modifying files during `git commit`.
+3. The hook, formatter configuration, CI wiring, and formatter dependency are
+   not added to `.quest-manifest` or otherwise copied by `quest_installer.sh`.
+4. Existing Quest installation and update fixtures prove the installed file
+   surface is unchanged.
+
+### Implementation approach
+
+- Add the Black configuration to `/Users/kjell/ws/extra/quest/pyproject.toml`.
+- Add a pinned Black install and `python3 -m black --check .` to the Quest
+  repository's Python CI workflow.
+- Add a small `.githooks/pre-commit` check that developers may enable with
+  `git config core.hooksPath .githooks`. The hook must fail with the remediation
+  `python3 -m black .`; it must not rewrite files during a commit.
+- Keep `.githooks/`, `pyproject.toml`, and the source-repository CI workflow out
+  of `.quest-manifest`. Do not modify the installed
+  `scripts/quest_validate-quest-config.sh` hook to run Black.
+
+### Validation
+
+**Automated test — source formatting and installer isolation**
+
+- **Files:** `/Users/kjell/ws/extra/quest/.github/workflows/test-python.yml` and
+  the existing manifest/installer test modules.
+- **Tests:** run Black in check mode; assert the new repository-only hook and
+  formatter tooling are absent from the manifest and a clean installed fixture.
+- **Run:** `python3 -m black --check .` plus the focused manifest/installer tests.
+- **Mocking:** temporary installed-consumer filesystem only.
+- **Expected:** source formatting drift fails CI while the installed Quest file
+  surface and consumer development policy remain unchanged.
+
+### Integration touchpoints
+
+- **Developer commits:** local hooks are optional and bypassable, so CI remains
+  the authoritative formatting gate.
+- **Partially staged work:** check-only behavior avoids silently rewriting
+  unstaged files or creating index/worktree mismatches during commit.
+- **Installer ownership:** source-repository tooling must remain outside the
+  manifest-controlled consumer surface.
+
+### Manual validation
+
+**MANUAL TEST — local hook and clean consumer install**
+
+- **Why manual:** confirms the local Git hook experience and the absence of
+  repository-only tooling after installation.
+- **Preconditions:** Black installed in the Quest development environment and a
+  temporary clean consumer repository.
+- **Steps:** enable `.githooks`, attempt a commit with intentionally unformatted
+  Python, run the remediation, retry, then install Quest into the consumer.
+- **Expected:** the first commit is blocked with a clear command, the formatted
+  retry passes, and the consumer receives no Black hook or formatting policy.
+- **Observability:** hook output, CI result, manifest diff, and installed file
+  list.
+
 ## End-to-end validation
 
-After all three PRs exist, each PR must run its focused commands plus the relevant
+After all four PRs exist, each PR must run its focused commands plus the relevant
 repository gates. Before marking its workstream `[done]`, record the PR and verify
 that its description maps acceptance criteria to tests.
 
@@ -426,11 +499,11 @@ added for `quest_claude_bridge.py`.
 
 ## Dependencies and ordering
 
-- Workstreams A, B, and C are independent and may run in parallel.
+- Workstreams A, B, C, and D are independent and may run in parallel.
 - Within A, implement #18 before #1 so atomic mutation builds on a validated
   shared state boundary.
 - Within B, no finding depends on another; keep commits independently reviewable.
-- Archive this idea only after all three workstream rows have PR links and are
+- Archive this idea only after all four workstream rows have PR links and are
   marked `[done]`.
 
 ## Open questions

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -67,11 +67,11 @@ parallel.
 
 | Status | PR workstream | Original findings | Branch suggestion | PR |
 |---|---|---|---|---|
-| [todo] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | — |
+| [ongoing] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | — |
 | [todo] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | — |
 | [todo] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
 
-## Workstream A — Runtime trust and state boundaries [todo]
+## Workstream A — Runtime trust and state boundaries [ongoing]
 
 ### Goal
 
@@ -439,4 +439,3 @@ added for `quest_claude_bridge.py`.
   small standard-library file-lock helper is acceptable. If current platform
   support requires a different locking primitive, resolve that within Workstream
   A without expanding the state model.
-

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -67,11 +67,11 @@ parallel.
 
 | Status | PR workstream | Original findings | Branch suggestion | PR |
 |---|---|---|---|---|
-| [ongoing] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | — |
+| [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [todo] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | — |
 | [todo] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
 
-## Workstream A — Runtime trust and state boundaries [ongoing]
+## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
 
 ### Goal
 

--- a/scripts/quest_allowlist_matcher.py
+++ b/scripts/quest_allowlist_matcher.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import shlex
+import shutil
 import sys
 from pathlib import Path
 
@@ -72,7 +73,10 @@ def executable_token_matches(command_token: str, entry_token: str) -> bool:
         return False
     command_path = Path(command_token)
     if command_path.is_absolute():
-        return command_path.name == entry_token
+        resolved_entry = shutil.which(entry_token)
+        if resolved_entry is None:
+            return False
+        return command_path.resolve() == Path(resolved_entry).resolve()
     return False
 
 

--- a/scripts/quest_complete.py
+++ b/scripts/quest_complete.py
@@ -34,6 +34,7 @@ from quest_celebrate.quest_data import (
 from quest_celebrate.persist import CelebrationWriteResult, write_celebration_file
 from quest_runtime.claude_runner import sweep_left_survivor
 from quest_runtime.quest_ids import parse_quest_id
+from quest_runtime.state import StateError, load_state
 
 
 def _today() -> date:
@@ -465,11 +466,9 @@ def main() -> int:
         return 1
 
     try:
-        state = json.loads(state_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
-        print(
-            f"Error: could not read state.json in {quest_dir}: {exc}", file=sys.stderr
-        )
+        state = load_state(quest_dir)
+    except StateError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         return 1
     if state.get("status") != "complete":
         print(

--- a/scripts/quest_preflight.sh
+++ b/scripts/quest_preflight.sh
@@ -21,6 +21,10 @@ CACHE_TTL_SECONDS="${QUEST_PREFLIGHT_CACHE_TTL_SECONDS:-43200}"
 case "$CACHE_TTL_SECONDS" in
   ''|*[!0-9]*) CACHE_TTL_SECONDS=43200 ;;  # fallback on non-integer input
 esac
+CODEX_LOGIN_TIMEOUT_SECONDS="${QUEST_CODEX_LOGIN_TIMEOUT_SECONDS:-5}"
+case "$CODEX_LOGIN_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0) CODEX_LOGIN_TIMEOUT_SECONDS=5 ;;
+esac
 
 # Resolve THIS script's real directory so helper scripts are found regardless of
 # the caller's cwd. Quest may be installed outside the target repo and invoked by
@@ -243,9 +247,32 @@ cache_fallback_allowed() {
 # Claude-led session: probe for Codex
 ###############################################################################
 
+codex_login_status_bounded() {
+  python3 - "$CODEX_LOGIN_TIMEOUT_SECONDS" <<'PY'
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        ["codex", "login", "status"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=int(sys.argv[1]),
+        check=False,
+    )
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+except OSError:
+    raise SystemExit(1)
+raise SystemExit(0 if result.returncode == 0 else 1)
+PY
+}
+
 probe_codex() {
   local codex_cli_installed="false"
   local codex_mcp_registered="false"
+  local codex_authenticated="false"
+  local codex_auth_reason="not_checked"
   local openai_auth="false"
   local available="false"
   local warning=""
@@ -253,6 +280,20 @@ probe_codex() {
   # Check Codex CLI
   if has_cmd codex; then
     codex_cli_installed="true"
+    local login_rc=0
+    if codex_login_status_bounded; then
+      codex_authenticated="true"
+      codex_auth_reason="authenticated"
+    else
+      login_rc=$?
+      if [ "$login_rc" -eq 124 ]; then
+        codex_auth_reason="timeout"
+      else
+        codex_auth_reason="unauthenticated"
+      fi
+    fi
+  else
+    codex_auth_reason="missing_cli"
   fi
 
   # Check MCP registration (requires claude CLI)
@@ -270,20 +311,22 @@ probe_codex() {
   fi
 
   # Determine overall availability
-  if [ "$codex_cli_installed" = "true" ] && [ "$codex_mcp_registered" = "true" ]; then
+  if [ "$codex_cli_installed" = "true" ] && \
+     [ "$codex_mcp_registered" = "true" ] && \
+     [ "$codex_authenticated" = "true" ]; then
     available="true"
   fi
 
   # Build warning lines if not available
   local warning_lines=""
   if [ "$available" = "false" ]; then
-    warning_lines="    \"Codex MCP not available -- quest will run Claude-only (all roles).\",\n"
+    warning_lines="    \"Codex is unavailable -- quest startup is paused for your decision.\",\n"
     warning_lines="${warning_lines}    \"To enable dual-model mode (Claude + Codex), run:\",\n"
     if [ "$codex_cli_installed" = "false" ]; then
       warning_lines="${warning_lines}    \"  npm i -g @openai/codex          # install Codex CLI\",\n"
     fi
-    if [ "$openai_auth" = "false" ]; then
-      warning_lines="${warning_lines}    \"  codex auth                       # login to OpenAI\",\n"
+    if [ "$codex_authenticated" = "false" ]; then
+      warning_lines="${warning_lines}    \"  codex login                      # login to OpenAI\",\n"
     fi
     if [ "$codex_mcp_registered" = "false" ]; then
       warning_lines="${warning_lines}    \"  claude mcp add --scope user codex-cli -- codex mcp-server\",\n"
@@ -299,6 +342,8 @@ probe_codex() {
   "checks": {
     "codex_cli_installed": ${codex_cli_installed},
     "codex_mcp_registered": ${codex_mcp_registered},
+    "codex_authenticated": ${codex_authenticated},
+    "codex_auth_reason": "${codex_auth_reason}",
     "openai_auth": ${openai_auth}
   },
   "warning": $(if [ -n "$warning_lines" ]; then printf '[\n%b\n  ]' "$warning_lines"; else echo 'null'; fi)

--- a/scripts/quest_runtime/state.py
+++ b/scripts/quest_runtime/state.py
@@ -27,9 +27,7 @@ class PhaseMismatchError(Exception):
     def __init__(self, expected: str, actual: object) -> None:
         self.expected = expected
         self.actual = actual
-        super().__init__(
-            f"Expected phase '{expected}' but state.json has '{actual}'"
-        )
+        super().__init__(f"Expected phase '{expected}' but state.json has '{actual}'")
 
 
 def utc_now_iso() -> str:
@@ -57,7 +55,7 @@ def load_state(quest_dir: str | Path) -> dict[str, Any]:
 
     try:
         state = json.loads(serialized)
-    except json.JSONDecodeError as exc:
+    except (ValueError, RecursionError) as exc:
         raise StateError("decode", state_path) from exc
     if not isinstance(state, dict):
         raise StateError("shape", state_path)
@@ -133,5 +131,7 @@ def update_state(
         finally:
             try:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            except OSError as exc:
-                raise StateError("lock", state_path) from exc
+            except OSError:
+                # Closing the descriptor releases the lock. Do not turn an
+                # already-committed replacement into a false failure report.
+                pass

--- a/scripts/quest_runtime/state.py
+++ b/scripts/quest_runtime/state.py
@@ -1,11 +1,35 @@
-"""Helpers for updating quest state.json consistently."""
+"""Helpers for reading and atomically updating Quest state.json."""
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
+import stat
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+
+class StateError(Exception):
+    """Stable state-boundary failure without platform-specific details."""
+
+    def __init__(self, category: str, state_path: Path) -> None:
+        self.category = category
+        self.state_path = state_path.resolve()
+        super().__init__(f"state_error[{category}]: {self.state_path}")
+
+
+class PhaseMismatchError(Exception):
+    """The locked state phase did not match the caller's expectation."""
+
+    def __init__(self, expected: str, actual: object) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Expected phase '{expected}' but state.json has '{actual}'"
+        )
 
 
 def utc_now_iso() -> str:
@@ -17,22 +41,97 @@ def utc_now_iso() -> str:
     )
 
 
+def _state_path(quest_dir: str | Path) -> Path:
+    return (Path(quest_dir) / "state.json").resolve()
+
+
 def load_state(quest_dir: str | Path) -> dict[str, Any]:
-    state_path = Path(quest_dir) / "state.json"
-    return json.loads(state_path.read_text(encoding="utf-8"))
+    """Load a Quest state object or raise a stable categorized error."""
+    state_path = _state_path(quest_dir)
+    try:
+        serialized = state_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise StateError("decode", state_path) from exc
+    except OSError as exc:
+        raise StateError("read", state_path) from exc
 
-
-def write_state(quest_dir: str | Path, state: dict[str, Any]) -> Path:
-    state_path = Path(quest_dir) / "state.json"
-    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
-    return state_path
-
-
-def update_state(quest_dir: str | Path, **updates: Any) -> dict[str, Any]:
-    state = load_state(quest_dir)
-    for key, value in updates.items():
-        if value is not None:
-            state[key] = value
-    state["updated_at"] = utc_now_iso()
-    write_state(quest_dir, state)
+    try:
+        state = json.loads(serialized)
+    except json.JSONDecodeError as exc:
+        raise StateError("decode", state_path) from exc
+    if not isinstance(state, dict):
+        raise StateError("shape", state_path)
+    # JSON state is an external deserialization boundary, so values are dynamic.
     return state
+
+
+def _atomic_write_state(state_path: Path, state: dict[str, Any]) -> None:
+    temp_path: Path | None = None
+    try:
+        state_mode = stat.S_IMODE(state_path.stat().st_mode)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=state_path.parent,
+            prefix=f".{state_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            json.dump(state, temp_file, indent=2)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        temp_path.chmod(state_mode)
+        os.replace(temp_path, state_path)
+        temp_path = None
+    except (OSError, TypeError, ValueError) as exc:
+        raise StateError("write", state_path) from exc
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def update_state(
+    quest_dir: str | Path,
+    *,
+    expected_phase: str | None = None,
+    clear_parked_bg_session: bool = False,
+    **updates: Any,
+) -> dict[str, Any]:
+    """Lock, reload, optionally compare, mutate, and atomically replace state."""
+    state_path = _state_path(quest_dir)
+    lock_path = state_path.with_name(f"{state_path.name}.lock")
+    try:
+        lock_file = lock_path.open("a", encoding="utf-8")
+    except OSError as exc:
+        raise StateError("lock", state_path) from exc
+
+    with lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        except OSError as exc:
+            raise StateError("lock", state_path) from exc
+
+        try:
+            state = load_state(state_path.parent)
+            actual_phase = state.get("phase")
+            if expected_phase is not None and actual_phase != expected_phase:
+                raise PhaseMismatchError(expected_phase, actual_phase)
+
+            for key, value in updates.items():
+                if value is not None:
+                    state[key] = value
+            if clear_parked_bg_session:
+                state.pop("parked_bg_session", None)
+            state["updated_at"] = utc_now_iso()
+            _atomic_write_state(state_path, state)
+            return state
+        finally:
+            try:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            except OSError as exc:
+                raise StateError("lock", state_path) from exc

--- a/scripts/quest_state.py
+++ b/scripts/quest_state.py
@@ -9,17 +9,14 @@ Supports two modes:
   Atomic validated transition (preferred):
     python3 scripts/quest_state.py --quest-dir .quest/<id> --transition building --status in_progress
 
-  With optimistic locking (recommended for multi-agent):
+  With an atomic expected-phase check (recommended for multi-agent):
     python3 scripts/quest_state.py --quest-dir .quest/<id> --transition building --status in_progress --expect-phase plan_reviewed
 
 The --transition flag calls quest_validate-quest-state.sh before writing.
 If validation fails, state.json is not modified.
 
-The --expect-phase flag adds optimistic locking: the transition is
-rejected immediately if the current phase in state.json does not match
-the expected value, narrowing (not eliminating — the check precedes the
-validator and the final write) TOCTOU races when multiple
-agents may be updating state concurrently.
+The --expect-phase flag checks the final state inside the same locked
+read/check/write transaction that atomically publishes the transition.
 """
 
 from __future__ import annotations
@@ -31,7 +28,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from quest_runtime.state import load_state, update_state, write_state
+from quest_runtime.state import (
+    PhaseMismatchError,
+    StateError,
+    update_state,
+)
 
 
 def find_validator() -> Path:
@@ -83,9 +84,8 @@ def parse_args() -> argparse.Namespace:
         "--expect-phase",
         metavar="PHASE",
         help=(
-            "Optimistic lock: reject immediately if current phase in "
-            "state.json does not match PHASE. Narrows (not eliminates) TOCTOU races "
-            "when multiple agents update state concurrently."
+            "Atomically reject the mutation if the locked state.json phase "
+            "does not match PHASE."
         ),
     )
     parser.add_argument("--last-role")
@@ -141,50 +141,17 @@ def main() -> int:
         return 1
 
     if args.transition:
-        # Read current phase BEFORE validation for accurate error reporting
-        current_phase = "unknown"
-        try:
-            current_phase = load_state(quest_dir).get("phase", "unknown")
-        except Exception:
-            pass
-
-        # Optimistic lock: reject if current phase doesn't match expectation
-        if args.expect_phase and current_phase != args.expect_phase:
-            print(
-                f"Optimistic lock failed: expected phase '{args.expect_phase}' "
-                f"but state.json has '{current_phase}'. Another agent may have "
-                f"modified state concurrently.",
-                file=sys.stderr,
-            )
-            return 1
-
+        # Validation is intentionally outside the filesystem lock. The final
+        # expected-phase comparison remains authoritative inside update_state().
         # Validate before mutating
         rc, output = run_validator(quest_dir, args.transition)
         if rc != 0:
             print(
-                f"Transition {current_phase} -> {args.transition} rejected by validator.",
+                f"Transition to {args.transition} rejected by validator.",
                 file=sys.stderr,
             )
             print(output, file=sys.stderr)
             return 1
-
-        # Re-check the lock AFTER the (slow) validator subprocess: a
-        # concurrent update landing during validation would otherwise be
-        # clobbered. This narrows the remaining check-to-write window from
-        # validator-duration to microseconds.
-        if args.expect_phase:
-            try:
-                current_phase = load_state(quest_dir).get("phase", "unknown")
-            except Exception:
-                current_phase = "unknown"
-            if current_phase != args.expect_phase:
-                print(
-                    f"Optimistic lock failed after validation: expected phase "
-                    f"'{args.expect_phase}' but state.json has '{current_phase}'. "
-                    "Another agent modified state concurrently.",
-                    file=sys.stderr,
-                )
-                return 1
 
     parked_bg_session = None
     if args.parked_bg_session is not None:
@@ -202,20 +169,26 @@ def main() -> int:
             )
             return 1
 
-    state = update_state(
-        quest_dir,
-        phase=target_phase,
-        status=args.status,
-        last_role=args.last_role,
-        last_verdict=args.last_verdict,
-        quest_mode=args.quest_mode,
-        plan_iteration=args.plan_iteration,
-        fix_iteration=args.fix_iteration,
-        parked_bg_session=parked_bg_session,
-    )
-    if args.clear_parked_bg_session and "parked_bg_session" in state:
-        state.pop("parked_bg_session", None)
-        write_state(quest_dir, state)
+    try:
+        state = update_state(
+            quest_dir,
+            expected_phase=args.expect_phase,
+            clear_parked_bg_session=args.clear_parked_bg_session,
+            phase=target_phase,
+            status=args.status,
+            last_role=args.last_role,
+            last_verdict=args.last_verdict,
+            quest_mode=args.quest_mode,
+            plan_iteration=args.plan_iteration,
+            fix_iteration=args.fix_iteration,
+            parked_bg_session=parked_bg_session,
+        )
+    except PhaseMismatchError as exc:
+        print(f"{exc}. Another agent modified state concurrently.", file=sys.stderr)
+        return 1
+    except StateError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     print(json.dumps(state, indent=2))
     return 0
 

--- a/tests/integration/test-enforce-allowlist.sh
+++ b/tests/integration/test-enforce-allowlist.sh
@@ -57,6 +57,23 @@ with open(path, "w", encoding="utf-8") as fh:
 PY
 }
 
+set_builder_bash_entries() {
+  local entries_json="$1"
+  python3 - "$ALLOWLIST_FILE" "$entries_json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+entries = json.loads(sys.argv[2])
+with open(path, encoding="utf-8") as fh:
+    data = json.load(fh)
+data["role_permissions"]["builder_agent"]["bash"] = entries
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+}
+
 test_bridge_allows_manifest_validation_command() {
   local output rc
   output=$(run_hook_for_command "builder_agent" "bash scripts/quest_validate-manifest.sh" 2>&1)
@@ -71,6 +88,42 @@ test_bridge_rejects_compound_bypass() {
   [ "$rc" -eq 2 ] &&
     echo "$output" | grep -q "BLOCKED:" &&
     echo "$output" | grep -q "blocked_metacharacter"
+}
+
+test_bridge_binds_absolute_command_to_path_selected_identity() {
+  local backup tmpdir resolved lookalike alias output rc
+  backup=$(mktemp) || return 1
+  tmpdir=$(mktemp -d) || return 1
+  cp "$ALLOWLIST_FILE" "$backup" || return 1
+  trap 'mv "$backup" "$ALLOWLIST_FILE"; rm -rf "$tmpdir"' RETURN
+
+  mkdir -p "$tmpdir/bin" "$tmpdir/other" "$tmpdir/alias"
+  resolved="$tmpdir/bin/rg"
+  lookalike="$tmpdir/other/rg"
+  alias="$tmpdir/alias/rg"
+  touch "$resolved" "$lookalike"
+  chmod +x "$resolved" "$lookalike"
+  ln -s "$resolved" "$alias"
+
+  set_builder_bash_entries '["rg"]' || return 1
+  output=$(PATH="$tmpdir/bin:$PATH" run_hook_for_command "builder_agent" "$resolved TODO" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ] || return 1
+  output=$(PATH="$tmpdir/bin:$PATH" run_hook_for_command "builder_agent" "$lookalike TODO" 2>&1)
+  rc=$?
+  [ "$rc" -eq 2 ] && printf '%s' "$output" | grep -q "no_match" || return 1
+
+  set_builder_bash_entries "[\"$resolved\"]" || return 1
+  output=$(PATH="$tmpdir/bin:$PATH" run_hook_for_command "builder_agent" "$resolved TODO" 2>&1)
+  rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$output" ] || return 1
+  output=$(PATH="$tmpdir/bin:$PATH" run_hook_for_command "builder_agent" "$alias TODO" 2>&1)
+  rc=$?
+
+  trap - RETURN
+  mv "$backup" "$ALLOWLIST_FILE"
+  rm -rf "$tmpdir"
+  [ "$rc" -eq 2 ] && printf '%s' "$output" | grep -q "no_match"
 }
 
 test_file_write_allows_nested_double_star_path() {
@@ -144,6 +197,7 @@ fi
 
 run_test test_bridge_allows_manifest_validation_command
 run_test test_bridge_rejects_compound_bypass
+run_test test_bridge_binds_absolute_command_to_path_selected_identity
 run_test test_file_write_allows_nested_double_star_path
 run_test test_file_write_allows_nested_docs_output
 run_test test_file_write_allows_root_markdown_for_double_star_slash_pattern

--- a/tests/test-quest-preflight.sh
+++ b/tests/test-quest-preflight.sh
@@ -202,6 +202,136 @@ EOF
   chmod +x "$path"
 }
 
+write_codex_preflight_claude() {
+  local path="$1"
+  local registered="$2"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "mcp" ] && [ "\$2" = "list" ]; then
+  if [ "$registered" = "true" ]; then
+    echo "codex-cli: codex mcp-server"
+  fi
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$path"
+}
+
+write_codex_login_cli() {
+  local path="$1"
+  local mode="$2"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "login" ] && [ "\$2" = "status" ]; then
+  case "$mode" in
+    authenticated) echo "Logged in"; exit 0 ;;
+    unauthenticated) echo "Not logged in" >&2; exit 1 ;;
+    timeout) sleep 2; exit 0 ;;
+  esac
+fi
+exit 1
+EOF
+  chmod +x "$path"
+}
+
+run_claude_codex_probe() {
+  local tmpdir="$1"
+  PATH="$tmpdir/bin:$PATH" \
+    QUEST_CODEX_LOGIN_TIMEOUT_SECONDS=1 \
+    "$PREFLIGHT_SCRIPT" --orchestrator claude 2>/dev/null
+}
+
+test_claude_preflight_requires_authenticated_codex() {
+  local tmpdir output
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" true
+  write_codex_login_cli "$tmpdir/bin/codex" authenticated
+  output=$(run_claude_codex_probe "$tmpdir")
+  rm -rf "$tmpdir"
+
+  [ "$(printf '%s' "$output" | jq -r '.available')" = "true" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_authenticated')" = "true" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_auth_reason')" = "authenticated" ]
+}
+
+test_claude_preflight_reports_login_failure_without_crashing() {
+  local tmpdir output rc warning
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" true
+  write_codex_login_cli "$tmpdir/bin/codex" unauthenticated
+  output=$(run_claude_codex_probe "$tmpdir")
+  rc=$?
+  warning=$(printf '%s' "$output" | jq -r '.warning | join(" ")')
+  rm -rf "$tmpdir"
+
+  [ "$rc" -eq 0 ] &&
+    [ "$(printf '%s' "$output" | jq -r '.available')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_authenticated')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_auth_reason')" = "unauthenticated" ] &&
+    printf '%s' "$warning" | grep -q "codex login" &&
+    ! printf '%s' "$warning" | grep -q "codex auth"
+}
+
+test_claude_preflight_reports_bounded_login_timeout() {
+  local tmpdir output rc
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" true
+  write_codex_login_cli "$tmpdir/bin/codex" timeout
+  output=$(run_claude_codex_probe "$tmpdir")
+  rc=$?
+  rm -rf "$tmpdir"
+
+  [ "$rc" -eq 0 ] &&
+    [ "$(printf '%s' "$output" | jq -r '.available')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_auth_reason')" = "timeout" ]
+}
+
+test_claude_preflight_does_not_treat_api_key_as_login() {
+  local tmpdir output
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" true
+  write_codex_login_cli "$tmpdir/bin/codex" unauthenticated
+  output=$(OPENAI_API_KEY=test-only run_claude_codex_probe "$tmpdir")
+  rm -rf "$tmpdir"
+
+  [ "$(printf '%s' "$output" | jq -r '.available')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.openai_auth')" = "true" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_authenticated')" = "false" ]
+}
+
+test_claude_preflight_requires_codex_mcp_registration() {
+  local tmpdir output
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" false
+  write_codex_login_cli "$tmpdir/bin/codex" authenticated
+  output=$(run_claude_codex_probe "$tmpdir")
+  rm -rf "$tmpdir"
+
+  [ "$(printf '%s' "$output" | jq -r '.available')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_mcp_registered')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_authenticated')" = "true" ]
+}
+
+test_claude_preflight_reports_missing_codex_cli() {
+  local tmpdir output
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/bin"
+  write_codex_preflight_claude "$tmpdir/bin/claude" true
+  output=$(PATH="$tmpdir/bin:/usr/bin:/bin" \
+    "$PREFLIGHT_SCRIPT" --orchestrator claude 2>/dev/null)
+  rm -rf "$tmpdir"
+
+  [ "$(printf '%s' "$output" | jq -r '.available')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_cli_installed')" = "false" ] &&
+    [ "$(printf '%s' "$output" | jq -r '.checks.codex_auth_reason')" = "missing_cli" ]
+}
+
 test_quest_preflight_caches_successful_codex_bridge_probe() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -604,6 +734,12 @@ test_quest_preflight_reports_missing_probe_helper_diagnostic() {
 run_test test_quest_preflight_resolves_helpers_by_absolute_path_from_foreign_cwd
 run_test test_quest_preflight_resolves_helpers_through_symlinked_entrypoint
 run_test test_quest_preflight_reports_missing_probe_helper_diagnostic
+run_test test_claude_preflight_requires_authenticated_codex
+run_test test_claude_preflight_reports_login_failure_without_crashing
+run_test test_claude_preflight_reports_bounded_login_timeout
+run_test test_claude_preflight_does_not_treat_api_key_as_login
+run_test test_claude_preflight_requires_codex_mcp_registration
+run_test test_claude_preflight_reports_missing_codex_cli
 run_test test_quest_preflight_caches_successful_codex_bridge_probe
 run_test test_quest_preflight_uses_cached_success_when_live_probe_fails
 run_test test_quest_preflight_does_not_use_cached_success_for_non_auth_probe_failure

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -9,6 +9,7 @@ _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
+import quest_allowlist_matcher
 from quest_allowlist_matcher import is_bash_command_allowed
 
 
@@ -193,13 +194,23 @@ def test_absolute_path_find_exec_is_blocked_for_bare_find_entry():
     assert reason == "blocked_find_action"
 
 
-def test_absolute_path_find_query_is_allowed_for_bare_find_entry():
+def test_bare_find_entry_rejects_same_basename_outside_resolved_path(
+    monkeypatch, tmp_path
+):
+    installed = tmp_path / "installed" / "find"
+    installed.parent.mkdir()
+    installed.touch()
+    lookalike = tmp_path / "lookalike" / "find"
+    lookalike.parent.mkdir()
+    lookalike.touch()
+    monkeypatch.setattr(quest_allowlist_matcher.shutil, "which", lambda _: str(installed))
+
     allowed, reason = is_bash_command_allowed(
-        "/usr/bin/find . -name '*.py' -type f",
+        f"{lookalike} . -name '*.py' -type f",
         ["find"],
     )
-    assert allowed is True
-    assert reason == "token_prefix_match"
+    assert allowed is False
+    assert reason == "no_match"
 
 
 def test_exact_find_exec_entry_is_allowed():
@@ -263,13 +274,72 @@ def test_absolute_path_rg_pre_is_blocked_for_bare_rg_entry():
     assert reason == "blocked_rg_flag"
 
 
-def test_absolute_path_rg_query_is_allowed_for_bare_rg_entry():
+def test_bare_rg_entry_rejects_same_basename_outside_resolved_path(
+    monkeypatch, tmp_path
+):
+    installed = tmp_path / "installed" / "rg"
+    installed.parent.mkdir()
+    installed.touch()
+    lookalike = tmp_path / "lookalike" / "rg"
+    lookalike.parent.mkdir()
+    lookalike.touch()
+    monkeypatch.setattr(quest_allowlist_matcher.shutil, "which", lambda _: str(installed))
+
     allowed, reason = is_bash_command_allowed(
-        "/opt/homebrew/bin/rg TODO tests/unit/",
+        f"{lookalike} TODO tests/unit/",
         ["rg"],
     )
-    assert allowed is True
-    assert reason == "token_prefix_match"
+    assert allowed is False
+    assert reason == "no_match"
+
+
+def test_bare_entry_accepts_path_resolved_absolute_executable(monkeypatch, tmp_path):
+    target = tmp_path / "bin" / "rg-real"
+    target.parent.mkdir()
+    target.touch()
+    path_entry = tmp_path / "path" / "rg"
+    path_entry.parent.mkdir()
+    path_entry.symlink_to(target)
+    monkeypatch.setattr(
+        quest_allowlist_matcher.shutil, "which", lambda _: str(path_entry)
+    )
+
+    assert is_bash_command_allowed(f"{path_entry} TODO", ["rg"]) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed(f"{target} TODO", ["rg"]) == (
+        True,
+        "token_prefix_match",
+    )
+
+
+def test_bare_entry_does_not_authorize_absolute_command_when_missing_from_path(
+    monkeypatch,
+):
+    monkeypatch.setattr(quest_allowlist_matcher.shutil, "which", lambda _: None)
+    assert is_bash_command_allowed("/custom/bin/rg TODO", ["rg"]) == (
+        False,
+        "no_match",
+    )
+
+
+def test_explicit_absolute_entry_requires_exact_executable_token(tmp_path):
+    configured = tmp_path / "bin" / "rg"
+    configured.parent.mkdir()
+    configured.touch()
+    alias = tmp_path / "alias" / "rg"
+    alias.parent.mkdir()
+    alias.symlink_to(configured)
+
+    assert is_bash_command_allowed(f"{configured} TODO", [str(configured)]) == (
+        True,
+        "token_prefix_match",
+    )
+    assert is_bash_command_allowed(f"{alias} TODO", [str(configured)]) == (
+        False,
+        "no_match",
+    )
 
 
 def test_exact_rg_pre_entry_is_allowed():

--- a/tests/unit/test_allowlist_matcher.py
+++ b/tests/unit/test_allowlist_matcher.py
@@ -203,7 +203,9 @@ def test_bare_find_entry_rejects_same_basename_outside_resolved_path(
     lookalike = tmp_path / "lookalike" / "find"
     lookalike.parent.mkdir()
     lookalike.touch()
-    monkeypatch.setattr(quest_allowlist_matcher.shutil, "which", lambda _: str(installed))
+    monkeypatch.setattr(
+        quest_allowlist_matcher.shutil, "which", lambda _: str(installed)
+    )
 
     allowed, reason = is_bash_command_allowed(
         f"{lookalike} . -name '*.py' -type f",
@@ -283,7 +285,9 @@ def test_bare_rg_entry_rejects_same_basename_outside_resolved_path(
     lookalike = tmp_path / "lookalike" / "rg"
     lookalike.parent.mkdir()
     lookalike.touch()
-    monkeypatch.setattr(quest_allowlist_matcher.shutil, "which", lambda _: str(installed))
+    monkeypatch.setattr(
+        quest_allowlist_matcher.shutil, "which", lambda _: str(installed)
+    )
 
     allowed, reason = is_bash_command_allowed(
         f"{lookalike} TODO tests/unit/",

--- a/tests/unit/test_quest_complete.py
+++ b/tests/unit/test_quest_complete.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 import quest_complete
 from quest_complete import build_journal_entry
 from quest_celebrate.quest_data import QuestData
@@ -35,6 +37,52 @@ def test_generate_journal_entry_prefers_full_original_prompt():
     assert "Full original prompt line two." in entry
     assert "Full original prompt was not recorded" not in entry
     assert "- Outcome: Shipped the fix cleanly." in entry
+
+
+@pytest.mark.parametrize(
+    ("payload", "category"),
+    [("{bad", "decode"), ("[]", "shape"), ("null", "shape")],
+)
+def test_complete_rejects_malformed_state_cleanly(
+    tmp_path, monkeypatch, capsys, payload, category
+):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text(payload, encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["quest_complete.py", "--quest-dir", str(quest_dir), "--skip-journal"],
+    )
+
+    assert quest_complete.main() == 1
+    captured = capsys.readouterr()
+    assert f"state_error[{category}]: {state_path.resolve()}" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_complete_translates_state_read_failure(tmp_path, monkeypatch, capsys):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["quest_complete.py", "--quest-dir", str(quest_dir), "--skip-journal"],
+    )
+
+    def fail_read(*_args, **_kwargs):
+        raise OSError("platform read detail")
+
+    monkeypatch.setattr(quest_complete.Path, "read_text", fail_read)
+
+    assert quest_complete.main() == 1
+    captured = capsys.readouterr()
+    assert captured.err == f"Error: state_error[read]: {state_path.resolve()}\n"
+    assert "platform read detail" not in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_generate_journal_entry_avoids_problem_statement_as_outcome():

--- a/tests/unit/test_quest_dispatch_guardrails.py
+++ b/tests/unit/test_quest_dispatch_guardrails.py
@@ -216,6 +216,8 @@ def test_claude_led_unavailable_preflight_requires_human_routing_decision() -> N
     assert "fix" in clause.lower() and "rerun preflight" in clause.lower()
     assert "continue Claude-only" in clause
     assert "cancel" in clause.lower()
+    assert "still assigns an active role to Codex" in clause
+    assert "do not prompt again" in clause
     assert "using Claude runtime fallback for all roles" not in clause
     assert "| Codex-led | Codex | local Codex subagent" in workflow
     assert "| Codex-led | Claude | `python3 scripts/quest_claude_runner.py`" in workflow

--- a/tests/unit/test_quest_dispatch_guardrails.py
+++ b/tests/unit/test_quest_dispatch_guardrails.py
@@ -204,6 +204,19 @@ def test_dispatch_matrix_documents_runtime_entrypoint_split() -> None:
     assert (
         "`runtime_for_model()` in `scripts/quest_runtime/orchestration.py`" in workflow
     )
+
+
+def test_claude_led_unavailable_preflight_requires_human_routing_decision() -> None:
+    workflow = _read(".skills/quest/delegation/workflow.md")
+    clause = workflow.split("**Claude-led sessions:**", 1)[1].split(
+        "**Codex-led sessions:**", 1
+    )[0]
+
+    assert "pause" in clause.lower()
+    assert "fix" in clause.lower() and "rerun preflight" in clause.lower()
+    assert "continue Claude-only" in clause
+    assert "cancel" in clause.lower()
+    assert "using Claude runtime fallback for all roles" not in clause
     assert "| Codex-led | Codex | local Codex subagent" in workflow
     assert "| Codex-led | Claude | `python3 scripts/quest_claude_runner.py`" in workflow
     assert "| Claude-led | Codex | Codex MCP" in workflow

--- a/tests/unit/test_quest_state.py
+++ b/tests/unit/test_quest_state.py
@@ -164,11 +164,33 @@ def test_load_state_classifies_invalid_json_as_decode(tmp_path):
     assert str(exc_info.value) == f"state_error[decode]: {state_path.resolve()}"
 
 
+@pytest.mark.parametrize(
+    "parse_error", [ValueError("too large"), RecursionError("deep")]
+)
+def test_load_state_classifies_parser_limit_failures_as_decode(
+    tmp_path, monkeypatch, parse_error
+):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text("{}", encoding="utf-8")
+
+    def fail_parse(_serialized):
+        raise parse_error
+
+    monkeypatch.setattr(state_runtime.json, "loads", fail_parse)
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.load_state(quest_dir)
+
+    assert str(exc_info.value) == f"state_error[decode]: {state_path.resolve()}"
+    assert str(parse_error) not in str(exc_info.value)
+
+
 def test_load_state_classifies_invalid_utf8_as_decode(tmp_path):
     quest_dir = tmp_path / "quest"
     quest_dir.mkdir()
     state_path = quest_dir / "state.json"
-    state_path.write_bytes(b'\xff')
+    state_path.write_bytes(b"\xff")
 
     with pytest.raises(state_runtime.StateError) as exc_info:
         state_runtime.load_state(quest_dir)
@@ -289,9 +311,7 @@ def test_update_state_holds_lock_through_atomic_replace(tmp_path, monkeypatch):
     real_replace = state_runtime.os.replace
 
     def record_flock(file_descriptor, operation):
-        events.append(
-            "lock" if operation == state_runtime.fcntl.LOCK_EX else "unlock"
-        )
+        events.append("lock" if operation == state_runtime.fcntl.LOCK_EX else "unlock")
         real_flock(file_descriptor, operation)
 
     def record_replace(source, destination):
@@ -304,6 +324,27 @@ def test_update_state_holds_lock_through_atomic_replace(tmp_path, monkeypatch):
     state_runtime.update_state(quest_dir, phase="building")
 
     assert events == ["lock", "replace", "unlock"]
+
+
+def test_update_state_does_not_report_failure_when_explicit_unlock_fails(
+    tmp_path, monkeypatch
+):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    real_flock = state_runtime.fcntl.flock
+
+    def fail_explicit_unlock(file_descriptor, operation):
+        if operation == state_runtime.fcntl.LOCK_UN:
+            raise OSError("platform unlock detail")
+        real_flock(file_descriptor, operation)
+
+    monkeypatch.setattr(state_runtime.fcntl, "flock", fail_explicit_unlock)
+
+    updated = state_runtime.update_state(quest_dir, phase="building")
+
+    assert updated["phase"] == "building"
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["phase"] == "building"
 
 
 def test_update_state_classifies_lock_failure(tmp_path, monkeypatch):
@@ -321,9 +362,7 @@ def test_update_state_classifies_lock_failure(tmp_path, monkeypatch):
     assert "platform lock detail" not in str(exc_info.value)
 
 
-def test_update_state_classifies_write_failure_and_cleans_temp(
-    tmp_path, monkeypatch
-):
+def test_update_state_classifies_write_failure_and_cleans_temp(tmp_path, monkeypatch):
     quest_dir = _make_quest_dir(tmp_path)
     state_path = quest_dir / "state.json"
     before = state_path.read_bytes()
@@ -363,9 +402,7 @@ def test_cli_invalid_state_has_readable_error_without_traceback(tmp_path):
     assert "Traceback" not in cp.stderr
 
 
-def test_validator_rejection_does_not_read_state(
-    tmp_path, monkeypatch, capsys
-):
+def test_validator_rejection_does_not_read_state(tmp_path, monkeypatch, capsys):
     quest_dir = _make_quest_dir(tmp_path)
     monkeypatch.setattr(
         sys,
@@ -430,9 +467,7 @@ def test_cli_translates_state_mutation_failures(
 
     assert quest_state.main() == 1
     captured = capsys.readouterr()
-    assert captured.err == (
-        f"Error: state_error[{category}]: {state_path.resolve()}\n"
-    )
+    assert captured.err == (f"Error: state_error[{category}]: {state_path.resolve()}\n")
     assert platform_text not in captured.err
     assert "Traceback" not in captured.err
 

--- a/tests/unit/test_quest_state.py
+++ b/tests/unit/test_quest_state.py
@@ -8,9 +8,15 @@ set/clear flags are contract, not convenience.
 from __future__ import annotations
 
 import json
+import stat
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
+
+import quest_state
+from quest_runtime import state as state_runtime
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUEST_STATE = REPO_ROOT / "scripts" / "quest_state.py"
@@ -131,3 +137,347 @@ def test_empty_expect_phase_fails_closed_instead_of_bypassing_lock(tmp_path):
     assert "non-empty" in cp.stderr
     state = json.loads((quest_dir / "state.json").read_text(encoding="utf-8"))
     assert state["phase"] == "plan"  # unmodified
+
+
+@pytest.mark.parametrize("payload", ["[]", '"state"', "1", "true", "null"])
+def test_load_state_rejects_non_object_top_level(tmp_path, payload):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.load_state(quest_dir)
+
+    assert str(exc_info.value) == f"state_error[shape]: {state_path.resolve()}"
+
+
+def test_load_state_classifies_invalid_json_as_decode(tmp_path):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text("{bad", encoding="utf-8")
+
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.load_state(quest_dir)
+
+    assert str(exc_info.value) == f"state_error[decode]: {state_path.resolve()}"
+
+
+def test_load_state_classifies_invalid_utf8_as_decode(tmp_path):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_bytes(b'\xff')
+
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.load_state(quest_dir)
+
+    assert str(exc_info.value) == f"state_error[decode]: {state_path.resolve()}"
+
+
+def test_load_state_classifies_read_io_without_platform_text(tmp_path, monkeypatch):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text("{}", encoding="utf-8")
+
+    def fail_read(*args, **kwargs):
+        raise OSError("platform-specific-secret")
+
+    monkeypatch.setattr(state_runtime.Path, "read_text", fail_read)
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.load_state(quest_dir)
+
+    assert str(exc_info.value) == f"state_error[read]: {state_path.resolve()}"
+    assert "platform-specific-secret" not in str(exc_info.value)
+
+
+def test_update_state_expected_phase_mismatch_preserves_exact_bytes(tmp_path):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    before = state_path.read_bytes()
+
+    with pytest.raises(state_runtime.PhaseMismatchError) as exc_info:
+        state_runtime.update_state(
+            quest_dir,
+            expected_phase="review",
+            phase="building",
+        )
+
+    assert exc_info.value.expected == "review"
+    assert exc_info.value.actual == "plan"
+    assert state_path.read_bytes() == before
+    assert (quest_dir / "state.json.lock").exists()
+
+
+def test_update_state_atomically_replaces_and_keeps_lock_file(tmp_path, monkeypatch):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    real_replace = state_runtime.os.replace
+    replacements = []
+
+    def record_replace(source, destination):
+        replacements.append((Path(source), Path(destination)))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(state_runtime.os, "replace", record_replace)
+    updated = state_runtime.update_state(
+        quest_dir,
+        expected_phase="plan",
+        phase="building",
+    )
+
+    assert updated["phase"] == "building"
+    assert len(replacements) == 1
+    assert replacements[0][1] == state_path
+    assert replacements[0][0].parent == quest_dir
+    assert (quest_dir / "state.json.lock").exists()
+    assert not replacements[0][0].exists()
+
+
+def test_update_state_clears_parked_session_in_single_replacement(
+    tmp_path, monkeypatch
+):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["parked_bg_session"] = PARKED
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    real_replace = state_runtime.os.replace
+    replacements = []
+
+    def record_replace(source, destination):
+        replacements.append((source, destination))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(state_runtime.os, "replace", record_replace)
+    updated = state_runtime.update_state(
+        quest_dir,
+        expected_phase="plan",
+        clear_parked_bg_session=True,
+        phase="building",
+    )
+
+    assert "parked_bg_session" not in updated
+    assert len(replacements) == 1
+    assert "expected_phase" not in updated
+    assert "clear_parked_bg_session" not in updated
+
+
+def test_clear_absent_parked_session_still_updates_once(tmp_path, monkeypatch):
+    quest_dir = _make_quest_dir(tmp_path)
+    real_replace = state_runtime.os.replace
+    replacements = []
+
+    def record_replace(source, destination):
+        replacements.append((source, destination))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(state_runtime.os, "replace", record_replace)
+    updated = state_runtime.update_state(quest_dir, clear_parked_bg_session=True)
+
+    assert "parked_bg_session" not in updated
+    assert "updated_at" in updated
+    assert len(replacements) == 1
+
+
+def test_update_state_holds_lock_through_atomic_replace(tmp_path, monkeypatch):
+    quest_dir = _make_quest_dir(tmp_path)
+    events = []
+    real_flock = state_runtime.fcntl.flock
+    real_replace = state_runtime.os.replace
+
+    def record_flock(file_descriptor, operation):
+        events.append(
+            "lock" if operation == state_runtime.fcntl.LOCK_EX else "unlock"
+        )
+        real_flock(file_descriptor, operation)
+
+    def record_replace(source, destination):
+        events.append("replace")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(state_runtime.fcntl, "flock", record_flock)
+    monkeypatch.setattr(state_runtime.os, "replace", record_replace)
+
+    state_runtime.update_state(quest_dir, phase="building")
+
+    assert events == ["lock", "replace", "unlock"]
+
+
+def test_update_state_classifies_lock_failure(tmp_path, monkeypatch):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+
+    def fail_lock(*args, **kwargs):
+        raise OSError("platform lock detail")
+
+    monkeypatch.setattr(state_runtime.fcntl, "flock", fail_lock)
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.update_state(quest_dir, phase="building")
+
+    assert str(exc_info.value) == f"state_error[lock]: {state_path.resolve()}"
+    assert "platform lock detail" not in str(exc_info.value)
+
+
+def test_update_state_classifies_write_failure_and_cleans_temp(
+    tmp_path, monkeypatch
+):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    before = state_path.read_bytes()
+
+    def fail_replace(*args, **kwargs):
+        raise OSError("platform write detail")
+
+    monkeypatch.setattr(state_runtime.os, "replace", fail_replace)
+    with pytest.raises(state_runtime.StateError) as exc_info:
+        state_runtime.update_state(quest_dir, phase="building")
+
+    assert str(exc_info.value) == f"state_error[write]: {state_path.resolve()}"
+    assert state_path.read_bytes() == before
+    assert not list(quest_dir.glob(".state.json.*.tmp"))
+
+
+def test_atomic_replace_preserves_existing_state_file_mode(tmp_path):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    state_path.chmod(0o640)
+
+    state_runtime.update_state(quest_dir, phase="building")
+
+    assert stat.S_IMODE(state_path.stat().st_mode) == 0o640
+
+
+def test_cli_invalid_state_has_readable_error_without_traceback(tmp_path):
+    quest_dir = tmp_path / "quest"
+    quest_dir.mkdir()
+    state_path = quest_dir / "state.json"
+    state_path.write_text("[]", encoding="utf-8")
+
+    cp = _run("--quest-dir", str(quest_dir), "--phase", "building")
+
+    assert cp.returncode == 1
+    assert f"state_error[shape]: {state_path.resolve()}" in cp.stderr
+    assert "Traceback" not in cp.stderr
+
+
+def test_validator_rejection_does_not_read_state(
+    tmp_path, monkeypatch, capsys
+):
+    quest_dir = _make_quest_dir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "quest_state.py",
+            "--quest-dir",
+            str(quest_dir),
+            "--transition",
+            "building",
+        ],
+    )
+    monkeypatch.setattr(
+        quest_state,
+        "run_validator",
+        lambda *_args: (1, "validator detail\n"),
+    )
+
+    def reject_state_read(*_args, **_kwargs):
+        raise AssertionError("validator rejection must not load state")
+
+    monkeypatch.setattr(quest_state, "load_state", reject_state_read, raising=False)
+
+    assert quest_state.main() == 1
+    captured = capsys.readouterr()
+    assert captured.err == (
+        "Transition to building rejected by validator.\nvalidator detail\n\n"
+    )
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("failure_boundary", "category", "platform_text"),
+    [
+        ("lock", "lock", "platform lock detail"),
+        ("write", "write", "platform write detail"),
+    ],
+)
+def test_cli_translates_state_mutation_failures(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    failure_boundary,
+    category,
+    platform_text,
+):
+    quest_dir = _make_quest_dir(tmp_path)
+    state_path = quest_dir / "state.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["quest_state.py", "--quest-dir", str(quest_dir), "--phase", "building"],
+    )
+
+    def fail(*_args, **_kwargs):
+        raise OSError(platform_text)
+
+    if failure_boundary == "lock":
+        monkeypatch.setattr(state_runtime.fcntl, "flock", fail)
+    else:
+        monkeypatch.setattr(state_runtime.os, "replace", fail)
+
+    assert quest_state.main() == 1
+    captured = capsys.readouterr()
+    assert captured.err == (
+        f"Error: state_error[{category}]: {state_path.resolve()}\n"
+    )
+    assert platform_text not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_expected_phase_mismatch_is_distinct_and_does_not_mutate(tmp_path):
+    quest_dir = _make_quest_dir(tmp_path)
+    (quest_dir / "orchestration.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "source": "default",
+                "models": {
+                    role: "test-model"
+                    for role in (
+                        "planner",
+                        "plan-reviewer-a",
+                        "plan-reviewer-b",
+                        "arbiter",
+                        "builder",
+                        "code-reviewer-a",
+                        "code-reviewer-b",
+                        "review-arbiter",
+                        "fixer",
+                    )
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    plan_dir = quest_dir / "phase_01_plan"
+    plan_dir.mkdir()
+    (plan_dir / "arbiter_verdict.md").write_text("approved", encoding="utf-8")
+    state_path = quest_dir / "state.json"
+    before = state_path.read_bytes()
+
+    cp = _run(
+        "--quest-dir",
+        str(quest_dir),
+        "--transition",
+        "plan",
+        "--expect-phase",
+        "review",
+    )
+
+    assert cp.returncode == 1
+    assert "Expected phase 'review' but state.json has 'plan'" in cp.stderr
+    assert "state_error" not in cp.stderr
+    assert state_path.read_bytes() == before


### PR DESCRIPTION
## ⭐ Why this matters

Quest now fails closed at four critical runtime boundaries: executable authorization, Codex authentication, persisted-state structure, and concurrent state transitions. This prevents lookalike binaries, unauthenticated runtimes, malformed state, and stale phase writers from being trusted.

---

## Summary

Harden Workstream A’s runtime trust and state boundaries without introducing a broader policy or persistence framework.

- Preserve valid PATH-based commands, raw state setters, and existing command-safety protections.
- Require an explicit human decision when Claude-led startup cannot verify Codex authentication.

## Changes

- **Executable authorization**:
  - Bind bare allowlist entries to the executable identity selected by the current process `PATH`.
  - Reject arbitrary absolute binaries sharing an allowed basename.
  - Keep explicitly allowlisted absolute paths token-exact.
  - Preserve metacharacter, `find`, `rg`, and exact-match protections.
- **Codex authentication**:
  - Require installed Codex CLI, registered `codex-cli` MCP, and successful bounded `codex login status`.
  - Emit machine-readable authentication state and timeout reasons.
  - Keep API-key discovery diagnostic-only and update remediation to `codex login`.
  - Pause for fix-and-rerun, explicit Claude-only continuation, or cancellation instead of silently falling back.
- **State integrity**:
  - Reject invalid JSON, invalid UTF-8, and non-object top-level values through a stable shared error contract.
  - Serialize every shared mutation under persistent `state.json.lock`.
  - Enforce expected-phase checks inside the locked transaction and publish with atomic replacement.
  - Clear parked sessions within the same mutation.
- **Documentation**:
  - Align canonical workflow guidance with the locked state transition and human preflight-routing contracts.
  - Record the completed Quest and Workstream A status.
- **Tests**:
  - Add focused unit, shell, integration, CLI-boundary, lock-order, atomic-replacement, and cleanup regressions.

## Validation

- [x] Run `pytest -q`; observed `1006 passed`.
- [x] Run `bash tests/test-quest-preflight.sh && bash tests/test-quest-runtime.sh && bash tests/test-validate-quest-state.sh`; observed 19 preflight, 50 runtime, and 68 state-validator cases passed.
- [x] **Walkthrough — verify host contracts**: Prerequisites: authenticated Codex CLI and a registered `codex-cli` MCP. Action: run `scripts/quest_preflight.sh --orchestrator claude`, then use a disposable Quest fixture to run matching and mismatching `scripts/quest_state.py --transition ... --expect-phase ...` commands. Expected: preflight reports all three checks and `available: true`; the matching transition succeeds; the mismatch exits 1 without changing `state.json`; and `state.json.lock` remains present.

Watch for: bare allowlist entries intentionally trust only the executable selected by the caller’s current `PATH`; additional installations require PATH selection or an explicit absolute entry.

## Notes

- Native Windows locking is intentionally out of scope; this uses the standard Unix advisory lock supported on macOS and Linux.
- No state versions, database, executable-location catalog, or automatic single-model fallback was introduced.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex gpt-5.6-sol &lt;noreply@openai.com&gt;
Co-Authored-By: Codex gpt-5.6-terra &lt;noreply@openai.com&gt;
Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


