### PR TITLE
Drop duplicated skill and doc-layer lists from Claude entry point

### DIFF
--- a/.claude/AGENTS.md
+++ b/.claude/AGENTS.md
@@ -22,16 +22,6 @@ This repository uses **layered documentation** for AI agent context management.
 2. Follow the entry point defined in bootstrap document
 3. Read `DOCUMENTATION_STRUCTURE.md` for project specific context
 
-## Documentation Layers
-
-| Layer | Location | Purpose |
-|-------|----------|---------|
-| Principles | `AGENTS.md`, `README.md` | Stable rules, always loaded |
-| Architecture | `docs/architecture/` | System design, when understanding how things work |
-| Implementation | `docs/implementation/` | Active plans, when building features |
-| History | `docs/implementation/history/` | Past decisions, when investigating |
-| Guides | `docs/guides/` | Reference docs, when doing specific tasks |
-
 ## Quick Navigation
 
 - **Delegate to Codex?** → Use `/gpt` command or `.skills/gpt/` skill
@@ -49,24 +39,6 @@ This repository uses **layered documentation** for AI agent context management.
 - **Create or update a PR?** → Use `.skills/pr-assistant/` skill
 - **IMPORTANT: For ALL pull request operations, you MUST invoke the `pr-assistant` skill. Always creates PRs in draft mode.**
 - **Understanding the system?** → Start with `docs/architecture/` if present
-
-## Skills
-
-This repository uses **skills** for specialized workflows. Skills are automatically discovered and used based on task context:
-
-- **gpt:** Delegate tasks to Codex via MCP — reviews, analysis, implementation, second opinions
-- **quest:** Multi-agent orchestration for features (plan → review → build → review → fix)
-- **celebrate:** Play quest completion celebration animation with achievements, metrics, and credits
-- **plan-reviewer:** Review implementation plans and PR specifications for test coverage
-- **code-reviewer:** Review actual code for quality, security, and patterns
-- **sharpen:** Adversarial Q&A against a plan or design — one question at a time with a recommended answer — to surface contradictions and unresolved tradeoffs
-- **ux-review:** Run the canonical UX stress-test rubric against a target (file, directory, URL, screenshot, or diff) and produce a P0–P3 critique with principle citations
-- **ux-context:** UX principles primer (auto-attached by quest orchestration when `ui_work: true`); bundles the canonical UX guidebook as a resource so the standard travels with the skill
-- **implementer:** Step-by-step implementation with traceability
-- **git-commit-assistant:** Generate commit messages from staged diff, match repo conventions, append Quest co-author trailer
-- **pr-assistant:** Create and update GitHub PRs in draft mode, generate title/description from branch commits
-
-See `.skills/BOOTSTRAP.md` for how to use skills with different AI platforms.
 
 ## Agentic Markdown Convention
 

--- a/DOCUMENTATION_STRUCTURE.md
+++ b/DOCUMENTATION_STRUCTURE.md
@@ -82,7 +82,6 @@ Repository Root
 │   ├── implementation/          ← Layer 3: Active plans
 │   │   ├── README.md                (navigation hub for plans)
 │   │   ├── [active plans...]
-│   │   ├── backlog/                 (future work)
 │   │   └── history/             ← Layer 4: Completed work
 │   │
 │   └── guides/                  ← Layer 5: Reference docs


### PR DESCRIPTION
## ⭐ Why this matters

The Claude entry point told agents about four skills that don't exist as skills — so an agent following it would try to invoke `implementer` or `code-reviewer` and get nothing. This removes the stale list rather than patching it, because Claude Code already injects every real skill description automatically. The file gets ~37% smaller and can no longer disagree with reality.

- **Fixes four false skill claims** that cost a wasted turn each time an agent trusts them
- **Removes ~500 est. tokens** from every session's always-loaded context
- **Deletes three sources of drift** — nothing left to keep in sync by hand

---

## Summary

Removes two hand-maintained sections from `.claude/AGENTS.md` that duplicated information sessions already get for free, and drops one stale path from the documentation map.

- The `## Skills` section restated `SKILL.md` frontmatter that Claude Code injects at session start, and had drifted into naming four non-loadable skills.
- The `## Documentation Layers` table duplicated `DOCUMENTATION_STRUCTURE.md`, which the same file already makes mandatory reading before responding.

> [!NOTE]
> The diff touches `.claude/AGENTS.md`, not `.claude/CLAUDE.md`. They are one tracked file — `.claude/CLAUDE.md` is a symlink to `.claude/AGENTS.md` — so a single edit updates both entry-point paths and they cannot diverge.

## Changes

- **Documentation**:
  - Removed `## Skills` (17 lines) from `.claude/AGENTS.md`. The nine real skills are auto-surfaced from `.claude/skills/*/SKILL.md` frontmatter; the section additionally listed `implementer`, `code-reviewer`, `plan-reviewer`, and `ux-context`, which exist only under `.skills/` and are not loadable as skills. `## Quick Navigation` already routes all four correctly via `.skills/<name>/` paths.
  - Removed `## Documentation Layers` (9 lines) from `.claude/AGENTS.md`. `DOCUMENTATION_STRUCTURE.md` carries the same five layers plus a stability column, the `docs/architecture/` vs `docs/guides/` distinction, and per-role entry points. The removed table also claimed `AGENTS.md` and `README.md` are "always loaded", which is inaccurate — only `CLAUDE.md` files are auto-loaded.
  - Removed the `docs/implementation/backlog/  (future work)` line from the map in `DOCUMENTATION_STRUCTURE.md`; that directory does not exist. The map's other 13 path claims were verified as accurate.

Retained deliberately: `## Start Here`, the "BEFORE responding to any request you must" block, all of `## Quick Navigation` including both `IMPORTANT: … you MUST invoke …` directives, and `## Agentic Markdown Convention`.

## Validation

- [ ] **Confirm nothing invocable was lost.** Action: run `ls -1 .claude/skills/` and compare against the skill list a fresh Claude Code session surfaces in this repo. Expected: the same nine names — `celebrate`, `git-commit-assistant`, `gpt`, `pr-assistant`, `pr-shepherd`, `pre-commit-review`, `quest`, `sharpen`, `ux-review`. The deleted section listed no tenth loadable skill.
- [ ] **Confirm the four removed names were never loadable.** Action: run `for n in implementer code-reviewer plan-reviewer ux-context; do test -d ".claude/skills/$n" && echo "$n LOADABLE" || echo "$n not a skill"; done`. Expected: all four report `not a skill`, i.e. the deleted text was wrong, not merely redundant.
- [ ] **Confirm the doc-layer information still has a home.** Action: open `DOCUMENTATION_STRUCTURE.md` and read `## Philosophy: Layered Context Management` plus `## Documentation Map`. Expected: all five layers with their paths, and `.claude/AGENTS.md` lines 20–23 still direct agents to read that file before responding — so the routing map is reachable, not deleted.
- [ ] **Confirm the removed backlog path really is absent.** Action: run `ls -d docs/implementation/backlog 2>&1` and `ls -1 docs/implementation/`. Expected: the first reports "No such file or directory"; the second shows only `README.md` and `history/`.
- [ ] **Confirm the symlink survived.** Action: run `ls -la .claude/CLAUDE.md` and `git ls-files .claude/CLAUDE.md .claude/AGENTS.md`. Expected: `CLAUDE.md -> AGENTS.md`, both tracked.

Watch for: if you *want* a resident copy of the doc-layer table for agents that skip the mandatory `DOCUMENTATION_STRUCTURE.md` read, that second cut is the one to push back on — the skills cut stands on its own regardless.

## Notes

- `AGENTS.md` at the repo root was audited in the same pass and is **not** changed here: all 14 of its path and content claims verify. The only finding was a 4-line internal duplication (the `### Skills Discovery READ THIS` block repeats the first bullet of `### Skills Source of Truth & Precedence`), reviewed and intentionally kept — the repetition is harmless.
- `.claude/skills/` and `.agents/skills/` are thin ~200–650 char wrappers that delegate to the single source of truth in `.skills/` (e.g. `.skills/quest/SKILL.md` is 22,417 chars vs 229 for its Claude wrapper). That is not duplication and should not be collapsed.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

