### PR TITLE
Fix Arbiter findings contract drift

### DIFF
--- a/.skills/quest/agents/arbiter.md
+++ b/.skills/quest/agents/arbiter.md
@@ -41,14 +41,19 @@ Apply the `AGENTS.md` principles: KISS, YAGNI, SRP, and DRY. Keep only work or f
 7. Synthesize canonical findings from both review markdown artifacts and write the scratch artifact:
    - `.quest/<id>/phase_01_plan/review_findings.json.next`
    - If no actionable findings exist, write an empty array (`[]`) instead of skipping the file
-8. On a findings-only retry, overwrite only `review_findings.json.next` and `handoff_arbiter.json`. Do not prepare, truncate, or rewrite a verdict scratch file that already validated. Preserve its exact digest.
+8. Before handoff, validate the scratch findings with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next` and correct every reported contract error.
+9. On a findings-only retry, overwrite only `review_findings.json.next` and `handoff_arbiter.json`. Do not prepare, truncate, or rewrite a verdict scratch file that already validated. Preserve its exact digest.
 
 Canonical findings schema (required fields per finding):
 `finding_id, source, kind, severity, confidence, path, line, summary, why_it_matters, evidence, action, needs_test, write_scope, related_acceptance_criteria`
 
 Allowed enum values:
+- `kind`: `code`, `plan`, `ux`, `regression-risk`, `review_comment`, `ci`, `correctness`, `plan_review`, `edge-case`, `test_failure`, `build_failure`, `shared_infrastructure`, `cross_cutting`
 - `severity`: `critical`, `high`, `medium`, `low`, `info`
 - `confidence`: `high`, `medium`, `low`
+
+Conditional UX field:
+- `principle_id` is required when `kind` is `ux` and must match the exact form `ux-guidebook§<section_number>` (for example, `ux-guidebook§4.8`).
 
 Minimal valid finding example:
 ```json

--- a/tests/unit/test_ux_findings_schema.py
+++ b/tests/unit/test_ux_findings_schema.py
@@ -55,3 +55,21 @@ def test_ux_example_finding_validates_against_canonical_schema() -> None:
 
     errors = validate_finding(finding)
     assert errors == [], f"ux-review example finding does not validate: {errors}"
+
+
+def test_arbiter_contract_documents_canonical_finding_rules() -> None:
+    sys.path.insert(0, str(_repo_root() / "scripts"))
+    from quest_runtime.review_intelligence import ALLOWED_KINDS  # noqa: E402
+
+    arbiter_text = (
+        _repo_root() / ".skills" / "quest" / "agents" / "arbiter.md"
+    ).read_text(encoding="utf-8")
+    allowed_kinds = ", ".join(f"`{kind}`" for kind in ALLOWED_KINDS)
+
+    assert f"- `kind`: {allowed_kinds}" in arbiter_text
+    assert "`principle_id` is required when `kind` is `ux`" in arbiter_text
+    assert "`ux-guidebook§<section_number>`" in arbiter_text
+    assert (
+        "python3 scripts/quest_review_intelligence.py validate-findings "
+        "--input .quest/<id>/phase_01_plan/review_findings.json.next" in arbiter_text
+    )


### PR DESCRIPTION
## ⭐ Why this matters
Plan review no longer stops because the Arbiter was asked to satisfy finding rules its instructions never disclosed. The producer contract now matches the validator and checks its own output before handoff.

---

## Summary
Align the plan Arbiter's findings instructions with the canonical validator so structural output errors are caught before Quest exhausts its retry.
- Keep the documented kind list locked to the runtime constant.
- Make the conditional UX principle identifier explicit.

## Changes
- **Arbiter contract**:
  - Document every allowed `kind` value.
  - Require `principle_id` for UX findings in exact canonical form.
  - Require `validate-findings` before handoff.
- **Regression coverage**:
  - Assert the documented kind list tracks `ALLOWED_KINDS`.
  - Assert the UX field and validation command remain part of the contract.

## Validation
- [x] `python3 -m black --check .`
- [x] `python3 -m pytest tests/ -q`, 1,232 passed
- [x] Quest configuration, manifest, handoff, and state validation scripts
- [x] `bash tests/test-quest-runtime.sh`, 72 passed

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex &lt;noreply@openai.com&gt;
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

