### PR TITLE
Pin the phase names workflow.md teaches to the ones the gate accepts

### DIFF
--- a/tests/unit/test_documented_phase_lockstep.py
+++ b/tests/unit/test_documented_phase_lockstep.py
@@ -1,0 +1,111 @@
+"""Drift guard: every phase name ``workflow.md`` teaches must be a phase name
+``expected_artifacts_for_role`` accepts.
+
+Quest's control flow is markdown an orchestrator reads, so ``workflow.md`` is
+not documentation *about* the dispatch contract -- it is the copy the
+orchestrator learns the contract from. The accepted spellings live in
+``ROLE_PHASE_ALIASES``. Nothing currently connects the two, so an edit to
+either side can teach an orchestrator a value the code rejects, and the suite
+stays green.
+
+That failure mode is worse than an off-path mistake: the orchestrator follows
+the documented path faithfully and still fails, on every quest, for every user.
+These tests fail by name the moment the doc and the gate disagree.
+
+Scope: phase *values*. The role *slot* dimension is guarded by
+``test_canonical_role_lockstep.py``, and the agent-contract-file dimension by
+``test_runtime_agent_role_files_reference_canonical.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from quest_runtime.artifacts import expected_artifacts_for_role
+from quest_runtime.orchestration import CANONICAL_ROLES
+
+WORKFLOW_DOC = (
+    Path(__file__).resolve().parents[2]
+    / ".skills"
+    / "quest"
+    / "delegation"
+    / "workflow.md"
+)
+
+# Matches the context_health.log-style examples the doc uses to teach dispatch,
+# e.g. "phase=plan_review | agent=plan-reviewer-a".
+_PHASE_PATTERN = re.compile(r"phase=([a-z_0-9]+)")
+_PAIR_PATTERN = re.compile(r"phase=([a-z_0-9]+) \| agent=([a-z0-9-]+)")
+
+
+def _doc_text() -> str:
+    return WORKFLOW_DOC.read_text(encoding="utf-8")
+
+
+def _documented_phases() -> set[str]:
+    return set(_PHASE_PATTERN.findall(_doc_text()))
+
+
+def _documented_pairs() -> set[tuple[str, str]]:
+    """Return (phase, agent) pairs whose agent is a real role slot.
+
+    The doc also contains templated agent names (for example a truncated
+    ``agent=code-reviewer-`` standing in for either slot). Those are prose, not
+    a claim about a specific role, so they are filtered out rather than
+    asserted on.
+    """
+
+    return {
+        (phase, agent)
+        for phase, agent in _PAIR_PATTERN.findall(_doc_text())
+        if agent in CANONICAL_ROLES
+    }
+
+
+def test_the_extraction_actually_finds_examples() -> None:
+    """Guard the guard.
+
+    Both tests below pass vacuously if the doc stops using the ``phase=``
+    convention or the regex drifts. A lockstep test that silently matches
+    nothing is worse than no test, so pin that examples exist at all.
+    """
+
+    assert WORKFLOW_DOC.exists(), f"missing dispatch doc: {WORKFLOW_DOC}"
+    assert len(_documented_phases()) >= 5, "workflow.md phase= examples disappeared"
+    assert len(_documented_pairs()) >= 3, "workflow.md phase/agent pairs disappeared"
+
+
+def test_every_documented_phase_is_accepted_by_some_role(tmp_path: Path) -> None:
+    """No phase name in the doc may be rejected by every role."""
+
+    for phase in sorted(_documented_phases()):
+        accepted_by = []
+        for agent in CANONICAL_ROLES:
+            try:
+                expected_artifacts_for_role(tmp_path, phase, agent)
+            except ValueError:
+                continue
+            accepted_by.append(agent)
+
+        assert accepted_by, (
+            f"workflow.md teaches phase={phase!r}, but no canonical role accepts "
+            "it. Either the doc example or ROLE_PHASE_ALIASES is wrong; an "
+            "orchestrator following the doc would fail here."
+        )
+
+
+def test_documented_phase_and_agent_pairs_resolve(tmp_path: Path) -> None:
+    """Each worked example in the doc must resolve for the role it names."""
+
+    for phase, agent in sorted(_documented_pairs()):
+        try:
+            paths = expected_artifacts_for_role(tmp_path, phase, agent)
+        except ValueError as exc:  # pragma: no cover - failure path is the point
+            pytest.fail(
+                f"workflow.md shows 'phase={phase} | agent={agent}', but that "
+                f"pairing is rejected: {exc}"
+            )
+        assert paths, f"phase={phase} agent={agent} resolved no artifacts"

--- a/tests/unit/test_documented_phase_lockstep.py
+++ b/tests/unit/test_documented_phase_lockstep.py
@@ -35,10 +35,15 @@ WORKFLOW_DOC = (
     / "workflow.md"
 )
 
-# Matches the context_health.log-style examples the doc uses to teach dispatch,
-# e.g. "phase=plan_review | agent=plan-reviewer-a".
+# Matches phase/agent examples in both forms the doc uses:
+#   context_health.log style  -- "phase=plan_review | agent=plan-reviewer-a"
+#   role-instance-list style  -- "(phase=plan, agent=planner)"
+# The second form is the doc's own authoritative per-role dispatch list (the
+# "Split by role instance" block), so missing it would have left the exact
+# pairing this PR claims to pin unchecked -- caught in review, not written
+# blind: an earlier version of this pattern matched only the first form.
 _PHASE_PATTERN = re.compile(r"phase=([a-z_0-9]+)")
-_PAIR_PATTERN = re.compile(r"phase=([a-z_0-9]+) \| agent=([a-z0-9-]+)")
+_PAIR_PATTERN = re.compile(r"phase=([a-z_0-9]+)[ |,]+agent=([a-z0-9-]+)")
 
 
 def _doc_text() -> str:


### PR DESCRIPTION
## ⭐ Why this matters

`workflow.md` is not documentation *about* the dispatch contract — it is the copy an orchestrator learns the contract from. If it teaches a phase name the code rejects, every quest fails on the documented path, for every user. Nothing currently checks the two agree.

- **Catches doc/code drift** before an orchestrator hits it, in the required `test` check.
- **Test-only.** No production change, no new accepted inputs.

---

## Summary

Add a drift guard asserting that every phase name `workflow.md` teaches is a phase name `expected_artifacts_for_role()` accepts.

- `test_canonical_role_lockstep.py` already guards this family, but checks `ROLE_PHASE_ALIASES` **keys** (role slots) only. The **values** were unguarded.
- They agree today. Nothing stops them drifting apart with a green suite.

> [!NOTE]
> This is the follow-up suggested in #166: rather than making the runtime helpers tolerate more hand-typed input, pin the path the orchestrator is actually told to take.

## Changes

- **New drift guard** (`tests/unit/test_documented_phase_lockstep.py`):
  - Every `phase=` example in `workflow.md` is accepted by at least one canonical role.
  - Every worked `phase=X | agent=Y` example resolves for the role it names.
  - The extraction itself finds examples, so the other two cannot pass vacuously if the doc convention or the regex drifts.
  - Templated agent names in the doc (a truncated `agent=code-reviewer-` standing in for either slot) are filtered out rather than asserted on.

## Validation

- [ ] `python3 -m pytest tests/unit/test_documented_phase_lockstep.py` — 3 passed.
- [ ] `python3 -m pytest` — 1195 passed, no regressions.
- [ ] `python3 -m black --check .` — clean.
- [ ] Drift check: remove `"build"` from `ROLE_PHASE_ALIASES["builder"]`, and `test_every_documented_phase_is_accepted_by_some_role` fails on `phase=build`, which `workflow.md` still teaches. Restore to pass.

Watch for: the guard reads `workflow.md` at `.skills/quest/delegation/workflow.md`. If that file moves, the first test fails loudly rather than silently skipping.

## Notes

- **Deliberately not covered:** `REPLAN_PHASES` in `scripts/quest_runtime/state.py`. `plan_reviewed`, `presenting` and `presentation_complete` are in no alias set, and do not need to be — they are lifecycle states and never reach `expected_artifacts_for_role()`. Production has exactly one caller of that function (`quest_claude_runner.py`), taking `phase` from argv. Asserting those were dispatch phases would have pinned the wrong contract, so I checked before writing.
- Scope is phase *values*. Role *slots* stay guarded by `test_canonical_role_lockstep.py`, agent contract files by `test_runtime_agent_role_files_reference_canonical.py`. New file rather than an addition, to keep those scope notes accurate.
- Independent of #166 and #167 — touches no file either of them touches.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

