### PR TITLE
Correct installed Quest setup guidance

### DIFF
--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -67,10 +67,10 @@ If the MCP server isn't showing up, you can manually add it to `.claude/mcp.json
 **Documentation:** https://platform.openai.com/docs/quickstart
 
 In a Claude-led Quest, Codex-backed role selections require this MCP runtime.
-Preflight verifies that the configured model families are available before the
-per-quest chooser is saved. If a selected runtime is unavailable, startup pauses
-for remediation or an explicit single-model choice; Quest does not silently
-change the role map.
+Before the per-quest chooser, preflight probes the second runtime regardless of
+the repository's current role defaults. If the probe fails, startup pauses for
+remediation or an explicit single-model choice; Quest does not silently change
+the role map.
 
 ### Optional: jq (for validation)
 
@@ -241,11 +241,13 @@ current orchestrator:
 ./scripts/quest_preflight.sh --orchestrator codex
 ```
 
-Claude-led preflight verifies the Codex MCP runtime when Codex-backed models are
-selected. Codex-led preflight verifies the configured Claude transport when
-Claude-family models are selected. An unavailable configured runtime pauses
-startup for remediation, an explicit supported transport choice, a deliberate
-single-model remap, or cancellation.
+Claude-led preflight always probes the Codex CLI and MCP runtime; Codex-led
+preflight always probes the configured Claude transport. This second-runtime
+probe happens before the role-model chooser and is independent of the current
+`models` defaults. The chooser then validates its active role selections against
+the cached preflight result. A failed probe pauses startup for remediation, an
+explicit supported transport choice, a deliberate single-model remap, or
+cancellation.
 
 To deliberately use Claude for every role, set all nine role models in
 `.ai/allowlist.json` `models`:

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -64,7 +64,11 @@ If the MCP server isn't showing up, you can manually add it to `.claude/mcp.json
 
 **Documentation:** https://platform.openai.com/docs/quickstart
 
-If you skip this, Quest uses Claude for all roles (still works, just single-model).
+In a Claude-led Quest, Codex-backed role selections require this MCP runtime.
+Preflight verifies that the configured model families are available before the
+per-quest chooser is saved. If a selected runtime is unavailable, startup pauses
+for remediation or an explicit single-model choice; Quest does not silently
+change the role map.
 
 ### Optional: jq (for validation)
 
@@ -193,12 +197,20 @@ Key sections to customize:
 | `role_permissions.fixer_agent.file_write` | Paths where fixer can write (usually same as builder minus docs) |
 | `role_permissions.*.bash` | Shell commands each role can run (test runners, build tools) |
 | `auto_approve_phases` | Which phases run without human confirmation |
-| `models.arbiter` | Set to `"claude"` or `"gpt-5.4"` to choose arbiter runtime |
+| `models.<role>` | Set a model ID for each canonical role: `planner`, `plan-reviewer-a`, `plan-reviewer-b`, `arbiter`, `builder`, `code-reviewer-a`, `code-reviewer-b`, `review-arbiter`, and `fixer` |
+| `claude_role_transport` | Codex-led Claude transport policy: `auto` (default), `background-agent`, or `bridge` |
 | `quest_id_format` | `slug-first` (default) or `date-first`; affects only new Quest folder names |
 | `review_mode` | `auto` (default), `fast`, or `full` for Codex reviews |
 | `fast_review_thresholds` | File/LOC thresholds used when `review_mode: auto` |
 
 Quest IDs use `<slug>_YYYY-MM-DD__HHMM` by default. Set `"quest_id_format": "date-first"` to create new quests as `YYYY-MM-DD_HHMM__<slug>` for chronological `.quest/` sorting. Existing folders are not renamed, and resume accepts both formats in mixed repositories.
+
+The `.ai/allowlist.json` `models.<role>` values are repository defaults used at
+Quest startup. The chooser expands them to all nine roles, validates the active
+model families against preflight, and allows per-quest overrides. It then saves
+the selected role map and Claude transport metadata in
+`.quest/<id>/orchestration.json`. Every role dispatch reads that saved per-quest
+file; it does not reread the allowlist as live configuration.
 
 
 ### 2. Gitignore
@@ -213,28 +225,44 @@ The `.quest/` folder contains ephemeral run state and should not be committed.
 
 ## One-Time MCP Setup (if using Codex)
 
-If you want to use Codex for reviews and arbiter, add the config to `.claude/mcp.json` (see [Prerequisites](#optional-codex-mcp-for-dual-model-reviews) above).
+If you want a Claude-led Quest to assign any role to a Codex-backed model, add
+the config to `.claude/mcp.json` (see
+[Prerequisites](#optional-codex-mcp-for-dual-model-reviews) above).
 
 This enables the `mcp__codex-cli__codex` tool for spawning Codex agents.
 
-If you don't have Codex or prefer Claude for all roles, set the role models in
-`.ai/allowlist.json` `models` (the same keys shown in the configuration table
-above):
+Quest runs preflight before creating a new quest. Use the command matching the
+current orchestrator:
+
+```bash
+./scripts/quest_preflight.sh --orchestrator claude
+./scripts/quest_preflight.sh --orchestrator codex
+```
+
+Claude-led preflight verifies the Codex MCP runtime when Codex-backed models are
+selected. Codex-led preflight verifies the configured Claude transport when
+Claude-family models are selected. An unavailable configured runtime pauses
+startup for remediation, an explicit supported transport choice, a deliberate
+single-model remap, or cancellation.
+
+To deliberately use Claude for every role, set all nine role models in
+`.ai/allowlist.json` `models`:
 
 ```json
 {
   "models": {
     "planner": "claude",
+    "plan-reviewer-a": "claude",
     "plan-reviewer-b": "claude",
     "arbiter": "claude",
     "builder": "claude",
+    "code-reviewer-a": "claude",
     "code-reviewer-b": "claude",
+    "review-arbiter": "claude",
     "fixer": "claude"
   }
 }
 ```
-
-The plan and code reviewers will also fall back to Claude if Codex is unavailable.
 
 ## Codex-Led Claude Transports
 
@@ -286,18 +314,18 @@ Quest uses a purpose-built CLI bridge (`scripts/quest_claude_bridge.py`) instead
 
 The bridge script itself is Quest-agnostic, it's a generic utility for calling Claude CLI with structured options. The Quest-specific behavior (handoff polling, logging, text fallback) lives in `quest_claude_runner.py`.
 
-For the full architecture rationale, see [Why the Bridge, Not MCP](quest_presentation.md#why-the-bridge-not-mcp) in the presentation doc.
-
 ### What Quest handles automatically
 
 - Probes the configured transport once per session and retains recent successful host probes (bg under `auto`; bridge only when explicitly configured/selected)
 - Sweeps orphaned `quest-<id>-*` background sessions and stale `quest-bg-probe-*` probe sessions at quest start/resume (`python3 scripts/claude_bg_run.py --sweep quest-<id>-` and `python3 scripts/claude_bg_run.py --sweep quest-bg-probe-`)
-- Routes Claude-designated roles (planner, reviewer A, arbiter) through `scripts/quest_claude_runner.py --model <models.<role>> --transport <resolved>` in the same host-visible context used for the probe/cache refresh
+- Routes every role whose saved model is Claude-family through `scripts/quest_claude_runner.py --model <models.<role>> --transport <resolved>` in the same host-visible context used for the probe/cache refresh
 - Keeps background-agent `needs_human` sessions parked for same-session resume, then resumes with `--resume <session_id> --answer-file <answer_file>` and updates the chained session id after Claude forks a continuation
 - Records the transport per role in `context_health.log` (`transport=background-agent|bridge`) and reports it in the quest end summary and celebration
-- Claude-led quests are unaffected, they keep native `Task(...)` execution
+- Claude-family roles in Claude-led quests keep native `Task(...)` execution
 
-If the probe fails, Claude-designated roles will block until the CLI/auth setup is fixed.
+If the probe fails, Quest pauses startup for the explicit remediation or
+single-model choices described above; it does not silently select the bridge or
+rewrite role models.
 
 ### Optional: manual verification
 
@@ -369,15 +397,18 @@ See `.ai/quest.md` for full usage documentation.
 
 Each agent runs in **complete isolation** — no shared conversation history:
 
-**Claude agents** (planner, builder, fixer, plan-reviewer):
-- Spawned via Task tool with `subagent_type: general-purpose`
-- Receive assembled prompt with role instructions from `.skills/quest/agents/*.md`
-- Start fresh, return handoff when done
+For every role, Quest reads `models.<role>` from the active quest's
+`orchestration.json`, derives the Claude or Codex runtime family, and then uses
+the entrypoint for the current orchestrator:
 
-**Codex agents** (code-reviewer, arbiter when configured):
-- Called via `mcp__codex-cli__codex` MCP tool
-- Completely separate model (GPT 5.x)
-- Receive assembled prompt, return handoff
+- Claude-led + Claude-family: native isolated task
+- Claude-led + Codex-backed: Codex MCP
+- Codex-led + Codex-backed: local Codex subagent
+- Codex-led + Claude-family: `scripts/quest_claude_runner.py` with the resolved
+  `background-agent` or explicitly selected `bridge` transport
+
+Each role receives an assembled prompt with its instructions and returns an
+artifact-backed handoff without sharing conversation history with other roles.
 
 ### Human as Gatekeeper
 
@@ -419,9 +450,14 @@ Check that your `allowlist.json` has the correct paths in `file_write` for the r
 
 If you have Codex installed but it's not being used:
 
-1. Check MCP is configured: `claude mcp list`
-2. Verify `allowlist.json` has `"arbiter": {"tool": "codex"}`
-3. The system falls back to Claude if Codex fails
+1. Run the preflight command for the active orchestrator and address every
+   reported availability warning.
+2. Inspect `.quest/<id>/orchestration.json` and verify the affected
+   `models.<role>` entries select the intended Codex-backed model.
+3. For Claude-led quests, check that MCP is configured with `claude mcp list`.
+4. To change repository defaults for future quests, update the corresponding
+   `.ai/allowlist.json` `models.<role>` values. Existing quests continue using
+   their saved orchestration file.
 
 ### Quest state is stale
 

--- a/docs/guides/quest_setup.md
+++ b/docs/guides/quest_setup.md
@@ -26,7 +26,9 @@ Quest can use Codex as a second reviewer. This gives you two different model fam
 
 **Requires:**
 - [Codex CLI](https://developers.openai.com/codex/cli/) installed globally (`npm i -g @openai/codex`)
-- Either `OPENAI_API_KEY` in your environment or a Codex login (`codex` → `/login`)
+- A CLI-confirmed Codex login: run `codex login`, then verify that
+  `codex login status` succeeds. `OPENAI_API_KEY` is diagnostic-only in Quest
+  preflight and does not replace the CLI login.
 
 Register the Codex MCP server globally (one-time setup):
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-07-14 | [installed-docs](installed-docs_2026-07-14.md) | Implement Workstream C — Installed documentation accuracy from `ideas/2026-07-11-quest-hardening.md` using the comple... |
 | 2026-07-12 | [operational-contracts](operational-contracts_2026-07-12.md) | ### Problem Three operational contracts currently trust the wrong boundary: 1. `pr_sync_default_branch.py` lets an ad... |
 | 2026-07-11 | [runtime-trust-state-boundaries](runtime-trust-state-boundaries_2026-07-11.md) | Implement Workstream A — Runtime trust and state boundaries from `ideas/2026-07-11-quest-hardening.md`. Scope is stri... |
 | 2026-07-11 | [host-safe-manifest-validation](host-safe-manifest-validation_2026-07-11.md) | Implement the Quest manifest-validation bugfix through the full Quest workflow. Quest is used in two supported topolo... |

--- a/docs/quest-journal/celebrations/installed-docs_2026-07-14.md
+++ b/docs/quest-journal/celebrations/installed-docs_2026-07-14.md
@@ -1,0 +1,106 @@
+<!-- quest-id: installed-docs_2026-07-13__1201 -->
+<!-- style: celebration -->
+<!-- quality-tier: Bronze -->
+<!-- date: 2026-07-14 -->
+<!-- journal: ../installed-docs_2026-07-14.md -->
+<!-- origin: step7-original -->
+
+# Quest Celebration: Quest brief: Installed documentation accuracy
+
+```text
+ ██████╗ ██╗   ██╗███████╗███████╗████████╗
+██╔═══██╗██║   ██║██╔════╝██╔════╝╚══██╔══╝
+██║   ██║██║   ██║█████╗  ███████╗   ██║
+██║▄▄ ██║██║   ██║██╔══╝  ╚════██║   ██║
+╚██████╔╝╚██████╔╝███████╗███████║   ██║
+ ╚══▀▀═╝  ╚═════╝ ╚══════╝╚══════╝   ╚═╝
+
+██████╗ ██████╗ ██╗███████╗███████╗
+██╔══██╗██╔══██╗██║██╔════╝██╔════╝
+██████╔╝██████╔╝██║█████╗  █████╗
+██╔══██╗██╔══██╗██║██╔══╝  ██╔══╝
+██████╔╝██║  ██║██║███████╗██║
+╚═════╝ ╚═╝  ╚═╝╚═╝╚══════╝╚═╝
+
+██╗███╗   ██╗███████╗████████╗ █████╗ ██╗     ██╗     ███████╗██████╗
+██║████╗  ██║██╔════╝╚══██╔══╝██╔══██╗██║     ██║     ██╔════╝██╔══██╗
+██║██╔██╗ ██║███████╗   ██║   ███████║██║     ██║     █████╗  ██║  ██║
+██║██║╚██╗██║╚════██║   ██║   ██╔══██║██║     ██║     ██╔══╝  ██║  ██║
+██║██║ ╚████║███████║   ██║   ██║  ██║███████╗███████╗███████╗██████╔╝
+╚═╝╚═╝  ╚═══╝╚══════╝   ╚═╝   ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═════╝
+
+██████╗  ██████╗  ██████╗██╗   ██╗███╗   ███╗███████╗
+██╔══██╗██╔═══██╗██╔════╝██║   ██║████╗ ████║██╔════╝
+██║  ██║██║   ██║██║     ██║   ██║██╔████╔██║█████╗
+██║  ██║██║   ██║██║     ██║   ██║██║╚██╔╝██║██╔══╝
+██████╔╝╚██████╔╝╚██████╗╚██████╔╝██║ ╚═╝ ██║███████╗
+╚═════╝  ╚═════╝  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚══════╝
+
+███╗   ██╗████████╗ █████╗ ████████╗██╗ ██████╗ ███╗   ██╗
+████╗  ██║╚══██╔══╝██╔══██╗╚══██╔══╝██║██╔═══██╗████╗  ██║
+██╔██╗ ██║   ██║   ███████║   ██║   ██║██║   ██║██╔██╗ ██║
+██║╚██╗██║   ██║   ██╔══██║   ██║   ██║██║   ██║██║╚██╗██║
+██║ ╚████║   ██║   ██║  ██║   ██║   ██║╚██████╔╝██║ ╚████║
+╚═╝  ╚═══╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝   ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+
+ █████╗  ██████╗ ██████╗██╗   ██╗██████╗  █████╗  ██████╗██╗   ██╗
+██╔══██╗██╔════╝██╔════╝██║   ██║██╔══██╗██╔══██╗██╔════╝╚██╗ ██╔╝
+███████║██║     ██║     ██║   ██║██████╔╝███████║██║      ╚████╔╝
+██╔══██║██║     ██║     ██║   ██║██╔══██╗██╔══██║██║       ╚██╔╝
+██║  ██║╚██████╗╚██████╗╚██████╔╝██║  ██║██║  ██║╚██████╗   ██║
+╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝   ╚═╝
+```
+
+---
+
+## What Started This
+
+Implement Workstream C — Installed documentation accuracy from ideas/2026-07-11-quest-hardening.md` using the complete Quest workflow and approval gates in an isolated worktree. Do not modify Candid Talent Edge.
+
+## Starring Cast
+
+- **arbiter** ........ The Judge
+- **builder** ........ The Implementer
+
+## Achievements
+
+- [BUG] **Gremlin Slayer** — Tackled 26 review findings
+- [TEST] **Battle Tested** — Survived 6 reviews
+- [PLAN] **Plan Perfectionist** — Iterated plan 3 times
+- [WIN] **Quest Complete** — All phases finished successfully
+
+## Impact Metrics
+
+- Review findings addressed: **26**
+- Review rounds completed: **6**
+- Plan iterations: **3**
+- Fix iterations: **1**
+
+## Handoff & Reliability
+
+- Handoffs parsed: 2
+- Reviewer handoffs: 0
+- Fixer handoffs: 0
+- Review findings tracked: 26
+- Reliability signal: medium
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## 🥉 Quality Tier: Bronze
+
+QUALITY SCORE
+----------------------------------------
+  [████████████████░░░░] 80% (Grade: B)
+
+
+## Quest Quote
+
+> "Review boundary holds.** The complete core diff (roadmap `[ongoing]` marker + two test modules + guide edits + any fixes) stays uncommitted through dual code review and the fix loop. Commit, push, manual consumer install, and draft-PR creation are orchestrator-owned and happen only after review/validation (Slice 6); the C `[done]` + PR-link change is a distinct second commit after the PR exists (Slice 7). HEAD is frozen at `bba0a0d…` and asserted at Builder/reviewer/Fixer boundaries (AC7, AC9). Builder/Fixer never commit."
+>
+> — Review finding
+
+## Victory Narrative
+
+Implement Workstream C — Installed documentation accuracy from ideas/2026-07-11-quest-hardening.md` using the complete Quest workflow and approval gates in an isolated worktree. Do not modify Candid Talent Edge. The quest finished with 3 plan iteration(s), 1 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/celebrations/installed-docs_2026-07-14.md
+++ b/docs/quest-journal/celebrations/installed-docs_2026-07-14.md
@@ -97,7 +97,7 @@ QUALITY SCORE
 
 ## Quest Quote
 
-> "Review boundary holds.** The complete core diff (roadmap `[ongoing]` marker + two test modules + guide edits + any fixes) stays uncommitted through dual code review and the fix loop. Commit, push, manual consumer install, and draft-PR creation are orchestrator-owned and happen only after review/validation (Slice 6); the C `[done]` + PR-link change is a distinct second commit after the PR exists (Slice 7). HEAD is frozen at `bba0a0d…` and asserted at Builder/reviewer/Fixer boundaries (AC7, AC9). Builder/Fixer never commit."
+> "Review boundary holds." The complete core diff (roadmap `[ongoing]` marker + two test modules + guide edits + any fixes) stays uncommitted through dual code review and the fix loop. Commit, push, manual consumer install, and draft-PR creation are orchestrator-owned and happen only after review/validation (Slice 6); the C `[done]` + PR-link change is a distinct second commit after the PR exists (Slice 7). HEAD is frozen at `bba0a0d…` and asserted at Builder/reviewer/Fixer boundaries (AC7, AC9). Builder/Fixer never commit."
 >
 > — Review finding
 

--- a/docs/quest-journal/installed-docs_2026-07-14.md
+++ b/docs/quest-journal/installed-docs_2026-07-14.md
@@ -1,0 +1,188 @@
+# Quest Journal: Quest brief: Installed documentation accuracy
+
+- Quest ID: `installed-docs_2026-07-13__1201`
+- Slug: installed-docs
+- Completed: 2026-07-14
+- Mode: workflow
+- Quality: Bronze
+- Celebration: [`celebrations/installed-docs_2026-07-14.md`](celebrations/installed-docs_2026-07-14.md)
+- Outcome: Implement Workstream C — Installed documentation accuracy from `ideas/2026-07-11-quest-hardening.md` using the complete Quest workflow and approval gates in an isolated worktree. Do not modify Cand...
+
+## What Shipped
+
+**Problem:** The Quest-owned setup guide that is installed into consumer
+repositories mixes obsolete runtime configuration (`arbiter.tool`), an
+unconditional Claude-fallback claim, and a relative link to
+`quest_presentation.md`, a source-repository document that Quest does not own or
+install. A c...
+
+## Files Changed
+
+- `.quest/installed-docs_2026-07-13__1201/phase_01_plan/plan.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/installed-docs_2026-07-13__1201/phase_01_plan/review_findings.json.next`
+- `.quest/installed-docs_2026-07-13__1201/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_02_implementation/pr_description.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_03_review/review_code-reviewer-a.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_03_review/review_findings_code-reviewer-a.json`
+- `.quest/installed-docs_2026-07-13__1201/phase_03_review/review_code-reviewer-b.md`
+- `.quest/installed-docs_2026-07-13__1201/phase_03_review/review_findings_code-reviewer-b.json`
+- `.quest/installed-docs_2026-07-13__1201/phase_03_review/review_fix_feedback_discussion.md`
+
+## Iterations
+
+- Plan iterations: 3
+- Fix iterations: 1
+
+## Agents
+
+- **The Judge** (arbiter):
+- **The Implementer** (builder):
+
+## Quest Brief
+
+Implement Workstream C — Installed documentation accuracy from
+`ideas/2026-07-11-quest-hardening.md` using the complete Quest workflow and
+approval gates in an isolated worktree. Do not modify Candid Talent Edge.
+
+Preconditions and lifecycle:
+
+- Workstreams A and B must each have a merged PR, `main` must contain both
+  merges, and both plan rows must be `[done]` with PR links.
+- Before implementation, mark Workstream C `[ongoing]` without altering A or B.
+- Create the complete Workstream C draft PR, then mark C `[done]`, record its PR
+  number/link, archive the all-done plan to
+  `ideas/archive/2026-07-11-quest-hardening.md`, and update `ideas/README.md` so
+  the same PR carries the lifecycle follow-up.
+- `[done]` means the PR exists; readiness and merge stay tracked on GitHub.
+
+Scope is strictly original findings #16 and #17:
+
+- Update `docs/guides/quest_setup.md` to describe supported `models.<role>`
+  configuration, per-quest `orchestration.json`, preflight, and
+  `claude_role_transport` accurately. Remove obsolete `arbiter.tool` guidance
+  and any unconditional Claude-fallback promise.
+- Remove the manifest-owned setup guide's deep link to
+  `quest_presentation.md`. Every remaining relative link in the installed guide
+  must resolve through Quest-owned installed files.
+
+Ownership boundaries:
+
+- Do not add `quest_presentation.md` to `.quest-manifest`.
+- Do not expand Quest ownership into host documentation or add host-owned files
+  merely to make source-checkout links pass.
+- Validate installed-consumer topology, not only the Quest source checkout.
+
+Acceptance and testing requirements:
+
+1. No `arbiter.tool` configuration instruction remains.
+2. Supported `models.<role>` and `claude_role_transport` contracts are accurate.
+3. No unsupported fallback behavior is promised.
+4. A clean installed-consumer fixture has no dangling relative links from the
+   modified setup sections.
+5. `quest_presentation.md` remains outside `.quest-manifest`.
+6. No unrelated host-owned file enters Quest's manifest/checksum ownership.
+7. Add focused terminology assertions, not brittle whole-paragraph snapshots.
+8. Add a temporary installed-consumer link/ownership test and manually inspect
+   every remaining local link in the modified sections.
+9. Run the requested focused documentation and manifest tests, relevant
+   installer/install-surface tests, strict source manifest/checksum validation,
+   and repository formatting/lint gates.
+
+Keep the change documentation-focused and minimal under KISS and YAGNI. Do not
+create a new documentation framework or broad prose snapshot test.
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- Full celebration: [`celebrations/installed-docs_2026-07-14.md`](celebrations/installed-docs_2026-07-14.md)
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/installed-docs_2026-07-14.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge",
+      "transport": "background-agent"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "claude_transport_counts": {
+    "background-agent": 11
+  },
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 26 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 6 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 3 times"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 3"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 1"
+    },
+    {
+      "icon": "📝",
+      "label": "Review rounds: 6"
+    },
+    {
+      "icon": "🚌",
+      "label": "Claude transport: background-agent ×11"
+    }
+  ],
+  "quality": {
+    "tier": "Bronze",
+    "grade": "B"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 12
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -74,7 +74,7 @@ delivery speed and may proceed in parallel.
 |---|---|---|---|---|
 | [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [done] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | [#150](https://github.com/KjellKod/quest/pull/150) |
-| [todo] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
+| [ongoing] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
 | [todo] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
 
 ## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
@@ -316,7 +316,7 @@ content and GitHub comment ownership.
   restore a non-conflicted worktree with actionable JSON.
 - **Observability:** exit code, JSON payload, `git status --porcelain`, and graph.
 
-## Workstream C — Installed documentation accuracy [todo]
+## Workstream C — Installed documentation accuracy [ongoing]
 
 ### Goal
 

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -74,7 +74,7 @@ delivery speed and may proceed in parallel.
 |---|---|---|---|---|
 | [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [done] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | [#150](https://github.com/KjellKod/quest/pull/150) |
-| [ongoing] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | — |
+| [done] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | [#152](https://github.com/KjellKod/quest/pull/152) |
 | [todo] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
 
 ## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
@@ -316,7 +316,7 @@ content and GitHub comment ownership.
   restore a non-conflicted worktree with actionable JSON.
 - **Observability:** exit code, JSON payload, `git status --porcelain`, and graph.
 
-## Workstream C — Installed documentation accuracy [ongoing]
+## Workstream C — Installed documentation accuracy [done] — [PR #152](https://github.com/KjellKod/quest/pull/152)
 
 ### Goal
 

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -77,6 +77,59 @@ def test_docs_state_artifact_driven_orchestration_principle() -> None:
     assert "handoff.json" in workflow
 
 
+def test_setup_guide_documents_current_model_and_transport_contracts() -> None:
+    setup = _read("docs/guides/quest_setup.md")
+
+    required_terms = (
+        "models.<role>",
+        ".ai/allowlist.json",
+        ".quest/<id>/orchestration.json",
+        "claude_role_transport",
+        "auto",
+        "background-agent",
+        "bridge",
+        "scripts/quest_preflight.sh --orchestrator claude",
+        "scripts/quest_preflight.sh --orchestrator codex",
+    )
+    for term in required_terms:
+        assert term in setup, f"setup guide is missing current contract term: {term}"
+
+    model_config_row = next(
+        line for line in setup.splitlines() if line.startswith("| `models.<role>` |")
+    )
+    for role in (
+        "planner",
+        "plan-reviewer-a",
+        "plan-reviewer-b",
+        "arbiter",
+        "builder",
+        "code-reviewer-a",
+        "code-reviewer-b",
+        "review-arbiter",
+        "fixer",
+    ):
+        assert f"`{role}`" in model_config_row
+
+    transport_config_row = next(
+        line
+        for line in setup.splitlines()
+        if line.startswith("| `claude_role_transport` |")
+    )
+    for policy in ("`auto`", "`background-agent`", "`bridge`"):
+        assert policy in transport_config_row
+
+    stale_instructions = (
+        "arbiter.tool",
+        '"arbiter": {"tool": "codex"}',
+        "The plan and code reviewers will also fall back to Claude if Codex is unavailable.",
+        "The system falls back to Claude if Codex fails",
+    )
+    for instruction in stale_instructions:
+        assert instruction not in setup, (
+            f"setup guide contains obsolete runtime guidance: {instruction}"
+        )
+
+
 def test_docs_contract_scope_excludes_history_and_journal_archives() -> None:
     assert (_repo_root() / "docs" / "quest-journal").exists()
     assert all(not path.startswith("docs/quest-journal/") for path in ACTIVE_DOCS)

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import fnmatch
+import re
+import shutil
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
 
 def _repo_root() -> Path:
@@ -19,6 +22,43 @@ def _manifest_entries() -> list[str]:
             continue
         entries.append(line)
     return entries
+
+
+def _manifest_file_entries() -> list[str]:
+    manifest = _repo_root() / ".quest-manifest"
+    entries: list[str] = []
+    section = ""
+    for raw_line in manifest.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        if not line or line.startswith("#") or section == "directories":
+            continue
+        entries.append(line)
+    return entries
+
+
+def _inline_markdown_targets(markdown: str) -> list[str]:
+    targets: list[str] = []
+    for match in re.finditer(r"(?<!!)\[[^\]]+\]\(([^)]+)\)", markdown):
+        raw_target = match.group(1).strip()
+        if raw_target.startswith("<") and ">" in raw_target:
+            target = raw_target[1 : raw_target.index(">")]
+        else:
+            target = raw_target.split(maxsplit=1)[0]
+        targets.append(target)
+    return targets
+
+
+def _guide_heading_slugs(markdown: str) -> set[str]:
+    slugs: set[str] = set()
+    for heading in re.findall(r"^#{1,6}\s+(.+?)\s*$", markdown, flags=re.MULTILINE):
+        slug = heading.lower()
+        for punctuation in ":()":
+            slug = slug.replace(punctuation, "")
+        slugs.add(re.sub(r"\s+", "-", slug.strip()))
+    return slugs
 
 
 def _validator_patterns() -> list[str]:
@@ -84,6 +124,85 @@ def test_manifest_validator_patterns_cover_installed_quest_surface() -> None:
 
 def test_manifest_includes_installed_quest_setup_guide() -> None:
     assert "docs/guides/quest_setup.md" in set(_manifest_entries())
+
+
+def test_installed_setup_guide_relative_links_resolve_to_manifest_owned_files(
+    tmp_path: Path,
+) -> None:
+    repo_root = _repo_root()
+    owned_files = set(_manifest_file_entries())
+    for entry in owned_files:
+        source = repo_root / entry
+        if not source.is_file():
+            continue
+        destination = tmp_path / entry
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    guide_entry = "docs/guides/quest_setup.md"
+    installed_guide = tmp_path / guide_entry
+    guide_text = installed_guide.read_text(encoding="utf-8")
+    local_targets = [
+        target
+        for target in _inline_markdown_targets(guide_text)
+        if not urlsplit(target).scheme and not target.startswith("//")
+    ]
+
+    assert local_targets, "expected at least one installed-guide local link"
+    assert "#optional-codex-mcp-for-dual-model-reviews" in local_targets
+
+    resolved_targets: list[str] = []
+    for target in local_targets:
+        path_text, _, fragment = target.partition("#")
+        relative_path = Path(unquote(path_text)) if path_text else Path(guide_entry)
+        if path_text:
+            target_path = (installed_guide.parent / relative_path).resolve()
+        else:
+            target_path = installed_guide.resolve()
+        try:
+            installed_entry = target_path.relative_to(tmp_path.resolve()).as_posix()
+        except ValueError:
+            raise AssertionError(f"local guide link escapes installed fixture: {target}")
+
+        assert installed_entry in owned_files, (
+            f"local guide link is not Quest-owned: {target} -> {installed_entry}"
+        )
+        assert target_path.is_file(), f"local guide link is not installed: {target}"
+        if not path_text and fragment:
+            assert fragment in _guide_heading_slugs(guide_text), (
+                f"local guide fragment does not match a heading: {target}"
+            )
+        resolved_targets.append(target)
+
+    assert len(resolved_targets) == len(local_targets)
+
+
+def test_installed_setup_guide_has_no_unchecked_relative_reference_links() -> None:
+    guide = (_repo_root() / "docs/guides/quest_setup.md").read_text(encoding="utf-8")
+    relative_definitions: list[str] = []
+    for target in re.findall(
+        r"^\s{0,3}\[[^\]]+\]:\s*(\S+)", guide, flags=re.MULTILINE
+    ):
+        normalized = (
+            target[1:-1]
+            if target.startswith("<") and target.endswith(">")
+            else target
+        )
+        if not urlsplit(normalized).scheme and not normalized.startswith("//"):
+            relative_definitions.append(normalized)
+
+    assert relative_definitions == [], (
+        "relative reference-style links are not covered by the installed-guide "
+        "resolver; extend it deliberately before using this syntax: "
+        + ", ".join(relative_definitions)
+    )
+
+
+def test_manifest_does_not_own_quest_presentation() -> None:
+    entries = set(_manifest_file_entries())
+
+    assert "docs/guides/quest_presentation.md" not in entries
+    assert "quest_presentation.md" not in entries
 
 
 def test_manifest_validator_does_not_scan_repo_tests() -> None:

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -54,9 +54,7 @@ def _inline_markdown_targets(markdown: str) -> list[str]:
 def _guide_heading_slugs(markdown: str) -> set[str]:
     slugs: set[str] = set()
     for heading in re.findall(r"^#{1,6}\s+(.+?)\s*$", markdown, flags=re.MULTILINE):
-        slug = heading.lower()
-        for punctuation in ":()":
-            slug = slug.replace(punctuation, "")
+        slug = re.sub(r"[^\w\s-]", "", heading.lower())
         slugs.add(re.sub(r"\s+", "-", slug.strip()))
     return slugs
 
@@ -175,6 +173,12 @@ def test_installed_setup_guide_relative_links_resolve_to_manifest_owned_files(
         resolved_targets.append(target)
 
     assert len(resolved_targets) == len(local_targets)
+
+
+def test_guide_heading_slugs_strip_github_anchor_punctuation() -> None:
+    markdown = "### What's next? Ready, set... go!"
+
+    assert _guide_heading_slugs(markdown) == {"whats-next-ready-set-go"}
 
 
 def test_installed_setup_guide_has_no_unchecked_relative_reference_links() -> None:


### PR DESCRIPTION
## ⭐ Why this matters

Repositories that install Quest should receive setup instructions matching the runtime they actually run. This removes obsolete configuration and fallback guidance while ensuring local links stay within Quest’s owned installation surface.

---

## Summary

Correct the installed setup guide’s model, preflight, and Claude transport contracts without expanding Quest’s documentation ownership.

- Keep `quest_presentation.md` outside the manifest-owned consumer surface.
- Add focused documentation and installed-topology regression coverage.
- Record Workstream C as done while keeping the roadmap active for Workstream D.

## Changes

- **Documentation**:
  - Replace obsolete `arbiter.tool` guidance with all nine supported `models.<role>` keys and per-quest `.quest/<id>/orchestration.json` precedence.
  - Document preflight and the `auto`, `background-agent`, and explicit `bridge` transport policies without promising automatic fallback.
  - Remove the installed guide’s link to unowned `quest_presentation.md`.
- **Tests**:
  - Add focused terminology assertions for current model and transport contracts.
  - Build a temporary consumer from manifest-owned files and verify every local guide link resolves to an installed, owned target.
  - Assert that `quest_presentation.md` remains outside `.quest-manifest`.
- **Roadmap**:
  - Record Workstream C and its draft PR while preserving completed A/B records and leaving Workstream D todo.
  - Keep the roadmap active until Workstream D is complete.
- **Quest record**:
  - Add the generated Quest journal and celebration record.

## Validation

- [x] `python3 -m pytest tests/ -q` — 1,038 passed.
- [x] `bash tests/test-quest-runtime.sh` — 50 passed.
- [x] `bash tests/test-quest-preflight.sh` — 19 passed.
- [x] `bash tests/test-validate-quest-state.sh` — 68 passed.
- [x] `bash scripts/quest_validate-manifest.sh --strict`, configuration validation, handoff validation, and `git diff --check`.
- [x] **Installed-consumer walkthrough**: Prerequisites: run from the Quest checkout after this branch is pushed. Action: create a temporary Git repository and install `quest/installed-docs` with `QUEST_ROOT=$PWD; tmp=$(mktemp -d); git -C "$tmp" init -q; (cd "$tmp" && bash "$QUEST_ROOT/scripts/quest_installer.sh" --branch quest/installed-docs --force)`, then inspect `docs/guides/quest_setup.md`. Expected: its sole local link resolves to `#optional-codex-mcp-for-dual-model-reviews`. Negative case: `docs/guides/quest_presentation.md` is neither installed nor manifest-owned.

## Notes

- `.quest-manifest` and `.quest-checksums` are intentionally unchanged.
- The checksum helper reports the same 63 pre-existing drift entries as baseline `HEAD`; this branch introduces no checksum drift.
- Workstream D keeps the roadmap active and unarchived.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex GPT-5.6 Sol &lt;noreply@openai.com&gt;
Co-Authored-By: Codex GPT-5.6 Terra &lt;noreply@openai.com&gt;
Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

