### PR TITLE
Enforce source-only Python formatting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+hook_dir=$(CDPATH= cd -P "$(dirname "$0")" && pwd) || exit 1
+repo_root=$(CDPATH= cd -P "$hook_dir/.." && pwd) || exit 1
+cd "$repo_root" || exit 1
+
+./scripts/quest_validate-quest-config.sh || exit $?
+
+if python3 -m black --check .; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+Python formatting check failed.
+Install the pinned development dependency:
+  python3 -m pip install -e '.[dev]'
+Format the repository, then retry the commit:
+  python3 -m black .
+EOF
+exit 1

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -37,10 +37,15 @@ jobs:
           fi
 
       - name: Set up Python
-        if: steps.check-tests.outputs.has_tests == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+
+      - name: Install Black
+        run: python3 -m pip install black==24.10.0
+
+      - name: Check Python formatting
+        run: python3 -m black --check .
 
       - name: Install test dependencies
         if: steps.check-tests.outputs.has_tests == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Python
 __pycache__/
+*.egg-info/
 
 # OS files
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,31 @@
 
 ## Development Setup
 
-### Pre-commit Hook (Recommended)
+### Required Development Setup
 
-Install the validation hook to catch configuration errors before commit:
+Install the pinned development dependencies and configure this repository to
+use its versioned pre-commit hook:
 
 ```bash
-./scripts/quest_validate-quest-config.sh --install
+python3 -m pip install -e '.[dev]'
+git config core.hooksPath .githooks
 ```
 
-This creates a symlink so the hook stays in sync with script updates.
+Every Quest contributor must configure `core.hooksPath` after cloning because
+Git cannot propagate this local setting through a clone. The hook runs the
+existing Quest configuration validation followed by
+`python3 -m black --check .`. It is check-only and never rewrites files during
+a commit.
 
-To remove:
+Check or format the source repository directly with:
+
 ```bash
-./scripts/quest_validate-quest-config.sh --uninstall
+python3 -m black --check .
+python3 -m black .
 ```
+
+The local hook can be bypassed, so CI is the authoritative, non-bypassable
+formatting gate.
 
 ### Manual Validation
 
@@ -46,7 +57,9 @@ The validation script checks:
 
 ## CI
 
-GitHub Actions runs the same validation on every push and PR. See `.github/workflows/validate-quest.yml`.
+GitHub Actions runs the same validation on every push and PR. See
+`.github/workflows/validate-quest-config.yml`. The Python workflow also enforces
+Black formatting for the Quest source repository.
 
 ## UI/UX Contributions
 

--- a/docs/quest-journal/README.md
+++ b/docs/quest-journal/README.md
@@ -6,6 +6,7 @@ Permanent record of quest runs. Each entry captures what was attempted, what shi
 
 | Date | Quest | Outcome |
 |------|-------|---------|
+| 2026-07-15 | [source-python-formatting](source-python-formatting_2026-07-15.md) | Implement Workstream D — Source-repository Python formatting from `ideas/2026-07-11-quest-hardening.md`. Precondition... |
 | 2026-07-14 | [installed-docs](installed-docs_2026-07-14.md) | Implement Workstream C — Installed documentation accuracy from `ideas/2026-07-11-quest-hardening.md` using the comple... |
 | 2026-07-12 | [operational-contracts](operational-contracts_2026-07-12.md) | ### Problem Three operational contracts currently trust the wrong boundary: 1. `pr_sync_default_branch.py` lets an ad... |
 | 2026-07-11 | [runtime-trust-state-boundaries](runtime-trust-state-boundaries_2026-07-11.md) | Implement Workstream A — Runtime trust and state boundaries from `ideas/2026-07-11-quest-hardening.md`. Scope is stri... |

--- a/docs/quest-journal/celebrations/source-python-formatting_2026-07-15.md
+++ b/docs/quest-journal/celebrations/source-python-formatting_2026-07-15.md
@@ -55,7 +55,7 @@
 
 ## What Started This
 
-Implement Workstream D — Source-repository Python formatting from ideas/2026-07-11-quest-hardening.md`.
+Implement Workstream D — Source-repository Python formatting from `ideas/2026-07-11-quest-hardening.md`.
 
 ## Starring Cast
 
@@ -103,4 +103,4 @@ QUALITY SCORE
 
 ## Victory Narrative
 
-Implement Workstream D — Source-repository Python formatting from ideas/2026-07-11-quest-hardening.md`. The quest finished with 2 plan iteration(s), 0 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.
+Implement Workstream D — Source-repository Python formatting from `ideas/2026-07-11-quest-hardening.md`. The quest finished with 2 plan iteration(s), 0 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/celebrations/source-python-formatting_2026-07-15.md
+++ b/docs/quest-journal/celebrations/source-python-formatting_2026-07-15.md
@@ -1,0 +1,106 @@
+<!-- quest-id: source-python-formatting_2026-07-14__1723 -->
+<!-- style: celebration -->
+<!-- quality-tier: Gold -->
+<!-- date: 2026-07-15 -->
+<!-- journal: ../source-python-formatting_2026-07-15.md -->
+<!-- origin: step7-original -->
+
+# Quest Celebration: Source-repository Python formatting
+
+```text
+███████╗ ██████╗ ██╗   ██╗██████╗  ██████╗███████╗
+██╔════╝██╔═══██╗██║   ██║██╔══██╗██╔════╝██╔════╝
+███████╗██║   ██║██║   ██║██████╔╝██║     █████╗
+╚════██║██║   ██║██║   ██║██╔══██╗██║     ██╔══╝
+███████║╚██████╔╝╚██████╔╝██║  ██║╚██████╗███████╗
+╚══════╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═╝ ╚═════╝╚══════╝
+
+██████╗ ███████╗██████╗  ██████╗ ███████╗
+██╔══██╗██╔════╝██╔══██╗██╔═══██╗██╔════╝
+██████╔╝█████╗  ██████╔╝██║   ██║███████╗
+██╔══██╗██╔══╝  ██╔═══╝ ██║   ██║╚════██║
+██║  ██║███████╗██║     ╚██████╔╝███████║
+╚═╝  ╚═╝╚══════╝╚═╝      ╚═════╝ ╚══════╝
+
+██╗████████╗ ██████╗ ██████╗ ██╗   ██╗
+██║╚══██╔══╝██╔═══██╗██╔══██╗╚██╗ ██╔╝
+██║   ██║   ██║   ██║██████╔╝ ╚████╔╝
+██║   ██║   ██║   ██║██╔══██╗  ╚██╔╝
+██║   ██║   ╚██████╔╝██║  ██║   ██║
+╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝   ╚═╝
+
+██████╗ ██╗   ██╗████████╗██╗  ██╗ ██████╗ ███╗   ██╗
+██╔══██╗╚██╗ ██╔╝╚══██╔══╝██║  ██║██╔═══██╗████╗  ██║
+██████╔╝ ╚████╔╝    ██║   ███████║██║   ██║██╔██╗ ██║
+██╔═══╝   ╚██╔╝     ██║   ██╔══██║██║   ██║██║╚██╗██║
+██║        ██║      ██║   ██║  ██║╚██████╔╝██║ ╚████║
+╚═╝        ╚═╝      ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+
+███████╗ ██████╗ ██████╗ ███╗   ███╗ █████╗
+██╔════╝██╔═══██╗██╔══██╗████╗ ████║██╔══██╗
+█████╗  ██║   ██║██████╔╝██╔████╔██║███████║
+██╔══╝  ██║   ██║██╔══██╗██║╚██╔╝██║██╔══██║
+██║     ╚██████╔╝██║  ██║██║ ╚═╝ ██║██║  ██║
+╚═╝      ╚═════╝ ╚═╝  ╚═╝╚═╝     ╚═╝╚═╝  ╚═╝
+
+████████╗████████╗██╗███╗   ██╗ ██████╗
+╚══██╔══╝╚══██╔══╝██║████╗  ██║██╔════╝
+   ██║      ██║   ██║██╔██╗ ██║██║  ███╗
+   ██║      ██║   ██║██║╚██╗██║██║   ██║
+   ██║      ██║   ██║██║ ╚████║╚██████╔╝
+   ╚═╝      ╚═╝   ╚═╝╚═╝  ╚═══╝ ╚═════╝
+```
+
+---
+
+## What Started This
+
+Implement Workstream D — Source-repository Python formatting from ideas/2026-07-11-quest-hardening.md`.
+
+## Starring Cast
+
+- **arbiter** ........ The Judge
+- **builder** ........ The Implementer
+
+## Achievements
+
+- [BUG] **Gremlin Slayer** — Tackled 13 review findings
+- [TEST] **Battle Tested** — Survived 5 reviews
+- [PLAN] **Plan Perfectionist** — Iterated plan 2 times
+- [WIN] **Quest Complete** — All phases finished successfully
+
+## Impact Metrics
+
+- Review findings addressed: **13**
+- Review rounds completed: **5**
+- Plan iterations: **2**
+- Fix iterations: **0**
+
+## Handoff & Reliability
+
+- Handoffs parsed: 2
+- Reviewer handoffs: 0
+- Fixer handoffs: 0
+- Review findings tracked: 13
+- Reliability signal: high
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## 🥇 Quality Tier: Gold
+
+QUALITY SCORE
+----------------------------------------
+  [██████████████████░░] 90% (Grade: A)
+
+
+## Quest Quote
+
+> "All five iteration-1 arbiter findings are resolved with concrete, plan-level procedures, and each resolution was verified against the live source tree — not accepted on assertion."
+>
+> — Review finding
+
+## Victory Narrative
+
+Implement Workstream D — Source-repository Python formatting from ideas/2026-07-11-quest-hardening.md`. The quest finished with 2 plan iteration(s), 0 fix loop(s), and a persisted celebration artifact that future readers can open directly from the journal.

--- a/docs/quest-journal/source-python-formatting_2026-07-15.md
+++ b/docs/quest-journal/source-python-formatting_2026-07-15.md
@@ -1,0 +1,261 @@
+# Quest Journal: Source-repository Python formatting
+
+- Quest ID: `source-python-formatting_2026-07-14__1723`
+- Slug: source-python-formatting
+- Completed: 2026-07-15
+- Mode: workflow
+- Quality: Gold
+- Celebration: [`celebrations/source-python-formatting_2026-07-15.md`](celebrations/source-python-formatting_2026-07-15.md)
+- Outcome: Implement Workstream D — Source-repository Python formatting from `ideas/2026-07-11-quest-hardening.md`. Preconditions and workflow requirements: - Workstreams A, B, and C must each have a merged P...
+
+## What Shipped
+
+**Problem:** Quest's source repository does not declare a formatter dependency, provide mandatory contributor hook setup, or enforce Python formatting in CI. Current contributor instructions install a recommended symlink in `.git/hooks`; changing the installed validator to add Black would leak so...
+
+## Files Changed
+
+- `.quest/source-python-formatting_2026-07-14__1723/phase_01_plan/plan.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_01_plan/arbiter_verdict.md.next`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_01_plan/review_findings.json.next`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_01_plan/review_plan-reviewer-a.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_01_plan/review_plan-reviewer-b.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_02_implementation/pr_description.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_02_implementation/builder_feedback_discussion.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_code-reviewer-a.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_findings_code-reviewer-a.json`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_code-reviewer-b.md`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_findings_code-reviewer-b.json`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_arbiter_verdict.md.next`
+- `.quest/source-python-formatting_2026-07-14__1723/phase_03_review/review_findings.json.next`
+
+## Iterations
+
+- Plan iterations: 2
+- Fix iterations: 0
+
+## Agents
+
+- **The Judge** (arbiter):
+- **The Implementer** (builder):
+
+## Quest Brief
+
+Implement Workstream D — Source-repository Python formatting from
+`ideas/2026-07-11-quest-hardening.md`.
+
+Preconditions and workflow requirements:
+
+- Workstreams A, B, and C must each have a merged PR.
+- Start from updated `main` containing PRs #149, #150, and #152.
+- Their roadmap rows must be `[done]` with PR links.
+- Use an isolated worktree.
+- Do not modify Candid Talent Edge.
+- Follow the complete full Quest workflow and approval gates: routing, plan,
+  dual plan review, arbiter, presentation and explicit approval,
+  implementation, dual code review, fixes, validation, commit approval, push
+  approval, draft PR creation, and lifecycle/archive follow-up.
+
+Intent and policy correction:
+
+- Python formatting is mandatory policy for the Quest source repository. It
+  must never be installed into or enforced in consumer repositories.
+- Correct Workstream D roadmap language during implementation: do not describe
+  the Quest source hook as optional or recommended.
+- Quest contributors must configure this repository with
+  `git config core.hooksPath .githooks`.
+- Git cannot propagate `core.hooksPath` automatically through a clone, so
+  document it as required contributor setup and configure it in the isolated
+  worktree for validation.
+- CI is the authoritative, non-bypassable formatting gate.
+
+Implementation scope:
+
+- Add a pinned Black development dependency for the Quest source repository.
+- Add Black configuration to `pyproject.toml`.
+- Format the Quest source Python files with that configuration.
+- Update `.github/workflows/test-python.yml` to install the pinned Black version
+  and run `python3 -m black --check .`.
+- Add an executable, versioned `.githooks/pre-commit` for the Quest source
+  repository.
+- Update `CONTRIBUTING.md` so configuring `core.hooksPath` to `.githooks` is
+  required Quest contributor setup, replacing the current recommended
+  source-repository hook instructions.
+
+Hook behavior:
+
+- The hook is check-only and never rewrites files during `git commit`.
+- It runs the existing Quest configuration validation and then
+  `python3 -m black --check .`.
+- Preserve the source repository's existing configuration-validation
+  protection when moving contributors from `.git/hooks` to `.githooks`.
+- If Black is missing or formatting fails, print clear remediation commands for
+  installing the pinned development dependency and running
+  `python3 -m black .`.
+- Handle invocation from subdirectories by resolving the repository root.
+- Keep the implementation small and shell-portable.
+
+Critical ownership boundary:
+
+- `.githooks`, `pyproject.toml`, `CONTRIBUTING.md`, source-only dependency
+  files, and `.github` workflows remain outside `.quest-manifest` and
+  `.quest-checksums` ownership.
+- Do not modify `scripts/quest_validate-quest-config.sh` hook installation
+  behavior; it is part of the installed consumer surface.
+- Do not add Black, formatting hooks, contributor policy, or source CI files to
+  the Quest installer.
+- Do not create or modify consumer-repository hooks.
+- Validate an installed consumer topology, not only the Quest source checkout.
+
+Focused tests:
+
+- Assert the source hook exists, is executable, runs existing Quest validation,
+  and invokes Black in check mode.
+- Assert the hook contains no automatic Black formatting command.
+- Assert its failure output gives the exact remediation command.
+- Assert CI installs a pinned Black version and runs Black check mode.
+- Assert `.githooks`, the source formatter dependency/configuration,
+  `CONTRIBUTING.md`, and source CI remain outside `.quest-manifest` and checksum
+  ownership.
+- Build a temporary installed-consumer fixture and prove it receives no
+  `.githooks` directory, Black dependency, formatter configuration, or
+  formatting policy.
+- Avoid brittle whole-file workflow or shell-script snapshots.
+
+Manual validation:
+
+- In a disposable Quest source clone or temporary worktree, configure
+  `git config core.hooksPath .githooks`.
+- Introduce an intentionally unformatted Python file and attempt a commit.
+- Confirm the hook blocks the commit without modifying the file and prints the
+  remediation command.
+- Run `python3 -m black .`, retry, and confirm the hook passes.
+- Confirm the existing Quest configuration validation still runs through the
+  same hook.
+- Install Quest into a clean temporary consumer repository and confirm no
+  source formatting tooling or hook is installed.
+
+Required validation:
+
+- `python3 -m black --check .`
+- `pytest -q` focused source-formatting and manifest/install-surface tests
+- `python3 -m pytest tests/ -q`
+- `bash tests/test-quest-runtime.sh`
+- `bash tests/test-quest-preflight.sh`
+- `bash tests/test-validate-quest-state.sh`
+- `bash scripts/quest_validate-manifest.sh --strict`
+- `bash scripts/quest_validate-quest-config.sh`
+- `bash scripts/quest_validate-handoff-contracts.sh`
+- `git diff --check`
+- The repository's remaining formatting, lint, and security gates
+
+Plan lifecycle and PR acceptance:
+
+- Before implementation, change Workstream D from `[todo]` to `[ongoing]`.
+- Do not alter completed A, B, or C PR records.
+- Create the complete Workstream D draft PR.
+- Once the PR exists, change D to `[done]` and record its PR number/link.
+- Because A through D will then all be `[done]`, move the roadmap to
+  `ideas/archive/2026-07-11-quest-hardening.md`.
+- Update `ideas/README.md` by removing the active entry and adding a done-index
+  entry linking the archived roadmap and PRs #149, #150, #152, and the new D PR.
+- Commit and push the lifecycle/archive update to the same Workstream D PR.
+- `[done]` means the PR exists; readiness and merge remain tracked on GitHub.
+- Acceptance requires the A-through-D roadmap to be marked done and archived in
+  the resulting PR.
+
+Keep the change source-repository-only and minimal under KISS and YAGNI. Do not
+introduce a formatting framework beyond Black, a small repository hook, the
+required contributor setup, CI enforcement, and focused ownership tests.
+
+## Carry-Over Findings
+
+- No carry-over findings this round; nothing was inherited from earlier quests and nothing needs to be saved for the next one.
+
+## Celebration
+
+This journal embeds the celebration payload used by `/celebrate`.
+
+- Full celebration: [`celebrations/source-python-formatting_2026-07-15.md`](celebrations/source-python-formatting_2026-07-15.md)
+- [Jump to Celebration Data](#celebration-data)
+- Replay locally: `/celebrate docs/quest-journal/source-python-formatting_2026-07-15.md`
+
+## Celebration Data
+
+<!-- celebration-data-start -->
+```json
+{
+  "quest_mode": "workflow",
+  "agents": [
+    {
+      "name": "arbiter",
+      "model": "",
+      "role": "The Judge",
+      "transport": "background-agent"
+    },
+    {
+      "name": "builder",
+      "model": "",
+      "role": "The Implementer"
+    }
+  ],
+  "claude_transport_counts": {
+    "background-agent": 8
+  },
+  "achievements": [
+    {
+      "icon": "[BUG]",
+      "title": "Gremlin Slayer",
+      "desc": "Tackled 13 review findings"
+    },
+    {
+      "icon": "[TEST]",
+      "title": "Battle Tested",
+      "desc": "Survived 5 reviews"
+    },
+    {
+      "icon": "[PLAN]",
+      "title": "Plan Perfectionist",
+      "desc": "Iterated plan 2 times"
+    },
+    {
+      "icon": "[WIN]",
+      "title": "Quest Complete",
+      "desc": "All phases finished successfully"
+    }
+  ],
+  "metrics": [
+    {
+      "icon": "📊",
+      "label": "Plan iterations: 2"
+    },
+    {
+      "icon": "🔧",
+      "label": "Fix iterations: 0"
+    },
+    {
+      "icon": "📝",
+      "label": "Review rounds: 5"
+    },
+    {
+      "icon": "🚌",
+      "label": "Claude transport: background-agent ×8"
+    }
+  ],
+  "quality": {
+    "tier": "Gold",
+    "grade": "G"
+  },
+  "inherited_findings_used": {
+    "count": 0,
+    "summaries": []
+  },
+  "findings_left_for_future_quests": {
+    "count": 0,
+    "summaries": []
+  },
+  "test_count": null,
+  "tests_added": null,
+  "files_changed": 13
+}
+```
+<!-- celebration-data-end -->

--- a/ideas/2026-07-11-quest-hardening.md
+++ b/ideas/2026-07-11-quest-hardening.md
@@ -75,7 +75,7 @@ delivery speed and may proceed in parallel.
 | [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [done] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | [#150](https://github.com/KjellKod/quest/pull/150) |
 | [done] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | [#152](https://github.com/KjellKod/quest/pull/152) |
-| [todo] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
+| [ongoing] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
 
 ## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
 
@@ -388,7 +388,7 @@ of host documentation.
   remaining link resolves.
 - **Observability:** installed file list and rendered Markdown links.
 
-## Workstream D — Source-repository Python formatting [todo]
+## Workstream D — Source-repository Python formatting [ongoing]
 
 ### Goal
 
@@ -411,8 +411,10 @@ installing or enforcing Black in consumer repositories.
 - Add the Black configuration to `/Users/kjell/ws/extra/quest/pyproject.toml`.
 - Add a pinned Black install and `python3 -m black --check .` to the Quest
   repository's Python CI workflow.
-- Add a small `.githooks/pre-commit` check that developers may enable with
-  `git config core.hooksPath .githooks`. The hook must fail with the remediation
+- Add a small `.githooks/pre-commit` check. Quest contributors must configure
+  this repository with `git config core.hooksPath .githooks`; Git cannot
+  propagate this local setting through a clone, so it is required contributor
+  setup after cloning. The hook must fail with the remediation
   `python3 -m black .`; it must not rewrite files during a commit.
 - Keep `.githooks/`, `pyproject.toml`, and the source-repository CI workflow out
   of `.quest-manifest`. Do not modify the installed
@@ -433,8 +435,9 @@ installing or enforcing Black in consumer repositories.
 
 ### Integration touchpoints
 
-- **Developer commits:** local hooks are optional and bypassable, so CI remains
-  the authoritative formatting gate.
+- **Developer commits:** configuring the source hook is required contributor
+  setup. The local check-only hook remains bypassable, so CI is the
+  authoritative, non-bypassable formatting gate.
 - **Partially staged work:** check-only behavior avoids silently rewriting
   unstaged files or creating index/worktree mismatches during commit.
 - **Installer ownership:** source-repository tooling must remain outside the
@@ -448,8 +451,9 @@ installing or enforcing Black in consumer repositories.
   repository-only tooling after installation.
 - **Preconditions:** Black installed in the Quest development environment and a
   temporary clean consumer repository.
-- **Steps:** enable `.githooks`, attempt a commit with intentionally unformatted
-  Python, run the remediation, retry, then install Quest into the consumer.
+- **Steps:** run `git config core.hooksPath .githooks`, attempt a commit with
+  intentionally unformatted Python, run the remediation, retry, then install
+  Quest into the consumer.
 - **Expected:** the first commit is blocked with a clear command, the formatted
   retry passes, and the consumer receives no Black hook or formatting policy.
 - **Observability:** hook output, CI result, manifest diff, and installed file

--- a/ideas/README.md
+++ b/ideas/README.md
@@ -43,7 +43,6 @@ Current roadmap:
 ### Architecture and Workflow Evolution
 | File | Status | Purpose |
 |---|---|---|
-| `2026-07-11-quest-hardening.md` | proposed | Three-PR hardening plan for findings #1, #3, #4, #9, #16, #17, #18, #20, and #22, tracked from `[todo]` through PR-created `[done]`. |
 | `2026-04-24-quest-hooks-vs-instructions-boundary.md` | proposed | Define the boundary between instruction files, hooks, and scripts for Quest, with Claude-first enforcement and Codex-aware adapter guidance. |
 | `2026-04-29-research-fanout-skill.md` | proposed | Add a reusable research fan-out skill for human-triggered and planner-requested parallel investigation with reconciled findings. |
 | `2026-05-19-sharpen-context-grounding.md` | proposed | Require sharpening questions to be grounded in targeted repo evidence before asking the user. |
@@ -88,6 +87,7 @@ Current roadmap:
 ### Done Index
 | Status | Idea | Note |
 |---|---|---|
+| done | ~~2026-07-11-quest-hardening~~ | Completed across PRs [#149](https://github.com/KjellKod/quest/pull/149), [#150](https://github.com/KjellKod/quest/pull/150), [#152](https://github.com/KjellKod/quest/pull/152), and [#153](https://github.com/KjellKod/quest/pull/153). Archived at [`ideas/archive/2026-07-11-quest-hardening.md`](archive/2026-07-11-quest-hardening.md). |
 | done | ~~deterministic-json-orchestration-overrides~~ | Implemented in PR #144: deterministic parser API and stdin CLI, pair/JSON compatibility, duplicate and delimiter validation, and equivalent orchestration output across accepted formats. Archived at [`ideas/archive/deterministic-json-orchestration-overrides.md`](archive/deterministic-json-orchestration-overrides.md). |
 | done | ~~quest-needs-human-resume-relay~~ | Full same-session relay shipped in PR #142 (items 0–6); item 7 (ask-policy) continues as `2026-07-05-bg-claude-ask-policy-relaxation.md`. Archived at [`ideas/archive/quest-needs-human-resume-relay.md`](archive/quest-needs-human-resume-relay.md). |
 | done | ~~2026-07-04-bg-transport-hardening-quest-brief~~ | Shipped in PR #142 (quest bg-transport-hardening_2026-07-04__1043): truthful block-cause classification, verified teardown, leak-proof sweeps, needs_human same-session relay, end-to-end model passthrough, docs accuracy sweep. Archived at [`ideas/archive/2026-07-04-bg-transport-hardening-quest-brief.md`](archive/2026-07-04-bg-transport-hardening-quest-brief.md). |

--- a/ideas/archive/2026-07-11-quest-hardening.md
+++ b/ideas/archive/2026-07-11-quest-hardening.md
@@ -1,7 +1,7 @@
 # Quest hardening
 
 Date: 2026-07-11
-Status: `proposed`
+Status: `done`
 Source analysis: `.ws/findings.md`
 
 ## Status contract
@@ -75,7 +75,7 @@ delivery speed and may proceed in parallel.
 | [done] | A. Runtime trust and state boundaries | #1, #4, #18, #22 | `hardening/runtime-boundaries` | [#149](https://github.com/KjellKod/quest/pull/149) |
 | [done] | B. Operational helper and transport correctness | #3, #9, #20 | `hardening/operational-contracts` | [#150](https://github.com/KjellKod/quest/pull/150) |
 | [done] | C. Installed documentation accuracy | #16, #17 | `hardening/installed-docs` | [#152](https://github.com/KjellKod/quest/pull/152) |
-| [ongoing] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | — |
+| [done] | D. Source-repository Python formatting | Repository follow-up | `hardening/python-formatting` | [#153](https://github.com/KjellKod/quest/pull/153) |
 
 ## Workstream A — Runtime trust and state boundaries [done] — [PR #149](https://github.com/KjellKod/quest/pull/149)
 
@@ -388,7 +388,7 @@ of host documentation.
   remaining link resolves.
 - **Observability:** installed file list and rendered Markdown links.
 
-## Workstream D — Source-repository Python formatting [ongoing]
+## Workstream D — Source-repository Python formatting [done] — [PR #153](https://github.com/KjellKod/quest/pull/153)
 
 ### Goal
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Static HTML dashboard generator for Quest"
 requires-python = ">=3.10"
 
+[project.optional-dependencies]
+dev = ["black==24.10.0"]
+
 [project.scripts]
 quest-checks = "quest_checks.cli:main"
 
@@ -13,3 +16,7 @@ where = ["scripts"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.black]
+target-version = ["py310"]
+line-length = 88

--- a/tests/unit/test_documentation_contracts.py
+++ b/tests/unit/test_documentation_contracts.py
@@ -125,9 +125,9 @@ def test_setup_guide_documents_current_model_and_transport_contracts() -> None:
         "The system falls back to Claude if Codex fails",
     )
     for instruction in stale_instructions:
-        assert instruction not in setup, (
-            f"setup guide contains obsolete runtime guidance: {instruction}"
-        )
+        assert (
+            instruction not in setup
+        ), f"setup guide contains obsolete runtime guidance: {instruction}"
 
 
 def test_docs_contract_scope_excludes_history_and_journal_archives() -> None:

--- a/tests/unit/test_pr_shepherd.py
+++ b/tests/unit/test_pr_shepherd.py
@@ -1419,9 +1419,24 @@ def test_post_reply_summary_missing_current_login_creates_without_patch(
 @pytest.mark.parametrize(
     ("author_login", "login_result", "expected_action", "expected_id"),
     [
-        ("KjellKod", _Result(stdout=json.dumps({"login": "KjellKod"})), "update_summary", 200),
-        ("alice", _Result(stdout=json.dumps({"login": "KjellKod"})), "create_summary", None),
-        ("KjellKod", _Result(returncode=1, stderr="not authenticated"), "create_summary", None),
+        (
+            "KjellKod",
+            _Result(stdout=json.dumps({"login": "KjellKod"})),
+            "update_summary",
+            200,
+        ),
+        (
+            "alice",
+            _Result(stdout=json.dumps({"login": "KjellKod"})),
+            "create_summary",
+            None,
+        ),
+        (
+            "KjellKod",
+            _Result(returncode=1, stderr="not authenticated"),
+            "create_summary",
+            None,
+        ),
     ],
 )
 def test_post_reply_summary_dry_run_uses_current_login_without_mutating(

--- a/tests/unit/test_quest_manifest.py
+++ b/tests/unit/test_quest_manifest.py
@@ -160,16 +160,18 @@ def test_installed_setup_guide_relative_links_resolve_to_manifest_owned_files(
         try:
             installed_entry = target_path.relative_to(tmp_path.resolve()).as_posix()
         except ValueError:
-            raise AssertionError(f"local guide link escapes installed fixture: {target}")
+            raise AssertionError(
+                f"local guide link escapes installed fixture: {target}"
+            )
 
-        assert installed_entry in owned_files, (
-            f"local guide link is not Quest-owned: {target} -> {installed_entry}"
-        )
+        assert (
+            installed_entry in owned_files
+        ), f"local guide link is not Quest-owned: {target} -> {installed_entry}"
         assert target_path.is_file(), f"local guide link is not installed: {target}"
         if not path_text and fragment:
-            assert fragment in _guide_heading_slugs(guide_text), (
-                f"local guide fragment does not match a heading: {target}"
-            )
+            assert fragment in _guide_heading_slugs(
+                guide_text
+            ), f"local guide fragment does not match a heading: {target}"
         resolved_targets.append(target)
 
     assert len(resolved_targets) == len(local_targets)
@@ -184,13 +186,9 @@ def test_guide_heading_slugs_strip_github_anchor_punctuation() -> None:
 def test_installed_setup_guide_has_no_unchecked_relative_reference_links() -> None:
     guide = (_repo_root() / "docs/guides/quest_setup.md").read_text(encoding="utf-8")
     relative_definitions: list[str] = []
-    for target in re.findall(
-        r"^\s{0,3}\[[^\]]+\]:\s*(\S+)", guide, flags=re.MULTILINE
-    ):
+    for target in re.findall(r"^\s{0,3}\[[^\]]+\]:\s*(\S+)", guide, flags=re.MULTILINE):
         normalized = (
-            target[1:-1]
-            if target.startswith("<") and target.endswith(">")
-            else target
+            target[1:-1] if target.startswith("<") and target.endswith(">") else target
         )
         if not urlsplit(normalized).scheme and not normalized.startswith("//"):
             relative_definitions.append(normalized)

--- a/tests/unit/test_source_python_formatting.py
+++ b/tests/unit/test_source_python_formatting.py
@@ -6,10 +6,14 @@ import os
 import shutil
 import stat
 import subprocess
-import tomllib
 from pathlib import Path
 
 import yaml
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 
 BLACK_PIN = "black==24.10.0"

--- a/tests/unit/test_source_python_formatting.py
+++ b/tests/unit/test_source_python_formatting.py
@@ -1,0 +1,270 @@
+"""Source-only formatting policy and installer-boundary tests."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tomllib
+from pathlib import Path
+
+import yaml
+
+
+BLACK_PIN = "black==24.10.0"
+INSTALL_REMEDIATION = "python3 -m pip install -e '.[dev]'"
+FORMAT_REMEDIATION = "python3 -m black ."
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _hook_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    fixture_root = tmp_path / "source-repository"
+    hook = fixture_root / ".githooks" / "pre-commit"
+    hook.parent.mkdir(parents=True)
+    shutil.copy2(_repo_root() / ".githooks" / "pre-commit", hook)
+
+    call_log = fixture_root / "calls.log"
+    _write_executable(
+        fixture_root / "scripts" / "quest_validate-quest-config.sh",
+        """#!/bin/sh
+printf 'validator|%s\n' "$PWD" >> "$CALL_LOG"
+exit "${VALIDATOR_EXIT:-0}"
+""",
+    )
+    _write_executable(
+        fixture_root / "fake-bin" / "python3",
+        """#!/bin/sh
+printf 'python3|%s|%s\n' "$PWD" "$*" >> "$CALL_LOG"
+exit "${BLACK_EXIT:-0}"
+""",
+    )
+
+    nested_directory = fixture_root / "nested" / "working-directory"
+    nested_directory.mkdir(parents=True)
+    return hook, call_log, nested_directory
+
+
+def _hook_environment(fixture_root: Path, call_log: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PATH"] = f"{fixture_root / 'fake-bin'}:{environment['PATH']}"
+    environment["CALL_LOG"] = str(call_log)
+    return environment
+
+
+def _manifest_file_entries() -> set[str]:
+    entries: set[str] = set()
+    section = ""
+    for raw_line in (
+        (_repo_root() / ".quest-manifest").read_text(encoding="utf-8").splitlines()
+    ):
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        if line and not line.startswith("#") and section != "directories":
+            entries.add(line)
+    return entries
+
+
+def _checksum_entries() -> set[str]:
+    entries: set[str] = set()
+    for raw_line in (
+        (_repo_root() / ".quest-checksums").read_text(encoding="utf-8").splitlines()
+    ):
+        line = raw_line.strip()
+        if line and not line.startswith("#"):
+            _, path = line.split(maxsplit=1)
+            entries.add(path)
+    return entries
+
+
+def test_pyproject_declares_exact_black_development_policy() -> None:
+    with (_repo_root() / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+
+    assert pyproject["project"]["optional-dependencies"]["dev"] == [BLACK_PIN]
+    assert pyproject["tool"]["black"] == {
+        "target-version": ["py310"],
+        "line-length": 88,
+    }
+
+
+def test_source_hook_is_executable_and_check_only() -> None:
+    hook = _repo_root() / ".githooks" / "pre-commit"
+    hook_text = hook.read_text(encoding="utf-8")
+
+    assert hook.stat().st_mode & stat.S_IXUSR
+    assert "./scripts/quest_validate-quest-config.sh" in hook_text
+    assert hook_text.count("python3 -m black --check .") == 1
+    assert hook_text.count(FORMAT_REMEDIATION) == 1
+    assert f"  {FORMAT_REMEDIATION}" in hook_text
+
+
+def test_source_hook_resolves_root_and_runs_validation_before_black(
+    tmp_path: Path,
+) -> None:
+    hook, call_log, nested_directory = _hook_fixture(tmp_path)
+    fixture_root = hook.parents[1]
+
+    result = subprocess.run(
+        [str(hook.resolve())],
+        cwd=nested_directory,
+        env=_hook_environment(fixture_root, call_log),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        f"validator|{fixture_root}",
+        f"python3|{fixture_root}|-m black --check .",
+    ]
+
+
+def test_source_hook_failure_is_non_mutating_and_prints_exact_remediation(
+    tmp_path: Path,
+) -> None:
+    hook, call_log, nested_directory = _hook_fixture(tmp_path)
+    fixture_root = hook.parents[1]
+    unformatted_file = fixture_root / "unformatted.py"
+    unformatted_file.write_text("value=  1\n", encoding="utf-8")
+    before = unformatted_file.read_bytes()
+    environment = _hook_environment(fixture_root, call_log)
+    environment["BLACK_EXIT"] = "1"
+
+    result = subprocess.run(
+        [str(hook.resolve())],
+        cwd=nested_directory,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert unformatted_file.read_bytes() == before
+    assert INSTALL_REMEDIATION in result.stderr
+    assert FORMAT_REMEDIATION in result.stderr
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        f"validator|{fixture_root}",
+        f"python3|{fixture_root}|-m black --check .",
+    ]
+
+
+def test_source_hook_stops_before_black_when_configuration_is_invalid(
+    tmp_path: Path,
+) -> None:
+    hook, call_log, nested_directory = _hook_fixture(tmp_path)
+    fixture_root = hook.parents[1]
+    environment = _hook_environment(fixture_root, call_log)
+    environment["VALIDATOR_EXIT"] = "1"
+
+    result = subprocess.run(
+        [str(hook.resolve())],
+        cwd=nested_directory,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        f"validator|{fixture_root}"
+    ]
+
+
+def test_python_ci_keeps_tests_and_enforces_pinned_black_unconditionally() -> None:
+    workflow_path = _repo_root() / ".github" / "workflows" / "test-python.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["test"]["steps"]
+    steps_by_name = {step["name"]: step for step in steps}
+
+    assert "if" not in steps_by_name["Set up Python"]
+    assert steps_by_name["Install Black"]["run"] == (
+        "python3 -m pip install black==24.10.0"
+    )
+    assert steps_by_name["Check Python formatting"]["run"] == (
+        "python3 -m black --check ."
+    )
+    for step_name in ("Install Black", "Check Python formatting"):
+        assert "if" not in steps_by_name[step_name]
+        assert "continue-on-error" not in steps_by_name[step_name]
+
+    assert steps_by_name["Install test dependencies"]["run"] == (
+        "python3 -m pip install pytest==9.0.3 pyyaml==6.0.3"
+    )
+    assert steps_by_name["Run tests"]["run"] == "python3 -m pytest tests/ -v"
+
+
+def test_source_formatting_files_remain_outside_installer_ownership() -> None:
+    manifest_entries = _manifest_file_entries()
+    checksum_entries = _checksum_entries()
+    forbidden_paths = {
+        ".githooks/pre-commit",
+        "pyproject.toml",
+        "CONTRIBUTING.md",
+        ".github/workflows/test-python.yml",
+        "tests/unit/test_source_python_formatting.py",
+    }
+
+    assert forbidden_paths.isdisjoint(manifest_entries)
+    assert forbidden_paths.isdisjoint(checksum_entries)
+    assert not any(path.startswith(".githooks/") for path in manifest_entries)
+    assert not any(path.startswith(".githooks/") for path in checksum_entries)
+    assert not any(path.startswith(".github/") for path in manifest_entries)
+    assert not any(path.startswith(".github/") for path in checksum_entries)
+
+
+def test_temporary_installed_consumer_has_no_source_formatting_policy(
+    tmp_path: Path,
+) -> None:
+    repo_root = _repo_root()
+    installer = repo_root / "scripts" / "quest_installer.sh"
+    installer_text = installer.read_text(encoding="utf-8")
+    assert 'COPY_AS_IS+=("scripts/quest_installer.sh")' in installer_text
+
+    installed_files = _manifest_file_entries() | {"scripts/quest_installer.sh"}
+    consumer_root = tmp_path / "consumer"
+    for entry in installed_files:
+        source = repo_root / entry
+        if source.is_file():
+            destination = consumer_root / entry
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+
+    forbidden_paths = (
+        ".githooks",
+        "pyproject.toml",
+        "CONTRIBUTING.md",
+        ".github/workflows/test-python.yml",
+    )
+    for path in forbidden_paths:
+        assert not (consumer_root / path).exists()
+
+    installed_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in consumer_root.rglob("*")
+        if path.is_file()
+    )
+    for source_policy in (
+        BLACK_PIN,
+        "[tool.black]",
+        "python3 -m black",
+        "core.hooksPath .githooks",
+    ):
+        assert source_policy not in installed_text
+
+    for source_only_path in forbidden_paths:
+        assert source_only_path not in installer_text


### PR DESCRIPTION
## ⭐ Why this matters

Quest contributors now get one deterministic Python format and an early local check, while CI remains the authoritative gate and installed consumer repositories remain untouched by source-development policy.

---

## Summary

Add pinned Black formatting, a check-only source hook, mandatory contributor setup, CI enforcement, and focused installer-boundary coverage for the Quest source repository.

- Black remains a development-only dependency and source-only configuration.
- The existing consumer hook installer and every manifest/checksum-owned path remain unchanged.

## Changes

- **Source formatting**:
  - Declare `black==24.10.0` in the `dev` extra and configure Python 3.10/88-column formatting in `pyproject.toml`.
  - Apply the pinned formatter to the three existing Python test files it selects.
- **Contributor checks**:
  - Add executable `.githooks/pre-commit`, which resolves the repository root, runs Quest configuration validation first, and invokes only `python3 -m black --check .`.
  - Require `git config core.hooksPath .githooks` after clone and document exact install/format remediation in `CONTRIBUTING.md`.
- **CI**:
  - Install the exact Black pin and run its check unconditionally in `test-python.yml`, while preserving the pinned pytest/PyYAML install and Python test run.
- **Ownership tests**:
  - Cover hook ordering, nested-directory execution, non-mutating failure, exact remediation, CI shape, manifest/checksum exclusions, and a temporary installed-consumer topology.
- **Roadmap**:
  - Move Workstream D to `[ongoing]` and correct its source-hook policy language without altering the completed A/B/C records.
  - Complete the `[done]` marker and roadmap archive in this PR using its assigned PR number.

## Validation

- [x] **Walkthrough — verify the source policy**: Prerequisites: install the development extra with `python3 -m pip install -e '.[dev]'`. Action: run `python3 -m black --check .`. Expected: Black reports every selected Python file unchanged. Negative case: make a temporary Python file unformatted and rerun the command; it must exit nonzero without rewriting the file.
- [ ] **Walkthrough — exercise the contributor hook in a disposable clone**: Prerequisites: clone this branch into a temporary directory, install `.[dev]`, and run `git config core.hooksPath .githooks`. Action: stage an intentionally unformatted Python file and attempt a commit. Expected: Quest configuration validation runs first, the commit is blocked, the file bytes remain unchanged, and output includes `python3 -m pip install -e '.[dev]'` and `python3 -m black .`; run the latter, stage, and retry to observe a passing commit.
- [x] **Walkthrough — verify consumer isolation**: Prerequisites: create a clean temporary Git repository. Action: run the Quest installer with `--branch quest/source-python-formatting --force`, then run `bash scripts/quest_validate-manifest.sh --installed`. Expected: installation validates and creates no `.githooks`, `pyproject.toml`, `CONTRIBUTING.md`, source workflow, Black dependency/configuration, formatting policy, consumer hook, or `core.hooksPath` setting.

Watch for: the roadmap archive and Done Index are completed by a follow-up commit in this same PR using its assigned PR number.

## Notes

- `.quest-manifest`, `.quest-checksums`, `scripts/quest_installer.sh`, and `scripts/quest_validate-quest-config.sh` are intentionally unchanged.
- CI is authoritative because local Git hooks can be bypassed even though configuring the versioned hook is required contributor setup.
- Verified locally: Black clean; 16 focused tests; 1,047 full tests; runtime 50/50; preflight 19/19; state 68/68; manifest/config/handoff/security/schema/Gitleaks gates green.
- A clean consumer installation from remote commit `db41de3` passed installed-manifest validation with no source-formatting surface.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: GPT-5.6 Sol &lt;noreply@openai.com&gt;
Co-Authored-By: Claude Opus 4.8 &lt;noreply@anthropic.com&gt;
Co-Authored-By: GPT-5.6 Terra &lt;noreply@openai.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

