### PR TITLE
Preserve rejected findings across Arbiter retries

### DIFF
--- a/.skills/quest/agents/arbiter.md
+++ b/.skills/quest/agents/arbiter.md
@@ -41,8 +41,14 @@ Apply the `AGENTS.md` principles: KISS, YAGNI, SRP, and DRY. Keep only work or f
 7. Synthesize canonical findings from both review markdown artifacts and write the scratch artifact:
    - `.quest/<id>/phase_01_plan/review_findings.json.next`
    - If no actionable findings exist, write an empty array (`[]`) instead of skipping the file
-8. Before handoff, validate the scratch findings with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next` and correct every reported contract error.
-9. On a findings-only retry, overwrite only `review_findings.json.next` and `handoff_arbiter.json`. Do not prepare, truncate, or rewrite a verdict scratch file that already validated. Preserve its exact digest.
+8. On the initial attempt, validate the scratch findings with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next` and correct every reported contract error.
+9. On a findings-only retry:
+   - read rejected findings from `review_findings.json.next`
+   - repair only the reported validation errors, preserving unrelated findings and fields
+   - write repaired findings to `review_findings.retry.json.next`
+   - write the retry handoff to `handoff_arbiter.retry.json`
+   - validate with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.retry.json.next` and correct every reported contract error
+   - do not prepare, truncate, or rewrite `arbiter_verdict.md.next`, `review_findings.json.next`, or `handoff_arbiter.json`; preserve their exact bytes and digests
 
 Canonical findings schema (required fields per finding):
 `finding_id, source, kind, severity, confidence, path, line, summary, why_it_matters, evidence, action, needs_test, write_scope, related_acceptance_criteria`
@@ -139,6 +145,11 @@ SUMMARY: Iteration <N>: <approve|iterate> - <reason>
 ```
 
 Both steps are required. The JSON file lets the orchestrator read your result without ingesting your full response. The text block is the backward-compatible fallback.
+
+On a findings-only retry, apply these path substitutions in both handoffs:
+- Write the JSON handoff to `.quest/<id>/phase_01_plan/handoff_arbiter.retry.json`.
+- Replace the findings artifact path with `.quest/<id>/phase_01_plan/review_findings.retry.json.next`.
+- Keep the existing verdict artifact path in the artifact list, but do not write or modify that file.
 
 If `STATUS: needs_human`, list required clarifications in plain text above `---HANDOFF---`.
 `STATUS: needs_human` is only valid when this role's selected runtime (`models.arbiter` in `.quest/<id>/orchestration.json`) is Claude (it may enter the human Q&A loop natively or through the bridge). On the Codex runtime, `needs_human` is non-compliant with Quest runtime policy — make explicit assumptions or return `blocked`.

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -598,7 +598,7 @@ Before every Planner, Plan Reviewer, or Arbiter dispatch, read `.quest/<id>/stat
 
    **If `quest_mode == "workflow"` (default):** Read `models.arbiter` from `.quest/<id>/orchestration.json`. Invoke Arbiter through the corresponding runtime:
    - Contract-hardening rollout order (required when implementing this behavior): land workflow + helper CLI (`build-backlog --phase`) + runtime `.next` artifact wiring first; trim arbiter output contract second. This prevents transient mismatches during migration.
-   - Before each arbiter attempt, remove stale scratch artifacts:
+   - Before the initial Arbiter attempt, remove stale scratch artifacts:
      - `.quest/<id>/phase_01_plan/review_findings.json.next`
      - `.quest/<id>/phase_01_plan/review_backlog.json.next`
    - **Artifact preparation** (per Handoff File Polling §5): Resolve and prepare:
@@ -634,14 +634,17 @@ Before every Planner, Plan Reviewer, or Arbiter dispatch, read `.quest/<id>/stat
    - Immediately validate findings:
      - `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next`
    - If findings validation fails:
-     - Preserve the valid `arbiter_verdict.md.next` bytes and digest.
-     - Prepare and retry only `review_findings.json.next` and `handoff_arbiter.json`, with validator stderr/stdout embedded in the retry prompt. Runner-dispatched Claude and Antigravity retries must pass `--artifact-subset findings-only`; native or local role dispatch prepares the same declared two-file subset explicitly.
-     - Reject the retry if the preserved verdict bytes or digest changed.
-     - Re-run `validate-findings` on the second attempt.
+     - Preserve the exact bytes and digests of the valid `arbiter_verdict.md.next`, rejected `review_findings.json.next`, and original `handoff_arbiter.json` when present.
+     - Keep those three files in place as immutable retry inputs and diagnostic evidence.
+     - Prepare only `review_findings.retry.json.next` and `handoff_arbiter.retry.json`. Runner-dispatched Claude and Antigravity retries must pass `--artifact-subset findings-only` and `--handoff-file .quest/<id>/phase_01_plan/handoff_arbiter.retry.json`; native or local role dispatch prepares the same declared two-file subset explicitly.
+     - Tell the retry Arbiter to read rejected findings from `review_findings.json.next`, repair only the reported validation errors, write repaired findings to `review_findings.retry.json.next`, and write the retry handoff to `handoff_arbiter.retry.json`. Embed validator stderr/stdout in the retry prompt.
+     - Reject the retry if the preserved verdict or rejected findings changed, or if the original handoff changed from its prior present or absent state.
+     - Validate the retry scratch with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.retry.json.next`.
+     - If validation passes, atomically promote the retry artifacts with `os.replace(".quest/<id>/phase_01_plan/review_findings.retry.json.next", ".quest/<id>/phase_01_plan/review_findings.json.next")` and `os.replace(".quest/<id>/phase_01_plan/handoff_arbiter.retry.json", ".quest/<id>/phase_01_plan/handoff_arbiter.json")`, then continue using the ordinary `.next` findings path.
      - If validation still fails, STOP route:
        - Do **not** call `quest_state.py --transition plan_reviewed`.
        - Surface validator output in orchestrator logs/user message.
-       - Keep canonical artifacts untouched; keep `.next` files for debugging.
+       - Keep canonical artifacts untouched; retain both the rejected `.next` input and retry scratch artifacts for debugging.
    - If arbiter handoff says `next: planner`, do not promote transient findings or build a backlog. Item 6 owns refinement publication, snapshot, cleanup, increment, Planner preparation, and exact binding verification.
    - If arbiter handoff says `next: builder` and findings validation passed:
      - Build backlog from validated findings:

--- a/.skills/quest/delegation/workflow.md
+++ b/.skills/quest/delegation/workflow.md
@@ -634,13 +634,14 @@ Before every Planner, Plan Reviewer, or Arbiter dispatch, read `.quest/<id>/stat
    - Immediately validate findings:
      - `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next`
    - If findings validation fails:
-     - Preserve the exact bytes and digests of the valid `arbiter_verdict.md.next`, rejected `review_findings.json.next`, and original `handoff_arbiter.json` when present.
+     - Require the original JSON handoff to be present and parseable before starting this scoped retry. A text-only fallback cannot safely enter findings-only repair; STOP and preserve the failed artifacts instead.
+     - Preserve the exact bytes and digests of the valid `arbiter_verdict.md.next`, rejected `review_findings.json.next`, and original `handoff_arbiter.json`.
      - Keep those three files in place as immutable retry inputs and diagnostic evidence.
      - Prepare only `review_findings.retry.json.next` and `handoff_arbiter.retry.json`. Runner-dispatched Claude and Antigravity retries must pass `--artifact-subset findings-only` and `--handoff-file .quest/<id>/phase_01_plan/handoff_arbiter.retry.json`; native or local role dispatch prepares the same declared two-file subset explicitly.
      - Tell the retry Arbiter to read rejected findings from `review_findings.json.next`, repair only the reported validation errors, write repaired findings to `review_findings.retry.json.next`, and write the retry handoff to `handoff_arbiter.retry.json`. Embed validator stderr/stdout in the retry prompt.
-     - Reject the retry if the preserved verdict or rejected findings changed, or if the original handoff changed from its prior present or absent state.
+     - Reject the retry if the preserved verdict, rejected findings, or original handoff bytes and digest changed.
      - Validate the retry scratch with `python3 scripts/quest_review_intelligence.py validate-findings --input .quest/<id>/phase_01_plan/review_findings.retry.json.next`.
-     - If validation passes, atomically promote the retry artifacts with `os.replace(".quest/<id>/phase_01_plan/review_findings.retry.json.next", ".quest/<id>/phase_01_plan/review_findings.json.next")` and `os.replace(".quest/<id>/phase_01_plan/handoff_arbiter.retry.json", ".quest/<id>/phase_01_plan/handoff_arbiter.json")`, then continue using the ordinary `.next` findings path.
+     - If validation passes, atomically promote only the repaired findings with `os.replace(".quest/<id>/phase_01_plan/review_findings.retry.json.next", ".quest/<id>/phase_01_plan/review_findings.json.next")`, then continue using the ordinary `.next` findings path. Keep the original `handoff_arbiter.json` byte-identical because it already names the ordinary findings path and remains authoritative. Retain `handoff_arbiter.retry.json` as execution evidence, not as a published handoff.
      - If validation still fails, STOP route:
        - Do **not** call `quest_state.py --transition plan_reviewed`.
        - Surface validator output in orchestrator logs/user message.

--- a/docs/architecture/orchestration-runtime-v1.md
+++ b/docs/architecture/orchestration-runtime-v1.md
@@ -152,7 +152,7 @@ Required behavior:
 - repeated identical failure trips adapter circuit breaker
 - circuit breaker emits explicit event
 - when a rejected artifact is retry input, it remains immutable
-- that repair attempt writes separate scratch artifacts, validates them, then atomically promotes them
+- that repair attempt writes separate scratch artifacts, validates the findings candidate, then atomically promotes only that candidate while keeping the original handoff immutable
 - failed repair dispatch or validation retains both the rejected input and retry scratch for diagnosis
 
 ## 8) MCP Policy

--- a/docs/architecture/orchestration-runtime-v1.md
+++ b/docs/architecture/orchestration-runtime-v1.md
@@ -5,7 +5,7 @@ audience: Runtime implementers and adapter maintainers
 scope: Execution lifecycle, events, adapters, retries, and question propagation
 status: active
 owner: maintainers
-last_updated: 2026-03-04
+last_updated: 2026-09-02
 related:
   - docs/architecture/quest-platform-constellations.md
   - docs/guides/opencode-model-observations.md
@@ -151,6 +151,9 @@ Required behavior:
 - retries use idempotency key
 - repeated identical failure trips adapter circuit breaker
 - circuit breaker emits explicit event
+- when a rejected artifact is retry input, it remains immutable
+- that repair attempt writes separate scratch artifacts, validates them, then atomically promotes them
+- failed repair dispatch or validation retains both the rejected input and retry scratch for diagnosis
 
 ## 8) MCP Policy
 
@@ -187,4 +190,3 @@ v1 intentionally excludes:
 - autonomous recursive swarm planning.
 
 Add only after measured pain and explicit acceptance criteria.
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,8 +51,8 @@ python3 scripts/quest_startup_branch.py --slug feature-x --mode branch
 # Run a Claude-designated role via the configured Claude transport with file polling
 python3 scripts/quest_claude_runner.py --quest-dir .quest/<id> --phase plan_review --agent plan-reviewer-a --iter 1 --prompt-file .quest/<id>/phase_01_plan/reviewer_a_prompt.txt --handoff-file .quest/<id>/phase_01_plan/handoff_plan-reviewer-a.json --model claude --transport background-agent
 
-# Retry only invalid Arbiter findings without truncating a valid verdict scratch file
-python3 scripts/quest_claude_runner.py --quest-dir .quest/<id> --phase plan_review --agent arbiter --iter <N> --prompt-file <retry-prompt> --handoff-file .quest/<id>/phase_01_plan/handoff_arbiter.json --artifact-subset findings-only --model <model> --transport background-agent
+# Retry invalid Arbiter findings into separate scratch files, preserving the rejected findings and valid verdict as inputs
+python3 scripts/quest_claude_runner.py --quest-dir .quest/<id> --phase plan_review --agent arbiter --iter <N> --prompt-file <retry-prompt> --handoff-file .quest/<id>/phase_01_plan/handoff_arbiter.retry.json --artifact-subset findings-only --model <model> --transport background-agent
 
 # Probe the Claude background-agent transport with a real artifact + handoff write
 python3 scripts/quest_claude_probe.py --quest-dir .quest/<id> --model claude --transport background-agent

--- a/scripts/quest_runtime/artifacts.py
+++ b/scripts/quest_runtime/artifacts.py
@@ -57,10 +57,12 @@ ROLE_ARTIFACTS: dict[str, tuple[str, tuple[str, ...]]] = {
 }
 
 ROLE_ARTIFACT_SUBSETS: dict[tuple[str, str], tuple[str, ...]] = {
+    # A findings repair reads the rejected ordinary .next artifacts, so its
+    # writable outputs must use distinct paths until validation succeeds.
     (
         "arbiter",
         "findings-only",
-    ): ("review_findings.json.next", "handoff_arbiter.json"),
+    ): ("review_findings.retry.json.next", "handoff_arbiter.retry.json"),
 }
 
 SOLO_DISABLED_AGENTS = frozenset(

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -704,7 +704,10 @@ test_workflow_documents_arbiter_validate_build_publish_contract() {
     grep -Fq 'review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.retry.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'Require the original JSON handoff to be present and parseable before starting this scoped retry' "$WORKFLOW_FILE" &&
+    grep -Fq 'original handoff bytes and digest changed' "$WORKFLOW_FILE" &&
     grep -Fq 'os.replace(".quest/<id>/phase_01_plan/review_findings.retry.json.next", ".quest/<id>/phase_01_plan/review_findings.json.next")' "$WORKFLOW_FILE" &&
+    grep -Fq 'Keep the original `handoff_arbiter.json` byte-identical' "$WORKFLOW_FILE" &&
     grep -Fq 'build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults' "$WORKFLOW_FILE" &&
     grep -Fq 'Canonical `arbiter_verdict.md` is not prepared or truncated; publish `arbiter_verdict.md.next` only after validation succeeds.' "$WORKFLOW_FILE" &&
@@ -2634,35 +2637,61 @@ findings_path = phase_dir / "review_findings.json.next"
 handoff_path = phase_dir / "handoff_arbiter.json"
 retry_findings_path = phase_dir / "review_findings.retry.json.next"
 retry_handoff_path = phase_dir / "handoff_arbiter.retry.json"
+rejected_findings = [
+    {
+        "finding_id": "runner-preserved-1",
+        "source": "arbiter",
+        "kind": "correctness",
+        "severity": "low",
+        "confidence": "high",
+        "path": "scripts/preserved.py",
+        "line": 3,
+        "summary": "Unrelated valid finding.",
+        "why_it_matters": "Its evidence must survive a focused repair.",
+        "evidence": ["preserve this evidence"],
+        "action": "keep unchanged",
+        "needs_test": False,
+        "write_scope": ["scripts/preserved.py"],
+        "related_acceptance_criteria": ["B4"],
+    },
+    {
+        "finding_id": "runner-repaired-1",
+        "source": "arbiter",
+        "kind": "unsupported-kind",
+        "severity": "high",
+        "confidence": "high",
+        "path": "scripts/new_runner.py",
+        "line": 7,
+        "summary": "Finding with one invalid field.",
+        "why_it_matters": "The retry must repair only the rejected field.",
+        "evidence": ["runner"],
+        "action": "fix now",
+        "needs_test": True,
+        "write_scope": ["scripts/new_runner.py"],
+        "related_acceptance_criteria": ["B5"],
+    },
+]
 if attempt == 1:
     verdict_path.write_text(f"arbiter attempt {attempt}\n", encoding="utf-8")
-    findings_path.write_text('[{"id":"bad-shape"}]\n', encoding="utf-8")
+    findings_path.write_text(
+        json.dumps(rejected_findings, indent=2) + "\n", encoding="utf-8"
+    )
 else:
-    assert findings_path.read_text(encoding="utf-8") == '[{"id":"bad-shape"}]\n'
+    repair_input = json.loads(findings_path.read_text(encoding="utf-8"))
+    assert repair_input == rejected_findings
     assert handoff_path.read_text(encoding="utf-8")
+    repaired_findings = json.loads(json.dumps(repair_input))
+    repaired_findings[1]["kind"] = "regression-risk"
+    assert repaired_findings[0] == rejected_findings[0]
+    assert {
+        key: value
+        for key, value in repaired_findings[1].items()
+        if key != "kind"
+    } == {
+        key: value for key, value in rejected_findings[1].items() if key != "kind"
+    }
     retry_findings_path.write_text(
-        json.dumps(
-            [
-                {
-                    "finding_id": "runner-new-1",
-                    "source": "arbiter",
-                    "kind": "regression-risk",
-                    "severity": "high",
-                    "confidence": "high",
-                    "path": "scripts/new_runner.py",
-                    "line": 7,
-                    "summary": "Valid findings after retry.",
-                    "why_it_matters": "Validates runner/orchestrator retry path.",
-                    "evidence": ["runner"],
-                    "action": "fix now",
-                    "needs_test": True,
-                    "write_scope": ["scripts/new_runner.py"],
-                    "related_acceptance_criteria": ["B5"],
-                }
-            ],
-            indent=2,
-        )
-        + "\n",
+        json.dumps(repaired_findings, indent=2) + "\n",
         encoding="utf-8",
     )
     handoff_path = retry_handoff_path
@@ -2780,7 +2809,8 @@ PY
         [ "$(stat_snapshot "$findings_next")" = "$rejected_findings_snapshot" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
         [ "$(stat_snapshot "$handoff_file")" = "$rejected_handoff_snapshot" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
         mv "$retry_findings" "$findings_next" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
-        mv "$retry_handoff" "$handoff_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+        [ "$(stat_snapshot "$handoff_file")" = "$rejected_handoff_snapshot" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+        [ -s "$retry_handoff" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
       fi
       validated=true
       break

--- a/tests/test-quest-runtime.sh
+++ b/tests/test-quest-runtime.sh
@@ -699,8 +699,12 @@ test_workflow_documents_no_vcs_review_path() {
 
 test_workflow_documents_arbiter_validate_build_publish_contract() {
   grep -Fq 'review_findings.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'review_findings.retry.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'handoff_arbiter.retry.json' "$WORKFLOW_FILE" &&
     grep -Fq 'review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'validate-findings --input .quest/<id>/phase_01_plan/review_findings.retry.json.next' "$WORKFLOW_FILE" &&
+    grep -Fq 'os.replace(".quest/<id>/phase_01_plan/review_findings.retry.json.next", ".quest/<id>/phase_01_plan/review_findings.json.next")' "$WORKFLOW_FILE" &&
     grep -Fq 'build-backlog --phase plan --findings .quest/<id>/phase_01_plan/review_findings.json.next --output .quest/<id>/phase_01_plan/review_backlog.json.next' "$WORKFLOW_FILE" &&
     grep -Fq 'validate-backlog --input .quest/<id>/phase_01_plan/review_backlog.json.next --expected-phase plan --strict-plan-defaults' "$WORKFLOW_FILE" &&
     grep -Fq 'Canonical `arbiter_verdict.md` is not prepared or truncated; publish `arbiter_verdict.md.next` only after validation succeeds.' "$WORKFLOW_FILE" &&
@@ -2535,7 +2539,7 @@ EOF
 }
 
 test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish() {
-  local tmpdir phase_dir verdict_file findings_file backlog_file verdict_next findings_next backlog_next prompt_file handoff_file
+  local tmpdir phase_dir verdict_file findings_file backlog_file verdict_next findings_next retry_findings backlog_next prompt_file handoff_file retry_handoff
   tmpdir=$(mktemp -d)
   phase_dir="$tmpdir/phase_01_plan"
   verdict_file="$phase_dir/arbiter_verdict.md"
@@ -2543,9 +2547,11 @@ test_plan_review_retry_via_runner_preserves_canonical_artifacts_until_publish() 
   backlog_file="$phase_dir/review_backlog.json"
   verdict_next="$phase_dir/arbiter_verdict.md.next"
   findings_next="$phase_dir/review_findings.json.next"
+  retry_findings="$phase_dir/review_findings.retry.json.next"
   backlog_next="$phase_dir/review_backlog.json.next"
   prompt_file="$phase_dir/arbiter_prompt.txt"
   handoff_file="$phase_dir/handoff_arbiter.json"
+  retry_handoff="$phase_dir/handoff_arbiter.retry.json"
   mkdir -p "$phase_dir"
 
   echo "old canonical verdict" > "$verdict_file"
@@ -2626,11 +2632,15 @@ attempt_file.write_text(str(attempt), encoding="utf-8")
 verdict_path = phase_dir / "arbiter_verdict.md.next"
 findings_path = phase_dir / "review_findings.json.next"
 handoff_path = phase_dir / "handoff_arbiter.json"
+retry_findings_path = phase_dir / "review_findings.retry.json.next"
+retry_handoff_path = phase_dir / "handoff_arbiter.retry.json"
 if attempt == 1:
     verdict_path.write_text(f"arbiter attempt {attempt}\n", encoding="utf-8")
     findings_path.write_text('[{"id":"bad-shape"}]\n', encoding="utf-8")
 else:
-    findings_path.write_text(
+    assert findings_path.read_text(encoding="utf-8") == '[{"id":"bad-shape"}]\n'
+    assert handoff_path.read_text(encoding="utf-8")
+    retry_findings_path.write_text(
         json.dumps(
             [
                 {
@@ -2655,6 +2665,8 @@ else:
         + "\n",
         encoding="utf-8",
     )
+    handoff_path = retry_handoff_path
+    findings_path = retry_findings_path
 
 handoff_path.write_text(
     json.dumps(
@@ -2727,13 +2739,17 @@ PY
   backlog_snapshot_before=$(stat_snapshot "$backlog_file")
 
   local attempts=0 retries=0 validated=false
-  local verdict_retry_snapshot=""
+  local verdict_retry_snapshot="" rejected_findings_snapshot="" rejected_handoff_snapshot=""
   local published=false
   while [ "$attempts" -lt 3 ]; do
-    local output runner_rc result_kind
+    local output runner_rc result_kind current_handoff candidate_findings
     local subset_args=()
+    current_handoff="$handoff_file"
+    candidate_findings="$findings_next"
     if [ "$attempts" -gt 0 ]; then
       subset_args=(--artifact-subset findings-only)
+      current_handoff="$retry_handoff"
+      candidate_findings="$retry_findings"
     fi
     output=$(python3 "$CLAUDE_RUNNER" \
       --quest-dir "$tmpdir" \
@@ -2741,7 +2757,7 @@ PY
       --agent arbiter \
       --iter 1 \
       --prompt-file "$prompt_file" \
-      --handoff-file "$handoff_file" \
+      --handoff-file "$current_handoff" \
       --model claude \
       --transport bridge \
       --bridge-script "$tmpdir/fake_arbiter_bridge.py" \
@@ -2758,13 +2774,21 @@ PY
     [ "$(stat_snapshot "$findings_file")" = "$findings_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
     [ "$(stat_snapshot "$backlog_file")" = "$backlog_snapshot_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
 
-    if python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$findings_next" >/dev/null 2>&1; then
+    if python3 "$REPO_ROOT/scripts/quest_review_intelligence.py" validate-findings --input "$candidate_findings" >/dev/null 2>&1; then
       record_event validate result=ok attempt="$attempts"
+      if [ "$attempts" -gt 1 ]; then
+        [ "$(stat_snapshot "$findings_next")" = "$rejected_findings_snapshot" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+        [ "$(stat_snapshot "$handoff_file")" = "$rejected_handoff_snapshot" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+        mv "$retry_findings" "$findings_next" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+        mv "$retry_handoff" "$handoff_file" || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }
+      fi
       validated=true
       break
     fi
     record_event validate result=fail attempt="$attempts"
     verdict_retry_snapshot=$(stat_snapshot "$verdict_next")
+    rejected_findings_snapshot=$(stat_snapshot "$findings_next")
+    rejected_handoff_snapshot=$(stat_snapshot "$handoff_file")
 
     retries=$((retries + 1))
     [ "$(cat "$verdict_file")" = "$canonical_verdict_before" ] || { unset QUEST_RUNNER_TELEMETRY_LOG; rm -rf "$tmpdir"; return 1; }

--- a/tests/unit/test_antigravity_runner.py
+++ b/tests/unit/test_antigravity_runner.py
@@ -624,23 +624,26 @@ def test_timeout_parser_rejects_nonfinite_and_absurd_values():
     )
 
 
-def test_cli_findings_only_arbiter_retry_preserves_verdict(tmp_path):
+def test_cli_findings_only_arbiter_retry_preserves_repair_inputs(tmp_path):
     quest_dir = tmp_path / ".quest" / "demo"
     plan_dir = quest_dir / "phase_01_plan"
     plan_dir.mkdir(parents=True)
     verdict = plan_dir / "arbiter_verdict.md.next"
     findings = plan_dir / "review_findings.json.next"
     handoff = plan_dir / "handoff_arbiter.json"
+    retry_findings = plan_dir / "review_findings.retry.json.next"
+    retry_handoff = plan_dir / "handoff_arbiter.retry.json"
     prompt = plan_dir / "retry_prompt.md"
     verdict.write_bytes(b"\x00VALID VERDICT\xff\n")
-    findings.write_text("stale findings\n", encoding="utf-8")
-    handoff.write_text("stale handoff\n", encoding="utf-8")
+    findings.write_bytes(b"INVALID FINDINGS\n")
+    handoff.write_bytes(b"ORIGINAL HANDOFF\n")
+    retry_findings.write_text("stale retry findings\n", encoding="utf-8")
+    retry_handoff.write_text("stale retry handoff\n", encoding="utf-8")
     prompt.write_text("Retry only the findings.\n", encoding="utf-8")
-    verdict_before = (
-        verdict.read_bytes(),
-        verdict.stat().st_ino,
-        verdict.stat().st_mtime_ns,
-    )
+    preserved = {
+        path: (path.read_bytes(), path.stat().st_ino, path.stat().st_mtime_ns)
+        for path in (verdict, findings, handoff)
+    }
 
     agy = _fake_agy(
         tmp_path / "fake_agy.py",
@@ -649,11 +652,15 @@ def test_cli_findings_only_arbiter_retry_preserves_verdict(tmp_path):
         f"verdict = pathlib.Path({str(verdict)!r})\n"
         f"findings = pathlib.Path({str(findings)!r})\n"
         f"handoff = pathlib.Path({str(handoff)!r})\n"
+        f"retry_findings = pathlib.Path({str(retry_findings)!r})\n"
+        f"retry_handoff = pathlib.Path({str(retry_handoff)!r})\n"
         'assert verdict.read_bytes() == b"\\x00VALID VERDICT\\xff\\n"\n'
-        'assert findings.read_bytes() == b""\n'
-        'assert handoff.read_bytes() == b""\n'
-        'findings.write_text("[]")\n'
-        'handoff.write_text(json.dumps({"status": "complete"}))\n'
+        'assert findings.read_bytes() == b"INVALID FINDINGS\\n"\n'
+        'assert handoff.read_bytes() == b"ORIGINAL HANDOFF\\n"\n'
+        'assert retry_findings.read_bytes() == b""\n'
+        'assert retry_handoff.read_bytes() == b""\n'
+        'retry_findings.write_text("[]")\n'
+        'retry_handoff.write_text(json.dumps({"status": "complete"}))\n'
         'print(json.dumps({"status": "SUCCESS", "response": "done"}))\n',
     )
 
@@ -674,7 +681,7 @@ def test_cli_findings_only_arbiter_retry_preserves_verdict(tmp_path):
             "--prompt-file",
             str(prompt),
             "--handoff-file",
-            str(handoff),
+            str(retry_handoff),
             "--model",
             "gemini-3.6-flash-low",
             "--artifact-subset",
@@ -692,13 +699,14 @@ def test_cli_findings_only_arbiter_retry_preserves_verdict(tmp_path):
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout)
     assert payload["result_kind"] == "handoff_json"
-    assert findings.read_bytes() == b"[]"
-    assert json.loads(handoff.read_text(encoding="utf-8"))["status"] == "complete"
-    assert (
-        verdict.read_bytes(),
-        verdict.stat().st_ino,
-        verdict.stat().st_mtime_ns,
-    ) == verdict_before
+    assert retry_findings.read_bytes() == b"[]"
+    assert json.loads(retry_handoff.read_text(encoding="utf-8"))["status"] == "complete"
+    for path, before in preserved.items():
+        assert (
+            path.read_bytes(),
+            path.stat().st_ino,
+            path.stat().st_mtime_ns,
+        ) == before
 
 
 def test_cli_findings_only_subset_reuses_role_contract(tmp_path):

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -84,8 +84,8 @@ class TestExpectedArtifactsForRole:
         )
 
         assert [path.name for path in paths] == [
-            "review_findings.json.next",
-            "handoff_arbiter.json",
+            "review_findings.retry.json.next",
+            "handoff_arbiter.retry.json",
         ]
 
     def test_findings_only_subset_is_rejected_for_other_roles(self, tmp_path: Path):
@@ -329,36 +329,125 @@ class TestPrepareArtifactFiles:
         assert "state_error[shape]" in result.stderr
         assert (plan.read_bytes(), handoff.read_bytes()) == before
 
-    def test_findings_only_arbiter_retry_preserves_verdict_scratch(
-        self, tmp_path: Path
-    ):
+    def test_findings_only_arbiter_retry_preserves_repair_inputs(self, tmp_path: Path):
         quest_dir = tmp_path / "quest"
         plan_dir = quest_dir / "phase_01_plan"
         plan_dir.mkdir(parents=True)
         verdict_next = plan_dir / "arbiter_verdict.md.next"
         findings_next = plan_dir / "review_findings.json.next"
         handoff = plan_dir / "handoff_arbiter.json"
+        retry_findings = plan_dir / "review_findings.retry.json.next"
+        retry_handoff = plan_dir / "handoff_arbiter.retry.json"
         verdict_next.write_bytes(b"VALID VERDICT\n")
-        findings_next.write_text("stale findings\n", encoding="utf-8")
-        handoff.write_text("stale handoff\n", encoding="utf-8")
+        findings_next.write_bytes(b"INVALID FINDINGS\n")
+        handoff.write_bytes(b"ORIGINAL HANDOFF\n")
+        retry_findings.write_bytes(b"STALE RETRY FINDINGS\n")
+        retry_handoff.write_bytes(b"STALE RETRY HANDOFF\n")
 
-        before = (
-            verdict_next.read_bytes(),
-            verdict_next.stat().st_ino,
-            verdict_next.stat().st_mtime_ns,
+        preserved = {
+            path: (path.read_bytes(), path.stat().st_ino, path.stat().st_mtime_ns)
+            for path in (verdict_next, findings_next, handoff)
+        }
+        artifacts = expected_artifacts_for_role(
+            quest_dir,
+            "plan_review",
+            "arbiter",
+            artifact_subset="findings-only",
         )
         prepared = prepare_artifact_files(
-            [findings_next, handoff], quest_dir=quest_dir, role="arbiter"
+            artifacts, quest_dir=quest_dir, role="arbiter"
         )
 
-        assert prepared == [findings_next.resolve(), handoff.resolve()]
-        assert findings_next.read_bytes() == b""
-        assert handoff.read_bytes() == b""
-        assert (
-            verdict_next.read_bytes(),
-            verdict_next.stat().st_ino,
-            verdict_next.stat().st_mtime_ns,
-        ) == before
+        assert prepared == [retry_findings.resolve(), retry_handoff.resolve()]
+        assert retry_findings.read_bytes() == b""
+        assert retry_handoff.read_bytes() == b""
+        for path, before in preserved.items():
+            assert (
+                path.read_bytes(),
+                path.stat().st_ino,
+                path.stat().st_mtime_ns,
+            ) == before
+
+    def test_failed_findings_only_background_dispatch_preserves_repair_inputs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        quest_dir = tmp_path / "quest"
+        plan_dir = quest_dir / "phase_01_plan"
+        plan_dir.mkdir(parents=True)
+        prompt = plan_dir / "retry_prompt.md"
+        prompt.write_text("Repair the rejected findings.\n", encoding="utf-8")
+        verdict_next = plan_dir / "arbiter_verdict.md.next"
+        findings_next = plan_dir / "review_findings.json.next"
+        handoff = plan_dir / "handoff_arbiter.json"
+        retry_findings = plan_dir / "review_findings.retry.json.next"
+        retry_handoff = plan_dir / "handoff_arbiter.retry.json"
+        verdict_next.write_bytes(b"VALID VERDICT\n")
+        findings_next.write_bytes(b"INVALID FINDINGS\n")
+        handoff.write_bytes(b"ORIGINAL HANDOFF\n")
+        preserved = {
+            path: (path.read_bytes(), path.stat().st_ino, path.stat().st_mtime_ns)
+            for path in (verdict_next, findings_next, handoff)
+        }
+
+        class FailedDispatch:
+            returncode = 3
+
+            def communicate(self, timeout: float | None = None):
+                return (
+                    json.dumps(
+                        {
+                            "status": "dispatch_failed",
+                            "message": "live same-name background session is actively working",
+                        }
+                    ),
+                    "",
+                )
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                return None
+
+            def kill(self):
+                return None
+
+        monkeypatch.setattr(
+            claude_runner_module.subprocess,
+            "Popen",
+            lambda *args, **kwargs: FailedDispatch(),
+        )
+
+        result = run_claude_role(
+            cwd=tmp_path,
+            quest_dir=quest_dir,
+            phase="plan_review",
+            agent="arbiter",
+            iteration=1,
+            prompt_file=prompt,
+            handoff_file=retry_handoff,
+            bridge_script=tmp_path / "unused_bridge.py",
+            model="claude",
+            timeout=1.0,
+            permission_mode="bypassPermissions",
+            artifact_paths=expected_artifacts_for_role(
+                quest_dir,
+                "plan_review",
+                "arbiter",
+                artifact_subset="findings-only",
+            ),
+            transport="background-agent",
+        )
+
+        assert result.result_kind == "invocation_error"
+        assert retry_findings.read_bytes() == b""
+        assert retry_handoff.read_bytes() == b""
+        for path, before in preserved.items():
+            assert (
+                path.read_bytes(),
+                path.stat().st_ino,
+                path.stat().st_mtime_ns,
+            ) == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ux_findings_schema.py
+++ b/tests/unit/test_ux_findings_schema.py
@@ -69,7 +69,18 @@ def test_arbiter_contract_documents_canonical_finding_rules() -> None:
     assert f"- `kind`: {allowed_kinds}" in arbiter_text
     assert "`principle_id` is required when `kind` is `ux`" in arbiter_text
     assert "`ux-guidebook§<section_number>`" in arbiter_text
+    assert "read rejected findings from `review_findings.json.next`" in arbiter_text
+    assert "repair only the reported validation errors" in arbiter_text
+    assert (
+        "write repaired findings to `review_findings.retry.json.next`" in arbiter_text
+    )
+    assert "write the retry handoff to `handoff_arbiter.retry.json`" in arbiter_text
     assert (
         "python3 scripts/quest_review_intelligence.py validate-findings "
         "--input .quest/<id>/phase_01_plan/review_findings.json.next" in arbiter_text
+    )
+    assert (
+        "python3 scripts/quest_review_intelligence.py validate-findings "
+        "--input .quest/<id>/phase_01_plan/review_findings.retry.json.next"
+        in arbiter_text
     )


### PR DESCRIPTION
## ⭐ Why this matters

A failed findings-only retry can no longer erase the rejected findings it needs to repair. Quest now keeps the original evidence available, reducing unnecessary regeneration and avoidable fail-closed stops.

---

## Summary

Preserve rejected Arbiter findings across repair retries by writing retry results to separate scratch artifacts before validation and promotion.
- Keep the valid verdict, rejected findings, and original handoff unchanged during retry dispatch.
- Apply the same artifact contract across Claude, Antigravity, native, and local role paths.

## Changes

- **Artifact lifecycle**:
  - Route `--artifact-subset findings-only` to dedicated retry findings and handoff paths.
  - Validate retry findings before atomically promoting them to the ordinary `.next` path.
  - Retain rejected and retry artifacts when dispatch or validation fails.
- **Arbiter contract**:
  - Require the retry Arbiter to read the rejected findings and repair only reported validation errors.
  - Preserve the existing verdict and original findings byte-for-byte until promotion.
- **Tests and documentation**:
  - Cover active same-name background dispatch rejection, Antigravity retry input preservation, artifact selection, and the full retry-to-publish flow.
  - Document the runtime-neutral retry transaction in the architecture and script guidance.

## Validation

- [x] `python3 -m pytest -q`, 1233 passed.
- [x] `bash tests/test-quest-runtime.sh`, all runtime checks passed.
- [x] `bash tests/test-validate-quest-state.sh`, 71 passed.
- [x] Black, Quest config, handoff contract, strict manifest, and `git diff --check` passed.

Watch for: a findings-only retry must never prepare or modify `arbiter_verdict.md.next`, `review_findings.json.next`, or the original handoff before retry validation succeeds.

<pre>
     ▐▛███▜▌
    ▝▜█████▛▘
      ▘▘ ▝▝
Quest/Co-Authored by
Co-Authored-By: Codex <noreply@openai.com>
in collaboration with KjellKod
</pre>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KjellKod/quest/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

