### PR TITLE
Preserve Arbiter verdicts during Antigravity findings retries

### DIFF
--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -635,7 +635,7 @@ Before every Planner, Plan Reviewer, or Arbiter dispatch, read `.quest/<id>/stat
      - `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next`
    - If findings validation fails:
      - Preserve the valid `arbiter_verdict.md.next` bytes and digest.
-     - Prepare and retry only `review_findings.json.next` and `handoff_arbiter.json`, with validator stderr/stdout embedded in the retry prompt. Runner-dispatched Claude retries must pass `--artifact-subset findings-only`; native or local role dispatch prepares the same declared two-file subset explicitly.
+     - Prepare and retry only `review_findings.json.next` and `handoff_arbiter.json`, with validator stderr/stdout embedded in the retry prompt. Runner-dispatched Claude and Antigravity retries must pass `--artifact-subset findings-only`; native or local role dispatch prepares the same declared two-file subset explicitly.
      - Reject the retry if the preserved verdict bytes or digest changed.
      - Re-run `validate-findings` on the second attempt.
      - If validation still fails, STOP route:

--- a/scripts/quest_antigravity_runner.py
+++ b/scripts/quest_antigravity_runner.py
@@ -49,6 +49,10 @@ def parse_args() -> argparse.Namespace:
         "--json-schema",
         help="Optional JSON schema path enforced on agy's structured output",
     )
+    parser.add_argument(
+        "--artifact-subset",
+        help="Optional declared role output subset (for example findings-only).",
+    )
     parser.add_argument("--agy-binary", default=DEFAULT_AGY_BINARY)
     args = parser.parse_args()
     if not args.model.strip():
@@ -66,6 +70,7 @@ def main() -> int:
             quest_dir=args.quest_dir,
             phase=args.phase,
             agent=args.agent,
+            artifact_subset=args.artifact_subset,
         )
     except ValueError as exc:
         payload = {

--- a/tests/unit/test_antigravity_runner.py
+++ b/tests/unit/test_antigravity_runner.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import argparse
 import json
+import subprocess
+import sys
 
 from quest_runtime.antigravity_runner import (
     AGY_MODE_READ_ONLY,
@@ -619,4 +621,119 @@ def test_timeout_parser_rejects_nonfinite_and_absurd_values():
     assert positive_finite_timeout("1800") == 1800.0
     assert positive_finite_timeout(str(MAX_TIMEOUT_SECONDS)) == float(
         MAX_TIMEOUT_SECONDS
+    )
+
+
+def test_cli_findings_only_arbiter_retry_preserves_verdict(tmp_path):
+    quest_dir = tmp_path / ".quest" / "demo"
+    plan_dir = quest_dir / "phase_01_plan"
+    plan_dir.mkdir(parents=True)
+    verdict = plan_dir / "arbiter_verdict.md.next"
+    findings = plan_dir / "review_findings.json.next"
+    handoff = plan_dir / "handoff_arbiter.json"
+    prompt = plan_dir / "retry_prompt.md"
+    verdict.write_bytes(b"\x00VALID VERDICT\xff\n")
+    findings.write_text("stale findings\n", encoding="utf-8")
+    handoff.write_text("stale handoff\n", encoding="utf-8")
+    prompt.write_text("Retry only the findings.\n", encoding="utf-8")
+    verdict_before = (
+        verdict.read_bytes(),
+        verdict.stat().st_ino,
+        verdict.stat().st_mtime_ns,
+    )
+
+    agy = _fake_agy(
+        tmp_path / "fake_agy.py",
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib\n"
+        f"verdict = pathlib.Path({str(verdict)!r})\n"
+        f"findings = pathlib.Path({str(findings)!r})\n"
+        f"handoff = pathlib.Path({str(handoff)!r})\n"
+        'assert verdict.read_bytes() == b"\\x00VALID VERDICT\\xff\\n"\n'
+        'assert findings.read_bytes() == b""\n'
+        'assert handoff.read_bytes() == b""\n'
+        'findings.write_text("[]")\n'
+        'handoff.write_text(json.dumps({"status": "complete"}))\n'
+        'print(json.dumps({"status": "SUCCESS", "response": "done"}))\n',
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "quest_antigravity_runner.py",
+            "--quest-dir",
+            str(quest_dir),
+            "--phase",
+            "plan_review",
+            "--agent",
+            "arbiter",
+            "--iter",
+            "1",
+            "--prompt-file",
+            str(prompt),
+            "--handoff-file",
+            str(handoff),
+            "--model",
+            "gemini-3.6-flash-low",
+            "--artifact-subset",
+            "findings-only",
+            "--add-dir",
+            str(quest_dir),
+            "--agy-binary",
+            agy,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["result_kind"] == "handoff_json"
+    assert findings.read_bytes() == b"[]"
+    assert json.loads(handoff.read_text(encoding="utf-8"))["status"] == "complete"
+    assert (
+        verdict.read_bytes(),
+        verdict.stat().st_ino,
+        verdict.stat().st_mtime_ns,
+    ) == verdict_before
+
+
+def test_cli_findings_only_subset_reuses_role_contract(tmp_path):
+    completed = subprocess.run(
+        [
+            sys.executable,
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "quest_antigravity_runner.py",
+            "--quest-dir",
+            str(tmp_path),
+            "--phase",
+            "plan",
+            "--agent",
+            "planner",
+            "--iter",
+            "1",
+            "--prompt-file",
+            str(tmp_path / "prompt.md"),
+            "--handoff-file",
+            str(tmp_path / "handoff.json"),
+            "--model",
+            "gemini-3.6-flash-low",
+            "--artifact-subset",
+            "findings-only",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    payload = json.loads(completed.stdout)
+    assert payload["result_kind"] == "invocation_error"
+    assert (
+        payload["stderr"]
+        == "Unsupported artifact subset 'findings-only' for role planner"
     )


### PR DESCRIPTION
## ⭐ Why this matters

An Antigravity findings-only retry no longer destroys an already-valid Arbiter verdict, avoiding an unnecessary complete Arbiter rerun.

---

## Summary

Add findings-only artifact preparation to the Antigravity runner so Arbiter retries preserve the existing verdict.
- Forward subset selection directly to the existing artifact contract.
- Keep ordinary Antigravity Arbiter invocations unchanged.

## Changes
- **Runtime**:
  - Add optional `--artifact-subset` support to `quest_antigravity_runner.py`.
  - Reuse `expected_artifacts_for_role()` for subset validation and selection.
- **Workflow**:
  - Require `--artifact-subset findings-only` for Antigravity Arbiter findings retries.
- **Tests**:
  - Prove verdict bytes, inode, and modification time remain unchanged.
  - Prove unsupported role/subset combinations still return the existing contract error.

## Validation
- [x] `python3 -m pytest -q tests/unit/test_antigravity_runner.py tests/unit/test_artifacts.py`, 81 passed.
- [x] `bash tests/test-quest-runtime.sh`, 72 passed.
- [x] `bash scripts/quest_validate-handoff-contracts.sh`, `bash scripts/quest_validate-manifest.sh --strict`, and `git diff --check` passed.

Watch for: a findings-only retry must prepare only findings and handoff, never `arbiter_verdict.md.next`.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

