### PR TITLE
Add a sparse PR template matching the pr-body-gate contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,16 @@
-<!--
-CI requires the two headings below (Summary, Changes). Keep them.
-Everything else is optional. Using an AI agent? /pr-assistant
-(.skills/pr-assistant/SKILL.md) generates a compliant body.
--->
+> [!NOTE]
+> The _italic hints_ below are for you, the author. Replace them with real content and delete this note.
+> CI requires the three headings (Summary, Changes, Validation). Keep them.
+> Using an AI agent? `/pr-assistant` (`.skills/pr-assistant/SKILL.md`) generates a compliant body.
 
 ## Summary
 
-<!-- One or two sentences: what this PR does and why. -->
+_One or two sentences: what this PR does and why._
 
 ## Changes
 
-<!-- Bullet list of what changed. File references welcome. -->
+- _Bullet list of what changed. File references welcome._
 
-<!-- Optional: how you verified it (commands run, tests passed). -->
+## Validation
+
+- _How you verified it: commands run, tests passed, what a reviewer can check._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+CI requires the two headings below (Summary, Changes). Keep them.
+Everything else is optional. Using an AI agent? /pr-assistant
+(.skills/pr-assistant/SKILL.md) generates a compliant body.
+-->
+
+## Summary
+
+<!-- One or two sentences: what this PR does and why. -->
+
+## Changes
+
+<!-- Bullet list of what changed. File references welcome. -->
+
+<!-- Optional: how you verified it (commands run, tests passed). -->


### PR DESCRIPTION
## ⭐ Why this matters
First-time contributors currently learn about the required PR body format only after the pr-body-gate fails their freshly opened PR. The template shows the contract before they write a word, so external PRs pass the gate on the first try.

---

## Summary
Add `.github/PULL_REQUEST_TEMPLATE.md` with exactly the three headings `pr-body-gate.yml` enforces (Summary, Changes, Validation), visible italic hints under a callout telling the author to replace them, and a pointer to `/pr-assistant` for agent-driven PRs.

## Changes
- **CI/Workflows**: new `.github/PULL_REQUEST_TEMPLATE.md`; the three gate-required headings are pre-filled, guidance is visible italic hint text (HTML comments looked empty in GitHub's rendered view) with an explicit note to replace it, and the top callout points agent users at `.skills/pr-assistant/SKILL.md`.

## Validation
- [ ] **Walkthrough — see the template in action**: Prerequisites: none. Action: open a new PR from any branch in the GitHub UI (or render `.github/PULL_REQUEST_TEMPLATE.md` in this PR's "Files changed" tab). Expected: a note callout, the three headings, and italic hints, with clear instruction to replace the hints.
- [ ] Confirm the headings satisfy the gate: they match the required-section patterns in `.github/workflows/pr-body-gate.yml` lines 30-34 (`summary`, `changes`, `validation`, case-insensitive). Verified programmatically against the workflow's exact regexes.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
in collaboration with KjellKod
</pre>
